### PR TITLE
Fix import "opreations" module in examples: oprerations->modules

### DIFF
--- a/examples/api_deploy.py
+++ b/examples/api_deploy.py
@@ -11,7 +11,7 @@ from pyinfra.api.connectors.vagrant import make_names_data  # noqa: E402
 from pyinfra.api.facts import get_facts  # noqa: E402
 from pyinfra.api.operation import add_op  # noqa: E402
 from pyinfra.api.operations import run_ops  # noqa: E402
-from pyinfra.operations import files, server  # noqa: E402
+from pyinfra.modules import files, server  # noqa: E402
 from pyinfra_cli.prints import jsonify  # noqa: E402
 
 

--- a/examples/apk.py
+++ b/examples/apk.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apk
+from pyinfra.modules import apk
 
 SUDO = True
 

--- a/examples/apt.py
+++ b/examples/apt.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt
+from pyinfra.modules import apt
 
 SUDO = True
 

--- a/examples/brew.py
+++ b/examples/brew.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import brew
+from pyinfra.modules import brew
 
 # To run: "pyinfra @local brew.py"
 

--- a/examples/choco.py
+++ b/examples/choco.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import choco
+from pyinfra.modules import choco
 
 computer_info = host.fact.windows_computer_info
 if computer_info:

--- a/examples/digitalocean/remove_10_ip.py
+++ b/examples/digitalocean/remove_10_ip.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import server
+from pyinfra.modules import server
 
 SUDO = True
 

--- a/examples/dnf.py
+++ b/examples/dnf.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import dnf
+from pyinfra.modules import dnf
 
 SUDO = True
 

--- a/examples/docker_ce.py
+++ b/examples/docker_ce.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt, init, python
+from pyinfra.modules import apt, init, python
 
 # Standalone example to show how to install Docker CE using
 # https://docs.docker.com/install/linux/docker-ce/ubuntu/

--- a/examples/files.py
+++ b/examples/files.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import files
+from pyinfra.modules import files
 
 # Note: This requires files in the files/ directory.
 

--- a/examples/files_download.py
+++ b/examples/files_download.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt, files
+from pyinfra.modules import apt, files
 
 SUDO = True
 

--- a/examples/files_line_with_quotes.py
+++ b/examples/files_line_with_quotes.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import files
+from pyinfra.modules import files
 
 SUDO = True
 

--- a/examples/gem.py
+++ b/examples/gem.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt, gem
+from pyinfra.modules import apt, gem
 
 SUDO = True
 

--- a/examples/git.py
+++ b/examples/git.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apk, apt, files, git, yum
+from pyinfra.modules import apk, apt, files, git, yum
 
 SUDO = True
 

--- a/examples/init.py
+++ b/examples/init.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import init
+from pyinfra.modules import init
 
 SUDO = True
 

--- a/examples/loops.py
+++ b/examples/loops.py
@@ -4,7 +4,7 @@ an example of looping while preserving the order.
 '''
 
 from pyinfra import state
-from pyinfra.operations import server
+from pyinfra.modules import server
 
 SUDO = True
 

--- a/examples/lxd.py
+++ b/examples/lxd.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import lxd, server
+from pyinfra.modules import lxd, server
 
 SUDO = True
 

--- a/examples/mysql.py
+++ b/examples/mysql.py
@@ -1,5 +1,5 @@
 from pyinfra import host, state
-from pyinfra.operations import apt, files, mysql, python
+from pyinfra.modules import apt, files, mysql, python
 
 SUDO = True
 

--- a/examples/npm.py
+++ b/examples/npm.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import apt, npm
+from pyinfra.modules import apt, npm
 
 SUDO = True
 

--- a/examples/pacman.py
+++ b/examples/pacman.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import pacman
+from pyinfra.modules import pacman
 
 SUDO = True
 

--- a/examples/pip.py
+++ b/examples/pip.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apk, apt, files, pip, yum
+from pyinfra.modules import apk, apt, files, pip, yum
 
 SUDO = True
 

--- a/examples/pkg.py
+++ b/examples/pkg.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import pkg
+from pyinfra.modules import pkg
 
 SUDO = True
 

--- a/examples/postgresql.py
+++ b/examples/postgresql.py
@@ -1,5 +1,5 @@
 from pyinfra import host, state
-from pyinfra.operations import apt, files, postgresql, python
+from pyinfra.modules import apt, files, postgresql, python
 
 SUDO = True
 

--- a/examples/puppet/step0.py
+++ b/examples/puppet/step0.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import server
+from pyinfra.modules import server
 
 SUDO = True
 

--- a/examples/puppet/step1.py
+++ b/examples/puppet/step1.py
@@ -1,5 +1,5 @@
 from pyinfra import host, inventory
-from pyinfra.operations import files, init, server, yum
+from pyinfra.modules import files, init, server, yum
 
 SUDO = True
 

--- a/examples/puppet/step2.py
+++ b/examples/puppet/step2.py
@@ -1,5 +1,5 @@
 from pyinfra import host, inventory
-from pyinfra.operations import init, puppet, server
+from pyinfra.modules import init, puppet, server
 
 SUDO = True
 USE_SUDO_LOGIN = True

--- a/examples/puppet/step3.py
+++ b/examples/puppet/step3.py
@@ -1,5 +1,5 @@
 from pyinfra import host, inventory
-from pyinfra.operations import files, puppet
+from pyinfra.modules import files, puppet
 
 SUDO = True
 USE_SUDO_LOGIN = True

--- a/examples/pxe/pxe_infra.py
+++ b/examples/pxe/pxe_infra.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt, files, init, server
+from pyinfra.modules import apt, files, init, server
 
 SUDO = True
 

--- a/examples/pxe_with_nfs/pxe_with_nfs_infra.py
+++ b/examples/pxe_with_nfs/pxe_with_nfs_infra.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt, files, init, server
+from pyinfra.modules import apt, files, init, server
 
 SUDO = True
 

--- a/examples/python.py
+++ b/examples/python.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import python
+from pyinfra.modules import python
 
 # Tip: Can run try it out using: 'pyinfra @docker/python python.py'
 

--- a/examples/python_app.py
+++ b/examples/python_app.py
@@ -1,6 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import git, pip, server
-
+from pyinfra.modules import git, pip, server
 
 # Ensure the state of git repositories
 git.repo(

--- a/examples/python_webserver/myweb.py
+++ b/examples/python_webserver/myweb.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import files, init, server
+from pyinfra.modules import files, init, server
 
 SUDO = True
 

--- a/examples/reboot.py
+++ b/examples/reboot.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import init, server
+from pyinfra.modules import init, server
 
 SUDO = True
 

--- a/examples/server.py
+++ b/examples/server.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt, server, yum
+from pyinfra.modules import apt, server, yum
 
 SUDO = True
 

--- a/examples/server_outputs.py
+++ b/examples/server_outputs.py
@@ -1,4 +1,4 @@
-from pyinfra.operations import server
+from pyinfra.modules import server
 
 SUDO = True
 

--- a/examples/ssh_demo/ssh_demo1.py
+++ b/examples/ssh_demo/ssh_demo1.py
@@ -1,5 +1,5 @@
 from pyinfra import host, inventory
-from pyinfra.operations import files, server
+from pyinfra.modules import files, server
 
 SUDO = True
 

--- a/examples/ssh_demo/ssh_demo2.py
+++ b/examples/ssh_demo/ssh_demo2.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import server
+from pyinfra.modules import server
 
 SUDO = True
 

--- a/examples/ssh_demo/ssh_demo3.py
+++ b/examples/ssh_demo/ssh_demo3.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import ssh
+from pyinfra.modules import ssh
 
 # Note: Not running as sudo, use the vagrant user.
 SUDO = False

--- a/examples/vagrant/vagrant.py
+++ b/examples/vagrant/vagrant.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt, files, python, server
+from pyinfra.modules import apt, files, python, server
 
 SUDO = True
 

--- a/examples/virtualbox/virtualbox.py
+++ b/examples/virtualbox/virtualbox.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import apt, python, server
+from pyinfra.modules import apt, python, server
 
 SUDO = True
 

--- a/examples/yum.py
+++ b/examples/yum.py
@@ -1,5 +1,5 @@
 from pyinfra import host
-from pyinfra.operations import yum
+from pyinfra.modules import yum
 
 SUDO = True
 


### PR DESCRIPTION
When using examples, I noticed that operations modules was changed but in examples left the old one
