### PR TITLE
Add support for pip3 or custom pip tool

### DIFF
--- a/pyinfra/modules/pip.py
+++ b/pyinfra/modules/pip.py
@@ -53,7 +53,7 @@ _virtualenv = virtualenv
 def packages(
     state, host,
     packages=None, present=True, latest=False,
-    requirements=None, virtualenv=None
+    requirements=None, virtualenv=None, pip='pip',
 ):
     '''
     Manage pip packages.
@@ -63,13 +63,14 @@ def packages(
     + latest: whether to upgrade packages without a specified version
     + requirements: location of requirements file to install
     + virtualenv: root directory of virtualenv to work in
+    + pip: name or path of the pip directory to use
 
     Versions:
         Package versions can be pinned like pip: ``<pkg>==<version>``
     '''
 
     if requirements is not None:
-        yield 'pip install -r {0}'.format(requirements)
+        yield '{0} install -r {1}'.format(pip, requirements)
 
     current_packages = host.fact.pip_packages(virtualenv)
 
@@ -79,19 +80,19 @@ def packages(
             _virtualenv(state, host, virtualenv)
 
     install_command = (
-        'pip install'
+        '{0} install'.format(pip)
         if virtualenv is None
         else '{0}/bin/pip install'.format(virtualenv)
     )
 
     uninstall_command = (
-        'pip uninstall'
+        '{0} uninstall'.format(pip)
         if virtualenv is None
         else '{0}/bin/pip uninstall'.format(virtualenv)
     )
 
     upgrade_command = (
-        'pip install --upgrade'
+        '{0} install --upgrade'.format(pip)
         if virtualenv is None
         else '{0}/bin/pip install --upgrade'.format(virtualenv)
     )

--- a/tests/operations/pip.packages/use_pip3.json
+++ b/tests/operations/pip.packages/use_pip3.json
@@ -1,0 +1,13 @@
+{
+    "args": [["test"]],
+    "kwargs": {
+        "pip": "pip3"
+    },
+    "facts": {
+        "pip_packages": {
+        }
+    },
+    "commands": [
+        "pip3 install test"
+    ]
+}


### PR DESCRIPTION
Recent distributions such as Ubuntu 16.04 LTS do not ship with
Python2 by default. The `pip` binary available in the package
python3-pip is called `pip3`, and cannot be used currently by
pyinfra. This branch fixes the issue by allowing to specify
the name or path of the `pip` tool to use.