### PR TITLE
Add LXD containers fact and module

### DIFF
--- a/pyinfra/facts/lxd.py
+++ b/pyinfra/facts/lxd.py
@@ -1,0 +1,19 @@
+# pyinfra
+# File: pyinfra/facts/lxd.py
+# Desc: LXD containers facts
+
+import json
+
+from pyinfra.api import FactBase
+
+
+class LXDContainers(FactBase):
+    '''
+    Returns a list of running LXD containers
+    '''
+
+    command = 'lxc list --format json --fast'
+
+    def process(self, output):
+        assert len(output) == 1
+        return json.loads(output[0])

--- a/pyinfra/modules/lxd.py
+++ b/pyinfra/modules/lxd.py
@@ -1,0 +1,57 @@
+# pyinfra
+# File: pyinfra/modules/lxd.py
+# Desc: manage LXD containers
+
+'''
+The LXD modules manage LXD containers
+'''
+
+from __future__ import unicode_literals
+
+from pyinfra.api import operation
+
+
+def get_container_named(name, containers):
+    for container in containers:
+        if container['name'] == name:
+            return container
+    else:
+        return None
+
+
+@operation
+def container(state, host, name, image='ubuntu:16.04',
+              present=True):
+    '''
+    Manage LXD containers.
+
+    Note: does not check if an existing container is based on the specified
+    image.
+
+    + name: name of the container
+    + image: image to base the container on
+    + present: whether the container should be present or absent
+    '''
+
+    container = get_container_named(name, host.fact.lxd_containers)
+
+    if container:
+        if present:
+            # Not removing the container if it should be present:
+            return []
+        else:
+            commands = []
+            if container['status'] == 'Running':
+                commands.append('lxc stop {}'.format(name))
+            # Command to remove the container:
+            commands.append('lxc delete {}'.format(name))
+            return commands
+    else:
+        if not present:
+            # Not creating the container if it should be absent:
+            return []
+        else:
+            # Command to create the container:
+            return [
+                'lxc launch {image} {name}'.format(name=name, image=image)
+            ]

--- a/tests/facts/lxd_containers/stripped.json
+++ b/tests/facts/lxd_containers/stripped.json
@@ -1,0 +1,14 @@
+{
+    "output": [
+        "[{\"name\": \"container1\", \"status\": \"Running\"},{\"name\": \"container2\"}]"
+    ],
+    "fact":  [
+        {
+            "name": "container1",
+            "status": "Running"
+        },
+        {
+            "name": "container2"
+        }
+    ]
+}

--- a/tests/operations/lxd.container/add_container.json
+++ b/tests/operations/lxd.container/add_container.json
@@ -1,0 +1,12 @@
+{
+    "kwargs": {
+        "name": "container1",
+        "image": "ubuntu:16.04"
+    },
+    "facts": {
+        "lxd_containers": []
+    },
+    "commands": [
+        "lxc launch ubuntu:16.04 container1"
+    ]
+}

--- a/tests/operations/lxd.container/already_absent.json
+++ b/tests/operations/lxd.container/already_absent.json
@@ -1,0 +1,17 @@
+{
+    "kwargs": {
+        "name": "container1",
+        "image": "ubuntu:16.04",
+        "present": false
+    },
+    "facts": {
+        "lxd_containers": [
+            {
+                "name": "container2",
+                "status": "Running"
+            }
+        ]
+    },
+    "commands": [
+    ]
+}

--- a/tests/operations/lxd.container/already_present.json
+++ b/tests/operations/lxd.container/already_present.json
@@ -1,0 +1,16 @@
+{
+    "kwargs": {
+        "name": "container1",
+        "image": "ubuntu:16.04"
+    },
+    "facts": {
+        "lxd_containers": [
+            {
+                "name": "container1",
+                "status": "Running"
+            }
+        ]
+    },
+    "commands": [
+    ]
+}

--- a/tests/operations/lxd.container/delete_container.json
+++ b/tests/operations/lxd.container/delete_container.json
@@ -1,0 +1,18 @@
+{
+    "kwargs": {
+        "name": "container1",
+        "image": "ubuntu:16.04",
+        "present": false
+    },
+    "facts": {
+        "lxd_containers": [
+            {
+                "name": "container1",
+                "status": "Stopped"
+            }
+        ]
+    },
+    "commands": [
+        "lxc delete container1"
+    ]
+}

--- a/tests/operations/lxd.container/delete_running_container.json
+++ b/tests/operations/lxd.container/delete_running_container.json
@@ -1,0 +1,19 @@
+{
+    "kwargs": {
+        "name": "container1",
+        "image": "ubuntu:16.04",
+        "present": false
+    },
+    "facts": {
+        "lxd_containers": [
+            {
+                "name": "container1",
+                "status": "Running"
+            }
+        ]
+    },
+    "commands": [
+        "lxc stop container1",
+        "lxc delete container1"
+    ]
+}


### PR DESCRIPTION
This branch adds the support for Linux containers using LXD (see [linuxcontainers.org/]( https://linuxcontainers.org)).

The `lxd` fact lists all containers present. `--fast` mode is used.
The module allows you to create a container based on a given image name, or delete it.