### PR TITLE
do not include commented out lines when parsing yum repo files

### DIFF
--- a/pyinfra/facts/util/packaging.py
+++ b/pyinfra/facts/util/packaging.py
@@ -25,7 +25,7 @@ def parse_yum_repositories(output):
     current_repo = {}
     for line in output:
         line = line.strip()
-        if not line:
+        if not line or line.startswith('#'):
             continue
 
         if line.startswith('['):

--- a/pyinfra/facts/yum.py
+++ b/pyinfra/facts/yum.py
@@ -10,7 +10,11 @@ class YumRepositories(FactBase):
     .. code:: python
 
         {
-            'baseurl': 'http://archive.ubuntu.org',
+            'name': 'CentOS-$releasever - AppStream',
+            'mirrorlist': 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream&infra=$infra',
+            'gpgcheck': '1',
+            'enabled': '1',
+            'gpgkey': 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial',
         },
         ...
     '''

--- a/pyinfra/facts/yum.py
+++ b/pyinfra/facts/yum.py
@@ -11,7 +11,7 @@ class YumRepositories(FactBase):
 
         {
             'name': 'CentOS-$releasever - AppStream',
-            'mirrorlist': 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=AppStream&infra=$infra',
+            'baseurl': 'http://mirror.centos.org/$contentdir/$releasever/AppStream/$basearch/os/',
             'gpgcheck': '1',
             'enabled': '1',
             'gpgkey': 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial',

--- a/tests/facts/yum_repositories/repos.json
+++ b/tests/facts/yum_repositories/repos.json
@@ -1,8 +1,11 @@
 {
     "command": "cat /etc/yum.conf /etc/yum.repos.d/*.repo 2> /dev/null || true",
     "output": [
+        "# comment line",
+        " # comment line with whitespaces",
         "[somerepo]",
         "baseurl=abc"
+
     ],
     "fact": [
         {


### PR DESCRIPTION
I've noticed when running for example `pyinfra @vagrant/centos8 fact yum_repositores` that the output includes extraneous entity that correspond to a yum repository.
This PR ignore parsing repo file starting with a `#` character.

Example before change:
```
...
        {                                                                                                                
            "name": "CentOS-$releasever - Base",                                                                         
            "mirrorlist": "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS&infra=$infra",
            "#baseurl": "http://mirror.centos.org/$contentdir/$releasever/BaseOS/$basearch/os/",                          
            "gpgcheck": "1",                                                                
            "enabled": "1",                                                                                   
            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",                 
            "# If the mirrorlist": " does not work for you, as a fall back you can try the",                     
            "# remarked out baseurl": " line instead."                            
        },
...
```
Example after change:
```
...
        {
            "name": "CentOS-$releasever - Base",
            "mirrorlist": "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=BaseOS&infra=$infra",
            "gpgcheck": "1",
            "enabled": "1",
            "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial"
        },
...
```

Also I've fixed the example structure of `yum_repositories` in `pyinfra.facts.yum.YumRepositories` docstring.