### PR TITLE
Set lower=False on `pacman.packages` operation

### DIFF
--- a/pyinfra/operations/pacman.py
+++ b/pyinfra/operations/pacman.py
@@ -67,4 +67,5 @@ def packages(
         host, packages, host.fact.pacman_packages, present,
         install_command='pacman --noconfirm -S',
         uninstall_command='pacman --noconfirm -R',
+        lower=False,
     )


### PR DESCRIPTION
`pacman` capitals on package names, and they are significant see for example `hunspell-en_US` https://www.archlinux.org/packages/extra/any/hunspell-en_US/. Currently that packages fails to install since it will search for `hunspell-en_us` instead.