### PR TITLE
Fix silently including all hosts on typo

### DIFF
--- a/pyinfra/api/inventory.py
+++ b/pyinfra/api/inventory.py
@@ -112,7 +112,7 @@ class Inventory(object):
         Get groups (lists of hosts) from the inventory by name.
         '''
 
-        return self.groups.get(key)
+        return self.groups[key]
 
     def __len__(self):
         '''


### PR DESCRIPTION
Making a typo in the name of a group, either in an inventory file
or in an include in deploy.py, results in all hosts being silently
ignored. This is due to the inventory returning None for unknown
group names.

This fixes the issue by not accepting unknown groups anymore.