### PR TITLE
fix the formatting on the help

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -81,3 +81,22 @@ pyinfra @ansible/path/to/inventory
 # Load using an absolute path
 pyinfra @ansible//absolute/path/to/inventory
 ```
+
+## `@winrm`
+
+**Note**: this connector is experimental and a work in progress! Some Windows facts and Windows operations work but this is to be considered experimental. For now, only `winrm-username` and `winrm-password` is being used. There are other methods for authentication, but they have not yet been added/experimented with.
+
+The `@winrm` connector can be used to communicate with Windows instances that have WinRM enabled.
+
+Examples using `@winrm`:
+
+```sh
+# get the windows_home fact
+pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant --winrm-port 5985 -vv --debug fact windows_home
+# create a directory
+pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant --winrm-port 5985 windows_files.windows_directory 'c:\temp'
+# Run a powershell command ('ps' is the default shell-executable for the winrm connector)
+pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant --winrm-port 5985 exec -- write-host hello
+# Run a command using the command prompt:
+pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant --winrm-port 5985 --shell-executable cmd exec -- date /T
+```

--- a/pyinfra/modules/windows.py
+++ b/pyinfra/modules/windows.py
@@ -23,6 +23,7 @@ from pyinfra.api import operation
 def service(state, host, name, running=True, restart=False, suspend=False):
     '''
     Stop/Start a Windows service.
+
     + name: name of the service to manage
     + running: whether the the service should be running or stopped
     + restart: whether the the service should be restarted
@@ -31,6 +32,7 @@ def service(state, host, name, running=True, restart=False, suspend=False):
     Example:
 
     .. code:: python
+
         windows.service(
             {'Stop the spooler service'},
             'service',


### PR DESCRIPTION
The formatting of the windows.service does not render well.

Also, if you take a look at  https://pyinfra.readthedocs.io/en/latest/modules/windows_files.html it looks like the `\` is rendering weird, too. Perhaps we change the docs to use `/` instead?