### PR TITLE
add option tu use venv instead of virtualenv

### DIFF
--- a/pyinfra/operations/pip.py
+++ b/pyinfra/operations/pip.py
@@ -14,12 +14,13 @@ from .util.packaging import ensure_packages
 @operation
 def virtualenv(
     state, host, path,
-    python=None, site_packages=False, always_copy=False, present=True,
+    python=None, venv=False, site_packages=False, always_copy=False, present=True,
 ):
     '''
     Add/remove Python virtualenvs.
 
     + python: python interpreter to use
+    + venv: use standard venv module instead of virtualenv
     + site_packages: give access to the global site-packages
     + always_copy: always copy files rather than symlinking
     + present: whether the virtualenv should exist
@@ -45,14 +46,19 @@ def virtualenv(
         # Create missing virtualenv
         command = ['virtualenv']
 
-        if python:
+        if venv:
+            command = [python or 'python', '-m', 'venv']
+
+        if python and not venv:
             command.append('-p {0}'.format(python))
 
         if site_packages:
             command.append('--system-site-packages')
 
-        if always_copy:
+        if always_copy and not venv:
             command.append('--always-copy')
+        elif always_copy and venv:
+            command.append('--copies')
 
         command.append(path)
 

--- a/tests/operations/pip.virtualenv/use_stdlib_venv.json
+++ b/tests/operations/pip.virtualenv/use_stdlib_venv.json
@@ -1,0 +1,14 @@
+{
+    "kwargs": {
+        "path": "/some/virtualenv",
+	"venv": true
+    },
+    "facts": {
+        "file": {
+            "/some/virtualenv/bin/activate": null
+        }
+    },
+    "commands": [
+        "python -m venv /some/virtualenv"
+    ]
+}

--- a/tests/operations/pip.virtualenv/use_stdlib_venv_py3.json
+++ b/tests/operations/pip.virtualenv/use_stdlib_venv_py3.json
@@ -1,0 +1,15 @@
+{
+    "kwargs": {
+        "path": "/some/virtualenv",
+        "python": "python3",
+	"venv": true
+    },
+    "facts": {
+        "file": {
+            "/some/virtualenv/bin/activate": null
+        }
+    },
+    "commands": [
+        "python3 -m venv /some/virtualenv"
+    ]
+}


### PR DESCRIPTION
One may want to use integrated standard `venv` module instead of
third-party `virtualenv`.

Fixes #322