### PR TITLE
follow tail /dev/null command to start docker container

### DIFF
--- a/pyinfra/api/connectors/docker.py
+++ b/pyinfra/api/connectors/docker.py
@@ -38,7 +38,7 @@ def connect(state, host, for_fact=None):
     try:
         with progress_spinner({'docker run'}):
             container_id = local.shell(
-                'docker run -d {0} sleep 10000'.format(host.data.docker_image),
+                'docker run -d {0} tail -f /dev/null'.format(host.data.docker_image),
                 splitlines=True,
             )[-1]  # last line is the container ID
     except PyinfraError as e:

--- a/tests/test_connectors/test_docker.py
+++ b/tests/test_connectors/test_docker.py
@@ -13,7 +13,7 @@ from ..util import make_inventory
 
 
 def fake_docker_shell(command, splitlines=None):
-    if command == 'docker run -d not-an-image sleep 10000':
+    if command == 'docker run -d not-an-image tail -f /dev/null':
         return ['containerid']
 
     elif command == 'docker commit containerid':


### PR DESCRIPTION
The PR improves the way docker container are started by using a `tail` on `/dev/null`. 
I think this is an improvement over the hard-coded `sleep` since we don't need to limit the amount of time the container started by `pyinfra` stays up.