### PR TITLE
declare connectors as setuptools entrypoints

### DIFF
--- a/pyinfra/api/connectors/__init__.py
+++ b/pyinfra/api/connectors/__init__.py
@@ -11,5 +11,5 @@ ALL_CONNECTORS = {
 EXECUTION_CONNECTORS = {
     connector: connector_mod
     for connector, connector_mod in ALL_CONNECTORS.items()
-    if getattr(connector_mod, "EXECUTION_CONNECTOR", False)
+    if getattr(connector_mod, 'EXECUTION_CONNECTOR', False)
 }

--- a/pyinfra/api/connectors/__init__.py
+++ b/pyinfra/api/connectors/__init__.py
@@ -1,23 +1,15 @@
-from . import ansible, chroot, docker, local, mech, ssh, vagrant, winrm
+import pkg_resources
+
+# Connectors that handle generation of inventories
+ALL_CONNECTORS = {
+    ep.name: ep.load()
+    for ep in pkg_resources.iter_entry_points('pyinfra.connectors')
+}
 
 
 # Connectors that handle execution of pyinfra operations
-EXECUTION_CONNECTORS = {  # pragma: no cover
-    'docker': docker,
-    'chroot': chroot,
-    'local': local,
-    'ssh': ssh,
-    'winrm': winrm,
-}
-
-# Connectors that handle generation of inventories
-ALL_CONNECTORS = {  # pragma: no cover
-    'ansible': ansible,
-    'docker': docker,
-    'chroot': chroot,
-    'local': local,
-    'mech': mech,
-    'ssh': ssh,
-    'vagrant': vagrant,
-    'winrm': winrm,
+EXECUTION_CONNECTORS = {
+    connector: connector_mod
+    for connector, connector_mod in ALL_CONNECTORS.items()
+    if getattr(connector_mod, "EXECUTION_CONNECTOR", False)
 }

--- a/pyinfra/api/connectors/__init__.py
+++ b/pyinfra/api/connectors/__init__.py
@@ -2,8 +2,8 @@ import pkg_resources
 
 # Connectors that handle generation of inventories
 ALL_CONNECTORS = {
-    ep.name: ep.load()
-    for ep in pkg_resources.iter_entry_points('pyinfra.connectors')
+    entrypoint.name: entrypoint.load()
+    for entrypoint in pkg_resources.iter_entry_points('pyinfra.connectors')
 }
 
 

--- a/pyinfra/api/connectors/chroot.py
+++ b/pyinfra/api/connectors/chroot.py
@@ -200,3 +200,6 @@ def get_file(
         )
 
     return status
+
+
+EXECUTION_CONNECTOR = True

--- a/pyinfra/api/connectors/docker.py
+++ b/pyinfra/api/connectors/docker.py
@@ -201,3 +201,6 @@ def get_file(
         ))
 
     return status
+
+
+EXECUTION_CONNECTOR = True

--- a/pyinfra/api/connectors/local.py
+++ b/pyinfra/api/connectors/local.py
@@ -177,3 +177,6 @@ def get_file(
         click.echo('{0}file copied: {1}'.format(host.print_prefix, remote_filename))
 
     return True
+
+
+EXECUTION_CONNECTOR = True

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -427,3 +427,6 @@ def put_file(
         click.echo('{0}file uploaded: {1}'.format(host.print_prefix, remote_filename))
 
     return True
+
+
+EXECUTION_CONNECTOR = True

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -209,3 +209,6 @@ def put_file(
     **command_kwargs
 ):
     raise PyinfraError('Not implemented')
+
+
+EXECUTION_CONNECTOR = True

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
                 'ssh = pyinfra.api.connectors.ssh',
                 'vagrant = pyinfra.api.connectors.vagrant',
                 'winrm = pyinfra.api.connectors.winrm',
-            ]
+            ],
         },
         install_requires=INSTALL_REQUIRES,
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import sys
-
 from io import open
 
 try:
@@ -101,6 +100,16 @@ if __name__ == '__main__':
             'console_scripts': (
                 'pyinfra=pyinfra_cli.__main__:execute_pyinfra',
             ),
+            'pyinfra.connectors': [
+                'ansible = pyinfra.api.connectors.ansible',
+                'chroot = pyinfra.api.connectors.chroot',
+                'docker = pyinfra.api.connectors.docker',
+                'local = pyinfra.api.connectors.local',
+                'mech = pyinfra.api.connectors.mech',
+                'ssh = pyinfra.api.connectors.ssh',
+                'vagrant = pyinfra.api.connectors.vagrant',
+                'winrm = pyinfra.api.connectors.winrm',
+            ]
         },
         install_requires=INSTALL_REQUIRES,
         extras_require={

--- a/words.txt
+++ b/words.txt
@@ -88,6 +88,7 @@ Unignored
 Vagrantfile
 W605
 Win32
+Xbps
 addsitedir
 adhoc
 agentrequesthandler
@@ -148,6 +149,7 @@ dnsmasq
 docbits
 docopt
 dport
+entrypoint
 epel
 excuted
 exe
@@ -342,6 +344,7 @@ wget
 whocares
 winrm
 writeable
+xbps
 yarn
 yaml
 zfill


### PR DESCRIPTION
This PR changes the way builtins connectors are declared, namely changed from being static entries on the `pyinfra.api.connections`  modules to being declared as `setuptools` `entrypoints`.
This will allow third party python modules to add connectors to pyinfra outside of pytnfra code base.