### PR TITLE
Prevent expand environment in echo command

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -219,7 +219,7 @@ def line(state, host, name, line, present=True, replace=None, flags=None):
         replace = ''
 
     # Save commands for re-use in dynamic script when file not present at fact stage
-    echo_command = 'echo "{0}" >> {1}'.format(line, name)
+    echo_command = 'echo \'{0}\' >> {1}'.format(line, name)
     sed_replace_command = sed_replace(
         name, match_line, replace,
         flags=flags,

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -219,7 +219,7 @@ def line(state, host, name, line, present=True, replace=None, flags=None):
         replace = ''
 
     # Save commands for re-use in dynamic script when file not present at fact stage
-    echo_command = 'echo \'{0}\' >> {1}'.format(line, name)
+    echo_command = "echo '{0}' >> {1}".format(line, name)
     sed_replace_command = sed_replace(
         name, match_line, replace,
         flags=flags,


### PR DESCRIPTION
Hi!

In `files.line` operation echo use double quotes for write.
https://github.com/Fizzadar/pyinfra/blob/master/pyinfra/operations/files.py#L222

It trigger expand environment variable on command execution. And if try write something like below, it could little obscure.

```python
files.line(
    name=some_export_filename,
    line="export PATH=$PATH:/usr/local/some/bin",
    present=True
)
```

Content of `some_export_filename` will be:

```
export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/go/bin:/usr/local/some/bin
```

I replace double quotes with single quotes and it is fine.