### PR TITLE
Fix not returning when user not wanted

### DIFF
--- a/pyinfra/modules/server.py
+++ b/pyinfra/modules/server.py
@@ -153,9 +153,10 @@ def user(
     if home is None:
         home = '/home/{0}'.format(name)
 
-    # User exists but we don't want them?
-    if not present and user:
-        commands.append('userdel {0}'.format(name))
+    # User not wanted?
+    if not present:
+        if user:
+            commands.append('userdel {0}'.format(name))
         return commands
 
     # User doesn't exist but we want them?


### PR DESCRIPTION
A state removing a user will fail the second time it is launched, as the rest of the operation implicitly assumes that the user in question exists.

To reproduce, run twice the following state:
```
server.user(
    'ubuntu',
    present=False,
)
```