### PR TITLE
Consider waiting units (timers) to be running

### DIFF
--- a/pyinfra/facts/init.py
+++ b/pyinfra/facts/init.py
@@ -41,7 +41,8 @@ class SystemdStatus(FactBase):
             line = line.strip()
             matches = re.match(self.regex, line)
             if matches:
-                services[matches.group(1)] = matches.group(2) == 'running'
+                services[matches.group(1)] = matches.group(2) == 'running' or\
+                                             matches.group(2) == 'waiting'
 
         return services
 

--- a/pyinfra/facts/init.py
+++ b/pyinfra/facts/init.py
@@ -41,8 +41,8 @@ class SystemdStatus(FactBase):
             line = line.strip()
             matches = re.match(self.regex, line)
             if matches:
-                services[matches.group(1)] = matches.group(2) == 'running' or\
-                                             matches.group(2) == 'waiting'
+                is_active = matches.group(2) == 'running' or matches.group(2) == 'waiting'
+                services[matches.group(1)] = is_active
 
         return services
 


### PR DESCRIPTION
Pyinfra explicitly checks for the `running` sub-state of a systemd unit.
E.g. for timers the sub-state equivalent is `waiting`.

This PR fixes PyInfra always starting timers (even though they are already waiting) if you specify `running=True` in the operation `init.systemd`.