### PR TITLE
Fix local.include to fail with wrong hosts type

### DIFF
--- a/pyinfra/local.py
+++ b/pyinfra/local.py
@@ -22,8 +22,8 @@ def include(filename, hosts=None):
     if not pseudo_state.active:
         return
 
-    if isinstance(hosts, list):
-        pseudo_state.limit_hosts = hosts
+    if hosts is not None:
+        pseudo_state.limit_hosts = list(hosts)
 
     filename = path.join(pseudo_state.deploy_dir, filename)
 


### PR DESCRIPTION
This fixes a bug in local.include where passing any data type
other that an list resulted silently in no limit on the hosts.

This change forces the `hosts` argument to be either None or an
iterable (list/tuple/generator).