### PR TITLE
Add : to apt regex versioning search and don't fail with no version

### DIFF
--- a/pyinfra/facts/apt.py
+++ b/pyinfra/facts/apt.py
@@ -95,7 +95,7 @@ class DebPackage(FactBase):
 
     _regexes = {
         'name': r'^Package: ([a-zA-Z0-9\-]+)$',
-        'version': r'^Version: ([0-9\.\-]+)$',
+        'version': r'^Version: ([0-9\:\.\-]+)$',
     }
 
     def command(self, name):

--- a/pyinfra/modules/apt.py
+++ b/pyinfra/modules/apt.py
@@ -162,7 +162,7 @@ def deb(state, host, source, present=True, force=False):
 
         if (
             info['name'] in current_packages
-            and info['version'] in current_packages[info['name']]
+            and info.get('version') in current_packages[info['name']]
         ):
             exists = True
 


### PR DESCRIPTION
Some versions include colons and these were ignored by the regex
If no version was found then the the module would fail- by doing get
this is avoided

Closes #152 