### PR TITLE
allow server.modprobe module param to be a list

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -5,7 +5,10 @@ Linux/BSD.
 
 from __future__ import division, unicode_literals
 
-import itertools
+try:
+    from itertools import filterfalse, tee
+except ImportError:
+    from itertools import ifilterfalse as filterfalse, tee
 from os import path
 from time import sleep
 
@@ -211,14 +214,14 @@ def modprobe(module, present=True, force=False, state=None, host=None):
     '''
     list_value = (
         [module]
-        if isinstance(module, str)
+        if isinstance(module, six.string_types)
         else module
     )
 
     # NOTE: https://docs.python.org/3/library/itertools.html#itertools-recipes
     def partition(pred, iterable):
-        t1, t2 = itertools.tee(iterable)
-        return list(filter(pred, t2)), list(itertools.filterfalse(pred, t1))
+        t1, t2 = tee(iterable)
+        return list(filter(pred, t2)), list(filterfalse(pred, t1))
 
     modules = host.fact.kernel_modules
     present_mods, missing_mods = partition(lambda mod: mod in modules, list_value)

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -5,9 +5,9 @@ Linux/BSD.
 
 from __future__ import division, unicode_literals
 
+import itertools
 from os import path
 from time import sleep
-import itertools
 
 import six
 

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -7,6 +7,7 @@ from __future__ import division, unicode_literals
 
 from os import path
 from time import sleep
+import itertools
 
 import six
 
@@ -208,21 +209,31 @@ def modprobe(module, present=True, force=False, state=None, host=None):
             module='floppy',
         )
     '''
+    list_value = (
+        [module]
+        if isinstance(module, str)
+        else module
+    )
+
+    # NOTE: https://docs.python.org/3/library/itertools.html#itertools-recipes
+    def partition(pred, iterable):
+        t1, t2 = itertools.tee(iterable)
+        return list(filter(pred, t2)), list(itertools.filterfalse(pred, t1))
 
     modules = host.fact.kernel_modules
-    is_present = module in modules
+    present_mods, missing_mods = partition(lambda mod: mod in modules, list_value)
 
     args = ''
     if force:
         args = ' -f'
 
     # Module is loaded and we don't want it?
-    if not present and is_present:
-        yield 'modprobe{0} -r {1}'.format(args, module)
+    if not present and present_mods:
+        yield 'modprobe{0} -r -a {1}'.format(args, ' '.join(present_mods))
 
     # Module isn't loaded and we want it?
-    elif present and not is_present:
-        yield 'modprobe{0} {1}'.format(args, module)
+    elif present and missing_mods:
+        yield 'modprobe{0} -a {1}'.format(args, ' '.join(missing_mods))
 
 
 @operation

--- a/tests/operations/server.modprobe/add-list.json
+++ b/tests/operations/server.modprobe/add-list.json
@@ -1,0 +1,11 @@
+{
+    "args": [["mod1", "mod2", "mod3"]],
+    "facts": {
+        "kernel_modules": {
+            "mod2": {}
+        }
+    },
+    "commands": [
+        "modprobe -a mod1 mod3"
+    ]
+}

--- a/tests/operations/server.modprobe/add.json
+++ b/tests/operations/server.modprobe/add.json
@@ -4,6 +4,6 @@
         "kernel_modules": {}
     },
     "commands": [
-        "modprobe somemodule"
+        "modprobe -a somemodule"
     ]
 }

--- a/tests/operations/server.modprobe/add_force.json
+++ b/tests/operations/server.modprobe/add_force.json
@@ -7,6 +7,6 @@
         "kernel_modules": {}
     },
     "commands": [
-        "modprobe -f somemodule"
+        "modprobe -f -a somemodule"
     ]
 }

--- a/tests/operations/server.modprobe/remove-list.json
+++ b/tests/operations/server.modprobe/remove-list.json
@@ -1,14 +1,14 @@
 {
-    "args": ["somemodule"],
+    "args": [["mod1", "mod2", "mod3"]],
     "kwargs": {
         "present": false
     },
     "facts": {
         "kernel_modules": {
-            "somemodule": {}
+            "mod1": {}
         }
     },
     "commands": [
-        "modprobe -r -a somemodule"
+        "modprobe -r -a mod1"
     ]
 }


### PR DESCRIPTION
Allow `server.modprobe` operation module parameter to be a list of modules name too.