### PR TITLE
Run file download with wget cleanup in a subshell

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -107,7 +107,7 @@ def download(
     # If we download, always do user/group/mode as SSH user may be different
     if download:
         curl_command = 'curl -sSLf {0} -o {1}'.format(src, dest)
-        wget_command = 'wget -q {0} -O {1} || rm -f {1}; exit 1'.format(src, dest)
+        wget_command = 'wget -q {0} -O {1} || (rm -f {1}; exit 1)'.format(src, dest)
 
         if host.fact.which('curl'):
             yield curl_command

--- a/tests/operations/files.download/download_no_curl_no_wget.json
+++ b/tests/operations/files.download/download_no_curl_no_wget.json
@@ -15,7 +15,7 @@
         }
     },
     "commands": [
-        "(curl -sSLf http://myfile -o /home/myfile) || (wget -q http://myfile -O /home/myfile || rm -f /home/myfile; exit 1)",
+        "(curl -sSLf http://myfile -o /home/myfile) || (wget -q http://myfile -O /home/myfile || (rm -f /home/myfile; exit 1))",
         "chgrp mygroup /home/myfile",
         "chmod 777 /home/myfile"
     ]

--- a/tests/operations/files.download/download_wget.json
+++ b/tests/operations/files.download/download_wget.json
@@ -15,7 +15,7 @@
         }
     },
     "commands": [
-        "wget -q http://myfile -O /home/myfile || rm -f /home/myfile; exit 1",
+        "wget -q http://myfile -O /home/myfile || (rm -f /home/myfile; exit 1)",
         "chgrp mygroup /home/myfile",
         "chmod 777 /home/myfile"
     ]


### PR DESCRIPTION
This fixes a bug where wget command always exits with 1.