### PR TITLE
use --queryformat parameter to get rpm package details

### DIFF
--- a/pyinfra/facts/rpm.py
+++ b/pyinfra/facts/rpm.py
@@ -6,7 +6,8 @@ from pyinfra.api import FactBase
 
 from .util.packaging import parse_packages
 
-rpm_regex = r'^([a-zA-Z0-9_\-\+]+)\-([0-9a-z\.\-]+)\.[a-z0-9_\.]+$'
+rpm_regex = r'^(\S+)\ (\S+)$'
+rpm_query_format = '%{NAME} %{VERSION}-%{RELEASE}\\n'
 
 
 class RPMPackages(FactBase):
@@ -19,7 +20,7 @@ class RPMPackages(FactBase):
         ...
     '''
 
-    command = 'rpm -qa'
+    command = 'rpm --queryformat "{0}" -qa'.format(rpm_query_format)
     default = dict
     use_default_on_error = True
 
@@ -46,7 +47,8 @@ class RpmPackage(FactBase):
     use_default_on_error = True
 
     def command(self, name):
-        return 'rpm -qp {0} 2> /dev/null || rpm -q {0}'.format(name)
+        return ('rpm --queryformat "{0}" -qp {1} 2> /dev/null || '
+                'rpm --queryformat "{0}" -q {1}'.format(rpm_query_format, name))
 
     def process(self, output):
         for line in output:

--- a/tests/facts/rpm_package/package.json
+++ b/tests/facts/rpm_package/package.json
@@ -1,11 +1,11 @@
 {
     "arg": "somepackage",
-    "command": "rpm -qp somepackage 2> /dev/null || rpm -q somepackage",
+    "command": "rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -qp somepackage 2> /dev/null || rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -q somepackage",
     "output": [
-        "pydash-3.48.0"
+        "pydash 3.48.0"
     ],
     "fact": {
         "name": "pydash",
-        "version": "3.48"
+        "version": "3.48.0"
     }
 }

--- a/tests/facts/rpm_packages/packages.json
+++ b/tests/facts/rpm_packages/packages.json
@@ -1,8 +1,8 @@
 {
     "output": [
-        "pydash-3.48.0"
+        "pydash 3.48.0"
     ],
     "fact": {
-        "pydash": ["3.48"]
+        "pydash": ["3.48.0"]
     }
 }


### PR DESCRIPTION
This PR changes the command that used to query the set of installed rpms by introducing `--queryformat` parameter.
I've run into a case where the regular expression was not good enough to match all the returned packages from `rpm -qa`. 

Steps to reproduce the issue:
```
$ cat Dockerfile
FROM centos:8
RUN yum install -y mariadb-server
$ docker build -t my-centos-image .
... (output remove for non relevance)
$ docker run -it --rm my-centos-image rpm -qa | grep mariadb-server
mariadb-server-utils-10.3.17-1.module_el8.1.0+257+48736ea6.x86_64
mariadb-server-10.3.17-1.module_el8.1.0+257+48736ea6.x86_64
$ pyinfra @docker/my-centos-image fact rpm_package:mariadb-server
--> Loading config...
--> Loading inventory...
    The @docker connector is in beta!

--> Connecting to hosts...
    [@docker/my-centos-image] Connected

--> Gathering facts...
    Loaded fact rpm_package: ('mariadb-server',)

--> Fact data for: rpm_package('mariadb-server',)
{
    "@docker/my-centos-image": null
}
    [@docker/my-centos-image] docker build complete, image ID: d4f1ea3be542
```