### PR TITLE
Add typing information for operation decorator

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
-include README.md LICENSE.md CHANGELOG.md
+include README.md LICENSE.md CHANGELOG.md pyinfra/py.typed
+global-include *.pyi

--- a/pyinfra/api/operation.pyi
+++ b/pyinfra/api/operation.pyi
@@ -1,0 +1,7 @@
+from typing import Any, Callable, TypeVar
+
+_TFunc = TypeVar("_TFunc", bound=Callable[..., Any])
+
+
+def operation(func: _TFunc = None, pipeline_facts=None, name: str = None) -> _TFunc:
+    ...

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,6 @@ if __name__ == '__main__':
             'ansible': ANSIBLE_REQUIRES,
         },
         include_package_data=True,
-        package_data={'pyinfra': ['py.typed', 'api/*.pyi']},
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ if __name__ == '__main__':
             'ansible': ANSIBLE_REQUIRES,
         },
         include_package_data=True,
+        package_data={'pyinfra': ['py.typed', 'api/*.pyi']},
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Environment :: Console',


### PR DESCRIPTION
This is a quick PR to simply add typing information for the `@operation` decorator. With this typing information added it allows pylance/pyright (and presumably mypy & pyre, though I haven't tested those) to properly check decorated operations. It does *not* check for global arguments (such as `name`), those require additional typing definitions to be added, that would be handled in a subsequent PR.

I have not done any testing beyond on my own system (python3.8 on macOS) so consider this a bit of an exploratory PR. Happy to add/change things as needed.