### PR TITLE
Allow leading numbers for brew cask names

### DIFF
--- a/pyinfra/facts/brew.py
+++ b/pyinfra/facts/brew.py
@@ -2,7 +2,7 @@ from pyinfra.api import FactBase
 
 from .util.packaging import parse_packages
 
-BREW_REGEX = r'^([a-zA-Z\-]+)\s([0-9\._+a-z\-]+)'
+BREW_REGEX = r'^([a-zA-Z0-9\-]+)\s([0-9\._+a-z\-]+)'
 
 
 class BrewPackages(FactBase):

--- a/tests/facts/brew_casks/casks.json
+++ b/tests/facts/brew_casks/casks.json
@@ -1,0 +1,27 @@
+{
+    "command": "brew cask list --versions",
+    "output": [
+        "1password-cli 0.10.0",
+        "google-chrome 76.0.3809.132",
+        "firefox 69.0",
+        "steam latest",
+        "vlc 3.0.8"
+    ],
+    "fact": {
+        "1password-cli": [
+            "0.10.0"
+        ],
+        "google-chrome": [
+            "76.0.3809.132"
+        ],
+        "firefox": [
+            "69.0"
+        ],
+        "steam": [
+            "latest"
+        ],
+        "vlc": [
+            "3.0.8"
+        ]
+    }
+}


### PR DESCRIPTION
This allows numbers as the first character of the cask name. It does also allow it for packages and while I could find such names for casks I failed to find any for packages; let me know if you would prefer there be separate regexes for the two. I also added a test file for the cask facts.

Thanks for this project, I've been thoroughly enjoying using it for a revised version of my personal setup scripts (currently authored with Ansible). I definitely appreciate being able to debug it with a conventional python debugger rather than any special tooling! 👍 