### PR TITLE
Bump gevent version requirement to pass tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ using a package manager (apt, yum, etc), normally named: python-setuptools
 
 
 INSTALL_REQUIRES = (
-    'gevent>1',
+    'gevent>=1.5',
     'paramiko>=2.2,<3',  # 2.2 (2017) adds Ed25519Key
     'click>2',
     'colorama<1',  # Windows color support for click


### PR DESCRIPTION
Version 1.4.0 of the gevent library does not appear to pass the pyinfra tests.

Build log: https://pastebin.com/DhLH1Ana

This PR bumps the minimal requirements to 1.5.0 (the first release to [officially support](http://www.gevent.org/whatsnew_1_5.html) python 3.8).  