### PR TITLE
Add support for yielding commands in modules

### DIFF
--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -209,7 +209,8 @@ def operation(func=None, pipeline_facts=None):
             for key, arg in six.iteritems(kwargs)
         }
 
-        commands = func(state, host, *actual_args, **actual_kwargs)
+        # Convert to list as the result may be a generator
+        commands = list(func(state, host, *actual_args, **actual_kwargs))
 
         state.in_op = False
         state.current_op_meta = None


### PR DESCRIPTION
This adds the support for the 'yield' instruction inside modules.
Instead of generating a list of commands, appending new commands
to it and finally returning it, it is now possible to simply
yield each command and get the same result.

Closes #62 