### PR TITLE
sed_replace: ensure string

### DIFF
--- a/pyinfra/operations/util/files.py
+++ b/pyinfra/operations/util/files.py
@@ -45,6 +45,7 @@ def sed_replace(
     flags = ''.join(flags) if flags else ''
 
     line = line.replace('/', r'\/')
+    replace = str(replace)
     replace = replace.replace('/', r'\/')
     backup_extension = get_timestamp()
 


### PR DESCRIPTION
Don't fail if the user wants to replace a match by a number.

Otherwise, we can get:

```
pyinfra/operations/util/files.py", line 48, in sed_replace
    replace = replace.replace('/', r'\/')
AttributeError: 'int' object has no attribute 'replace'
```

Without this, the user first sees this error, and then must understand to not give a number to `replace` (maybe before searching such error on GitHub issues).

This commit makes pyinfra a tad more user friendly.