### PR TITLE
initial work on zypper operations and opensuse support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,4 +76,14 @@ Vagrant.configure('2') do |config|
             v.gui = true
        end
     end
+
+    config.vm.define :opensuse_leap15 do |opensuse|
+        opensuse.vm.box = 'bento/opensuse-leap-15'
+        opensuse.vm.box_version = "202006.17.0"
+    end
+
+    config.vm.define :opensuse_tumbleweed do |opensuse|
+        opensuse.vm.box = "opensuse/Tumbleweed.x86_64"
+        opensuse.vm.box_version = "1.0.20200618"
+    end
 end

--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -450,6 +450,8 @@ class LinuxDistribution(FactBase):
 
     name_to_pretty_name = {
         'Centos': 'CentOS',
+        'Opensuse-Tumbleweed': 'openSUSE',
+        'Opensuse-Leap': 'openSUSE',
     }
 
     @staticmethod
@@ -464,7 +466,7 @@ class LinuxDistribution(FactBase):
         meta = {}
 
         for line in output:
-            if '=' in line:
+            if '=' in line and not line.startswith('#'):
                 key, value = line.split('=')
                 meta[key] = value.strip('"')
 

--- a/pyinfra/facts/util/packaging.py
+++ b/pyinfra/facts/util/packaging.py
@@ -19,7 +19,7 @@ def parse_packages(regex, output, lower=True):
     return packages
 
 
-def parse_yum_repositories(output):
+def _parse_yum_or_zypper_repositories(output):
     repos = []
 
     current_repo = {}
@@ -43,3 +43,8 @@ def parse_yum_repositories(output):
         repos.append(current_repo)
 
     return repos
+
+
+parse_yum_repositories = _parse_yum_or_zypper_repositories
+
+parse_zypper_repositories = _parse_yum_or_zypper_repositories

--- a/pyinfra/facts/zypper.py
+++ b/pyinfra/facts/zypper.py
@@ -1,0 +1,26 @@
+from pyinfra.api import FactBase
+
+from .util.packaging import parse_zypper_repositories
+
+
+class ZypperRepositories(FactBase):
+    '''
+    Returns a list of installed zypper repositories:
+
+    .. code:: python
+
+        {
+            'name': 'Main Repository',
+            'enabled': '1',
+            'autorefresh': '0',
+            'baseurl': 'http://download.opensuse.org/distribution/leap/$releasever/repo/oss/',
+            'type': 'rpm-md'
+        },
+        ...
+    '''
+
+    command = 'cat /etc/zypp/repos.d/*.repo 2> /dev/null || true'
+    default = list
+
+    def process(self, output):
+        return parse_zypper_repositories(output)

--- a/pyinfra/operations/util/packaging.py
+++ b/pyinfra/operations/util/packaging.py
@@ -166,7 +166,7 @@ def ensure_rpm(state, host, files, source, present, package_manager_command):
 def ensure_yum_repo(
     state, host, files,
     name_or_url, baseurl, present, description, enabled, gpgcheck, gpgkey,
-    package_config_command,
+    package_config_command,  # FIXME: parameter not used.
 ):
     url = None
     url_parts = urlparse(name_or_url)
@@ -199,6 +199,57 @@ def ensure_yum_repo(
         'baseurl={0}'.format(baseurl),
         'enabled={0}'.format(1 if enabled else 0),
         'gpgcheck={0}'.format(1 if gpgcheck else 0),
+    ]
+
+    if gpgkey:
+        repo_lines.append('gpgkey={0}'.format(gpgkey))
+
+    repo_lines.append('')
+    repo = '\n'.join(repo_lines)
+    repo = StringIO(repo)
+
+    # Ensure this is the file on the server
+    yield files.put(state, host, repo, filename)
+
+
+# FIXME: the function is almost identical to ensure_yum_repo.
+# TODO: Find a way DRY the code.
+def ensure_zypper_repo(
+    state, host, files,
+    name_or_url, baseurl, present, description, enabled, gpgcheck, gpgkey, type,
+):
+    url = None
+    url_parts = urlparse(name_or_url)
+    if url_parts.scheme:
+        url = name_or_url
+        name_or_url = url_parts.path.split('/')[-1]
+        if name_or_url.endswith('.repo'):
+            name_or_url = name_or_url[:-5]
+
+    filename = '/etc/zypp/repos.d/{0}.repo'.format(name_or_url)
+
+    # If we don't want the repo, just remove any existing file
+    if not present:
+        yield files.file(state, host, filename, present=False)
+        return
+
+    # If we're a URL, download the repo if it doesn't exist
+    if url:
+        if not host.fact.file(filename):
+            yield files.download(state, host, url, filename)
+        return
+
+    # Description defaults to name
+    description = description or name_or_url
+
+    # Build the repo file from string
+    repo_lines = [
+        '[{0}]'.format(name_or_url),
+        'name={0}'.format(description),
+        'baseurl={0}'.format(baseurl),
+        'enabled={0}'.format(1 if enabled else 0),
+        'gpgcheck={0}'.format(1 if gpgcheck else 0),
+        'type={0}'.format(type if type else 'rpm-md'),
     ]
 
     if gpgkey:

--- a/pyinfra/operations/zypper.py
+++ b/pyinfra/operations/zypper.py
@@ -1,0 +1,195 @@
+from __future__ import unicode_literals
+
+from pyinfra.api import operation
+
+from . import files
+from .util.packaging import ensure_packages, ensure_rpm, ensure_zypper_repo
+from .yum import key as yum_key
+
+key = yum_key
+
+
+@operation
+def repo(
+    state,
+    host,
+    name,
+    baseurl=None,
+    present=True,
+    description=None,
+    enabled=True,
+    gpgcheck=True,
+    gpgkey=None,
+    type=None,
+):
+    '''
+    Add/remove/update zypper repositories.
+
+    + name: URL or name for the ``.repo``   file
+    + baseurl: the baseurl of the repo (if ``name`` is not a URL)
+    + present: whether the ``.repo`` file should be present
+    + description: optional verbose description
+    + enabled: whether this repo is enabled
+    + gpgcheck: whether set ``gpgcheck=1``
+    + gpgkey: the URL to the gpg key for this repo
+    + type: the type field this repo (defaults to ``rpm-md``)
+
+    ``Baseurl``/``description``/``gpgcheck``/``gpgkey``:
+        These are only valid when ``name`` is a filename (ie not a URL). This is
+        for manual construction of repository files. Use a URL to download and
+        install remote repository files.
+
+    Examples:
+
+    .. code:: python
+
+        # Download a repository file
+        zypper.repo(
+            {'Install container virtualization repo via URL'},
+            'https://download.opensuse.org/repositories/Virtualization:containers/openSUSE_Tumbleweed/Virtualization:containers.repo',
+        )
+
+        # Create the repository file from baseurl/etc
+        zypper.repo(
+            {'Install container virtualization repo'},
+            name='Virtualization:containers (openSUSE_Tumbleweed)',
+            baseurl='https://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Tumbleweed/',
+        )
+    '''
+
+    yield ensure_zypper_repo(
+        state,
+        host,
+        files,
+        name,
+        baseurl,
+        present,
+        description,
+        enabled,
+        gpgcheck,
+        gpgkey,
+        type,
+    )
+
+
+@operation
+def rpm(state, host, source, present=True):
+    # NOTE: if updating this docstring also update `dnf.rpm`
+    '''
+    Add/remove ``.rpm`` file packages.
+
+    + source: filename or URL of the ``.rpm`` package
+    + present: whether ore not the package should exist on the system
+
+    URL sources with ``present=False``:
+        If the ``.rpm`` file isn't downloaded, pyinfra can't remove any existing
+        package as the file won't exist until mid-deploy.
+
+    Example:
+
+    .. code:: python
+
+        zypper.rpm(
+           {'Install task from rpm'},
+           'https://github.com/go-task/task/releases/download/v2.8.1/task_linux_amd64.rpm'
+        )
+    '''
+
+    yield ensure_rpm(state, host, files, source, present, 'zypper --non-interactive')
+
+
+@operation
+def update(state, host):
+    '''
+    Updates all zypper packages.
+    '''
+
+    yield 'zypper update -y'
+
+
+_update = update  # noqa: E305 (for use below where update is a kwarg)
+
+
+@operation
+def packages(
+    state,
+    host,
+    packages=None,
+    present=True,
+    latest=False,
+    update=False,
+    clean=False,
+    extra_global_install_args=None,
+    extra_install_args=None,
+    extra_global_uninstall_args=None,
+    extra_uninstall_args=None,
+):
+    '''
+    Install/remove/update zypper packages & updates.
+
+    + packages: list of packages to ensure
+    + present: whether the packages should be installed
+    + latest: whether to upgrade packages without a specified version
+    + update: run zypper update
+    + clean: run zypper clean
+    + extra_global_install_args: additional global arguments to the zypper install command
+    + extra_install_args: additional arguments to the zypper install command
+    + extra_global_uninstall_args: additional global arguments to the zypper uninstall command
+    + extra_uninstall_args: additional arguments to the zypper uninstall command
+
+    Versions:
+        Package versions can be pinned like zypper: ``<pkg>=<version>``
+
+    Examples:
+
+    .. code:: python
+
+        # Update package list and install packages
+        zypper.packages(
+            {'Install Vim and Vim enhanced'},
+            ['vim-enhanced', 'vim'],
+            update=True,
+        )
+
+        # Install the latest versions of packages (always check)
+        zypper.packages(
+            {'Install latest Vim'},
+            ['vim'],
+            latest=True,
+        )
+    '''
+
+    if clean:
+        yield 'zypper clean --all'
+
+    if update:
+        yield _update(state, host)
+
+    install_command = ['zypper', '--non-interactive', 'install', '-y']
+
+    if extra_install_args:
+        install_command.append(extra_install_args)
+
+    if extra_global_install_args:
+        install_command.insert(1, extra_global_install_args)
+
+    uninstall_command = ['zypper', '--non-interactive', 'remove', '-y']
+
+    if extra_uninstall_args:
+        uninstall_command.append(extra_uninstall_args)
+
+    if extra_global_uninstall_args:
+        uninstall_command.insert(1, extra_global_uninstall_args)
+
+    upgrade_command = 'zypper update -y'
+
+    yield ensure_packages(
+        packages,
+        host.fact.rpm_packages,
+        present,
+        install_command=' '.join(install_command),
+        uninstall_command=' '.join(uninstall_command),
+        upgrade_command=upgrade_command,
+        version_join='=',
+        latest=latest,
+    )

--- a/tests/operations/zypper.key/add.json
+++ b/tests/operations/zypper.key/add.json
@@ -1,0 +1,6 @@
+{
+    "args": ["mykey"],
+    "commands": [
+        "rpm --import mykey"
+    ]
+}

--- a/tests/operations/zypper.packages/add_packages.json
+++ b/tests/operations/zypper.packages/add_packages.json
@@ -1,0 +1,15 @@
+{
+    "args": [[
+        "git",
+        "python-devel",
+        "something"
+    ]],
+    "facts": {
+        "rpm_packages": {
+            "something": [""]
+        }
+    },
+    "commands": [
+        "zypper --non-interactive install -y git python-devel"
+    ]
+}

--- a/tests/operations/zypper.packages/install_with_args.json
+++ b/tests/operations/zypper.packages/install_with_args.json
@@ -1,0 +1,12 @@
+{
+    "args": [ "docker-ce"],
+    "kwargs": {
+        "extra_install_args": "--foo"
+    },
+    "facts": {
+        "rpm_packages": {}
+    },
+    "commands": [
+        "zypper --non-interactive install -y --foo docker-ce"
+    ]
+}

--- a/tests/operations/zypper.packages/install_with_global_args.json
+++ b/tests/operations/zypper.packages/install_with_global_args.json
@@ -1,0 +1,12 @@
+{
+    "args": [ "docker-ce"],
+    "kwargs": {
+        "extra_global_install_args": "--bar"
+    },
+    "facts": {
+        "rpm_packages": {}
+    },
+    "commands": [
+        "zypper --bar --non-interactive install -y docker-ce"
+    ]
+}

--- a/tests/operations/zypper.packages/uninstall_with_args.json
+++ b/tests/operations/zypper.packages/uninstall_with_args.json
@@ -1,0 +1,17 @@
+{
+	"args": [[
+        "git"
+    ]],
+    "kwargs": {
+		"present": false,
+        "extra_uninstall_args": "--force"
+    },
+	"facts": {
+        "rpm_packages": {
+            "git": [""]
+        }
+    },
+    "commands": [
+        "zypper --non-interactive remove -y --force git"
+    ]
+}

--- a/tests/operations/zypper.packages/uninstall_with_global_args.json
+++ b/tests/operations/zypper.packages/uninstall_with_global_args.json
@@ -1,0 +1,17 @@
+{
+	"args": [[
+        "git"
+    ]],
+    "kwargs": {
+		"present": false,
+        "extra_global_uninstall_args": "--quiet"
+    },
+	"facts": {
+        "rpm_packages": {
+            "git": [""]
+        }
+    },
+    "commands": [
+        "zypper --quiet --non-interactive remove -y git"
+    ]
+}

--- a/tests/operations/zypper.packages/update_clean.json
+++ b/tests/operations/zypper.packages/update_clean.json
@@ -1,0 +1,13 @@
+{
+    "kwargs": {
+        "update": true,
+        "clean": true
+    },
+    "facts": {
+        "rpm_packages": {}
+    },
+    "commands": [
+        "zypper clean --all",
+        "zypper update -y"
+    ]
+}

--- a/tests/operations/zypper.repo/add.json
+++ b/tests/operations/zypper.repo/add.json
@@ -1,0 +1,18 @@
+{
+    "args": ["somerepo", "http://baseurl"],
+    "kwargs": {
+        "description": "description",
+        "gpgcheck": false,
+        "gpgkey": "test"
+    },
+    "facts": {
+        "file": {
+            "/etc/zypp/repos.d/somerepo.repo": {}
+        }
+    },
+    "commands": [[
+        "upload",
+        "[somerepo]\nname=description\nbaseurl=http://baseurl\nenabled=1\ngpgcheck=0\ntype=rpm-md\ngpgkey=test\n",
+            "/etc/zypp/repos.d/somerepo.repo"
+    ]]
+}

--- a/tests/operations/zypper.repo/add_url.json
+++ b/tests/operations/zypper.repo/add_url.json
@@ -1,0 +1,14 @@
+{
+    "args": ["http://somesite/somerepo.repo"],
+    "facts": {
+        "file": {
+            "/etc/zypp/repos.d/somerepo.repo": null
+        },
+        "which": {
+            "curl": "yes"
+        }
+    },
+    "commands": [
+        "curl -sSLf http://somesite/somerepo.repo -o /etc/zypp/repos.d/somerepo.repo"
+    ]
+}

--- a/tests/operations/zypper.repo/remove.json
+++ b/tests/operations/zypper.repo/remove.json
@@ -1,0 +1,14 @@
+{
+    "args": ["somerepo", "http://baseurl"],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "file": {
+            "/etc/zypp/repos.d/somerepo.repo": {
+                "mode": 0
+            }
+        }
+    },
+    "commands": ["rm -f /etc/zypp/repos.d/somerepo.repo"]
+}

--- a/tests/operations/zypper.rpm/add.json
+++ b/tests/operations/zypper.rpm/add.json
@@ -1,0 +1,16 @@
+{
+    "args": ["something.rpm"],
+    "facts": {
+        "rpm_packages": {},
+        "rpm_package": {
+            "something.rpm": {
+                "name": "something",
+                "version": "abc"
+            },
+            "something": null
+        }
+    },
+    "commands": [
+        "rpm -i something.rpm"
+    ]
+}

--- a/tests/operations/zypper.rpm/add_existing.json
+++ b/tests/operations/zypper.rpm/add_existing.json
@@ -1,0 +1,15 @@
+{
+    "args": ["something.rpm"],
+    "facts": {
+        "rpm_package": {
+            "something.rpm": {
+                "name": "something",
+                "version": "1.1"
+            },
+            "something": {
+                "version": "1.1"
+            }
+        }
+    },
+    "commands": []
+}

--- a/tests/operations/zypper.rpm/add_existing_upgrade.json
+++ b/tests/operations/zypper.rpm/add_existing_upgrade.json
@@ -1,0 +1,15 @@
+{
+    "args": ["something.rpm"],
+    "facts": {
+        "rpm_package": {
+            "something.rpm": {
+                "name": "something",
+                "version": "1.1"
+            },
+            "something": {
+                "version": "1.0"
+            }
+        }
+    },
+    "commands": ["rpm -i something.rpm"]
+}

--- a/tests/operations/zypper.rpm/add_url.json
+++ b/tests/operations/zypper.rpm/add_url.json
@@ -1,0 +1,18 @@
+{
+    "args": ["https://something.rpm"],
+    "facts": {
+        "file": {
+            "_tempfile_.rpm": null
+        },
+        "rpm_package": {
+            "_tempfile_.rpm": null
+        },
+        "which": {
+            "curl": "yes"
+        }
+    },
+    "commands": [
+        "curl -sSLf https://something.rpm -o _tempfile_.rpm",
+        "rpm -q `rpm -qp _tempfile_.rpm` 2> /dev/null || rpm -i _tempfile_.rpm"
+    ]
+}

--- a/tests/operations/zypper.rpm/remove.json
+++ b/tests/operations/zypper.rpm/remove.json
@@ -1,0 +1,20 @@
+{
+    "args": ["something.rpm"],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "rpm_package": {
+            "something.rpm": {
+                "name": "something",
+                "version": "1.1"
+            },
+            "something": {
+                "version": "1.1"
+            }
+        }
+    },
+    "commands": [
+        "zypper --non-interactive remove -y something"
+    ]
+}

--- a/words.txt
+++ b/words.txt
@@ -33,6 +33,7 @@ E402
 E501
 F401
 F403
+FIXME
 Ed25519
 Gevent
 HKLM
@@ -344,3 +345,4 @@ writeable
 yarn
 yaml
 zfill
+zypper


### PR DESCRIPTION
This PR has the following changes:
added operations:
* zypper.key
* zypper.repo
* zypper.rpm
* zypper.update
* zypper.packages

added facts:
* zypper_repositories

added vagrant boxes:
* opensuse_leap15 (openSUSE leap v15)
* opensuse_tumbleweed (openSUSE Tumbleweed)

The implementation is very similar to existing code for yum base operations for example.
The only thing that I think missing is openSUSE specific integrations tests.