### PR TITLE
Removing vim on Fedora Workstation doesn't work

### DIFF
--- a/tests/operations/dnf.packages/remove_packages.json
+++ b/tests/operations/dnf.packages/remove_packages.json
@@ -1,0 +1,20 @@
+{
+    "args": [[
+        "git",
+        "vim-enhanced",
+        "vim-common"
+    ]],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "rpm_packages": {
+            "git": ["2.26.2-1.fc32"],
+            "vim-enhanced": ["8.2.1081-1.fc32"],
+            "vim-common": ["8.2.1081-1.fc32"]
+        }
+    },
+    "commands": [
+        "dnf remove -y git vim-enhanced vim-common"
+    ]
+}

--- a/tests/operations/dnf.packages/remove_packages_with_alias.json
+++ b/tests/operations/dnf.packages/remove_packages_with_alias.json
@@ -1,0 +1,19 @@
+{
+    "args": [[
+        "git",
+        "vim"
+    ]],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "rpm_packages": {
+            "git": ["2.26.2-1.fc32"],
+            "vim-enhanced": ["8.2.1081-1.fc32"],
+            "vim-common": ["8.2.1081-1.fc32"]
+        }
+    },
+    "commands": [
+        "dnf remove -y git vim"
+    ]
+}


### PR DESCRIPTION
So there is no package called **vim**, but there are **vim-enhanced** and **vim-common**. The problem is when trying to remove the vim package this does not work.

This is the code that I am trying to run on my Fedora 32 Workstation:

```python
from pyinfra import host
from pyinfra.operations import dnf, server

dnf.packages(
    packages=["vim"],
    present=False,
    sudo=True,
)
```
Output copied from the rpm_packages fact
[rpm_packages_fact_output.txt](https://github.com/Fizzadar/pyinfra/files/4929463/rpm_packages_fact_output.txt)

