### PR TITLE
Added kwargs to git module for updating submodules

### DIFF
--- a/docs/modules/git.rst
+++ b/docs/modules/git.rst
@@ -27,7 +27,7 @@ Clone/pull git repositories.
 
     git.repo(
         source, target, branch='master', pull=True, rebase=False, user=None, group=None,
-        use_ssh_user=False, ssh_keyscan=False
+        use_ssh_user=False, ssh_keyscan=False, update_submodules=False, recursive_submodules=False
     )
 
 + **source**: the git source URL
@@ -38,6 +38,8 @@ Clone/pull git repositories.
 + **user**: chown files to this user after
 + **group**: chown files to this group after
 + **ssh_keyscan**: keyscan the remote host if not in known_hosts before clone/pull
++ **update_submodules**: update any submodules in the repository
++ **recursive_submodules**: recursively update submodules in the repository
 
 + [DEPRECATED] use_ssh_user: whether to use the SSH user to clone/pull
 

--- a/pyinfra/modules/git.py
+++ b/pyinfra/modules/git.py
@@ -48,6 +48,7 @@ def repo(
     state, host, source, target,
     branch='master', pull=True, rebase=False,
     user=None, group=None, use_ssh_user=False, ssh_keyscan=False,
+    update_submodules=False, recursive_submodules=False,
 ):
     '''
     Clone/pull git repositories.
@@ -60,6 +61,8 @@ def repo(
     + user: chown files to this user after
     + group: chown files to this group after
     + ssh_keyscan: keyscan the remote host if not in known_hosts before clone/pull
+    + update_submodules: update any git submodules
+    + recursive_submodules: update git submodules recursively
 
     + [DEPRECATED] use_ssh_user: whether to use the SSH user to clone/pull
 
@@ -118,6 +121,12 @@ def repo(
                 git_commands.append('pull --rebase')
             else:
                 git_commands.append('pull')
+
+    if update_submodules:
+        if recursive_submodules:
+            git_commands.append('submodule update --recursive')
+        else:
+            git_commands.append('submodule update')
 
     # Attach prefixes for directory
     command_prefix = 'cd {0} && git'.format(target)

--- a/tests/operations/git.repo/recursive_submodules.json
+++ b/tests/operations/git.repo/recursive_submodules.json
@@ -1,0 +1,22 @@
+{
+    "args": ["myrepo", "/home/myrepo"],
+    "kwargs": {
+        "update_submodules": true,
+        "recursive_submodules": true
+    },
+    "facts": {
+        "directory": {
+            "/home/myrepo": {},
+            "/home/myrepo/.git": {
+                "mode": 0
+            }
+        },
+        "git_branch": {
+            "/home/myrepo": "master"
+        }
+    },
+    "commands": [
+        "cd /home/myrepo && git pull",
+        "cd /home/myrepo && git submodule update --recursive"
+    ]
+}

--- a/tests/operations/git.repo/update_submodules.json
+++ b/tests/operations/git.repo/update_submodules.json
@@ -1,0 +1,21 @@
+{
+    "args": ["myrepo", "/home/myrepo"],
+    "kwargs": {
+        "update_submodules": true
+    },
+    "facts": {
+        "directory": {
+            "/home/myrepo": {},
+            "/home/myrepo/.git": {
+                "mode": 0
+            }
+        },
+        "git_branch": {
+            "/home/myrepo": "master"
+        }
+    },
+    "commands": [
+        "cd /home/myrepo && git pull",
+        "cd /home/myrepo && git submodule update"
+    ]
+}


### PR DESCRIPTION
This PR adds a couple of kwargs to the git module, allowing the updating of submodules within a git repository, either one level deep or recursively.