### PR TITLE
Remove unnecessary import and variable declaration

### DIFF
--- a/pyinfra/progress.py
+++ b/pyinfra/progress.py
@@ -25,7 +25,7 @@ TERMINAL_WIDTH = 0
 if IS_TTY:
     try:
         TERMINAL_WIDTH = os.get_terminal_size().columns
-    except ImportError:
+    except AttributeError:
         if not IS_WINDOWS:
             terminal_size = os.popen('stty size', 'r').read().split()
             if len(terminal_size) == 2:

--- a/pyinfra/progress.py
+++ b/pyinfra/progress.py
@@ -24,8 +24,7 @@ TERMINAL_WIDTH = 0
 
 if IS_TTY:
     try:
-        from os import get_terminal_size
-        TERMINAL_WIDTH = get_terminal_size().columns
+        TERMINAL_WIDTH = os.get_terminal_size().columns
     except ImportError:
         if not IS_WINDOWS:
             terminal_size = os.popen('stty size', 'r').read().split()

--- a/pyinfra_cli/legacy.py
+++ b/pyinfra_cli/legacy.py
@@ -198,7 +198,6 @@ def setup_op_and_args(op_string, args_string):
         # Either default to server.shell w/op as command if no args are passed
         if not args_string:
             args_string = op_string
-            op_bits = ['server', 'shell']
 
         # Or fail as it's an invalid op
         else:


### PR DESCRIPTION
`pyinfra/progress.py`: "os" is already imported at the top, so the "from os import" is not necessary
`pyinfra_cli/legacy.py`: the "op_bits" variable is never used