### PR TITLE
Adjust systemd unit name regex to documentation

### DIFF
--- a/pyinfra/facts/init.py
+++ b/pyinfra/facts/init.py
@@ -12,7 +12,7 @@ from pyinfra.api import FactBase
 # ".swap", ".target", ".path", ".timer", ".slice", or ".scope".
 # Units names can be parameterized by a single argument called the "instance name".
 # A template unit must have a single "@" at the end of the name (right before the type suffix).
-# The name of the full unit is formed by inserting the instance name 
+# The name of the full unit is formed by inserting the instance name
 # between "@" and the unit type suffix.
 SYSTEMD_UNIT_NAME_REGEX = (
     r'[a-zA-Z0-9\:\-\_\.\\\@]+\.'
@@ -80,8 +80,7 @@ class SystemdEnabled(FactBase):
     '''
 
     regex = r'^({systemd_unit_name_regex})\s+([a-z]+)'.format(
-        systemd_unit_name_regex=SYSTEMD_UNIT_NAME_REGEX
-    )
+        systemd_unit_name_regex=SYSTEMD_UNIT_NAME_REGEX)
     default = dict
     use_default_on_error = True
 

--- a/pyinfra/facts/init.py
+++ b/pyinfra/facts/init.py
@@ -12,9 +12,11 @@ from pyinfra.api import FactBase
 # ".swap", ".target", ".path", ".timer", ".slice", or ".scope".
 # Units names can be parameterized by a single argument called the "instance name".
 # A template unit must have a single "@" at the end of the name (right before the type suffix).
-# The name of the full unit is formed by inserting the instance name between "@" and the unit type suffix.
+# The name of the full unit is formed by inserting the instance name 
+# between "@" and the unit type suffix.
 SYSTEMD_UNIT_NAME_REGEX = (
-    r'[a-zA-Z0-9\:\-\_\.\\\@]+\.(?:service|socket|device|mount|automount|swap|target|path|timer|slice|scope)'
+    r'[a-zA-Z0-9\:\-\_\.\\\@]+\.'
+    r'(?:service|socket|device|mount|automount|swap|target|path|timer|slice|scope)'
 )
 
 
@@ -46,8 +48,7 @@ class SystemdStatus(FactBase):
 
     command = 'systemctl -al list-units'
     regex = r'^({systemd_unit_name_regex})\s+[a-z\-]+\s+[a-z]+\s+([a-z]+)'.format(
-        systemd_unit_name_regex=SYSTEMD_UNIT_NAME_REGEX
-    )
+        systemd_unit_name_regex=SYSTEMD_UNIT_NAME_REGEX)
     default = dict
     use_default_on_error = True
 


### PR DESCRIPTION
`systemd.init` fails for units containing dots in their name, e.g. `abc.def.service`, even though they match the systemd spec.
See https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Description for reference:
```
Valid unit names consist of a "name prefix" and a dot and a suffix specifying the unit type. The "unit prefix" must consist of one or more valid characters (ASCII letters, digits, ":", "-", "_", ".", and "\"). The total length of the unit name including the suffix must not exceed 256 characters. The type suffix must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".slice", or ".scope".

Units names can be parameterized by a single argument called the "instance name". The unit is then constructed based on a "template file" which serves as the definition of multiple services or other units. A template unit must have a single "@" at the end of the name (right before the type suffix). The name of the full unit is formed by inserting the instance name between "@" and the unit type suffix.
```

This PR makes pyinfra use a regex allowing all unit names described in the manual (and more, but we don't want to overcomplicate the regex).