### PR TITLE
added --yes to pip uninstall to make the action not wait for user confirmation

### DIFF
--- a/pyinfra/operations/pip.py
+++ b/pyinfra/operations/pip.py
@@ -124,7 +124,7 @@ def packages(
         yield ensure_packages(
             packages, current_packages, present,
             install_command='{0} install'.format(pip),
-            uninstall_command='{0} uninstall'.format(pip),
+            uninstall_command='{0} uninstall --yes'.format(pip),
             upgrade_command='{0} install --upgrade'.format(pip),
             version_join='==',
             latest=latest,

--- a/tests/operations/pip.packages/remove_packages.json
+++ b/tests/operations/pip.packages/remove_packages.json
@@ -13,6 +13,6 @@
         }
     },
     "commands": [
-        "pip uninstall pyinfra test==1.1"
+        "pip uninstall --yes pyinfra test==1.1"
     ]
 }


### PR DESCRIPTION
Without the --yes uninstall option, the command will get stuck waiting for user confirmation.