### PR TITLE
docs: Fix simple typo, envrionment -> environment

### DIFF
--- a/pyinfra/api/connectors/local.py
+++ b/pyinfra/api/connectors/local.py
@@ -51,7 +51,7 @@ def run_shell_command(
         command (string): actual command to execute
         sudo (boolean): whether to wrap the command with sudo
         sudo_user (string): user to sudo to
-        env (dict): envrionment variables to set
+        env (dict): environment variables to set
         timeout (int): timeout for this command to complete before erroring
 
     Returns:

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -243,7 +243,7 @@ def run_shell_command(
         sudo (boolean): whether to wrap the command with sudo
         sudo_user (string): user to sudo to
         get_pty (boolean): whether to get a PTY before executing the command
-        env (dict): envrionment variables to set
+        env (dict): environment variables to set
         timeout (int): timeout for this command to complete before erroring
 
     Returns:

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -141,7 +141,7 @@ def run_shell_command(
         TODO print_intput (boolean): print the input
         return_combined_output (boolean): combine the stdout and stderr lists
         shell_executable (string): shell to use - 'sh'=cmd, 'ps'=powershell(default)
-        env (dict): envrionment variables to set
+        env (dict): environment variables to set
 
     Returns:
         tuple: (exit_code, stdout, stderr)


### PR DESCRIPTION
There is a small typo in pyinfra/api/connectors/local.py, pyinfra/api/connectors/ssh.py, pyinfra/api/connectors/winrm.py.

Should read `environment` rather than `envrionment`.

