### PR TITLE
rework of git.worktree + new git.tracking_branch fact

### DIFF
--- a/pyinfra/facts/git.py
+++ b/pyinfra/facts/git.py
@@ -41,14 +41,14 @@ class GitTrackingBranch(FactBase):
 
     @staticmethod
     def command(repo):
-        return r'cd {0} && git status -sb'.format(repo)
+        return r'cd {0} && git status --branch --porcelain'.format(repo)
 
     @staticmethod
     def process(output):
         if not output:
             return None
 
-        m = re.search('\\.{3}(\\S+)\\b', output[0])
+        m = re.search(r'\.{3}(\S+)\b', output[0])
         if m:
             return m.group(1)
         return None

--- a/pyinfra/facts/git.py
+++ b/pyinfra/facts/git.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import re
+
 from pyinfra.api.facts import FactBase
 
 
@@ -32,3 +34,21 @@ class GitConfig(FactBase):
             items[key] = value
 
         return items
+
+
+class GitTrackingBranch(FactBase):
+    requires_command = 'git'
+
+    @staticmethod
+    def command(repo):
+        return r'cd {0} && git status -sb'.format(repo)
+
+    @staticmethod
+    def process(output):
+        if not output:
+            return None
+
+        m = re.search('\\.{3}(\\S+)\\b', output[0])
+        if m:
+            return m.group(1)
+        return None

--- a/tests/facts/git_tracking_branch/branch.json
+++ b/tests/facts/git_tracking_branch/branch.json
@@ -1,0 +1,8 @@
+{
+    "arg": "myrepo",
+    "command": "cd myrepo && git status -sb",
+    "output": [
+        "## branch1...origin/master"
+    ],
+    "fact": "origin/master"
+}

--- a/tests/facts/git_tracking_branch/branch.json
+++ b/tests/facts/git_tracking_branch/branch.json
@@ -1,6 +1,6 @@
 {
     "arg": "myrepo",
-    "command": "cd myrepo && git status -sb",
+    "command": "cd myrepo && git status --branch --porcelain",
     "output": [
         "## branch1...origin/master"
     ],

--- a/tests/facts/git_tracking_branch/branch_behind.json
+++ b/tests/facts/git_tracking_branch/branch_behind.json
@@ -1,0 +1,8 @@
+{
+    "arg": "myrepo",
+    "command": "cd myrepo && git status -sb",
+    "output": [
+        "## branch1...origin/master [behind 692]"
+    ],
+    "fact": "origin/master"
+}

--- a/tests/facts/git_tracking_branch/branch_behind.json
+++ b/tests/facts/git_tracking_branch/branch_behind.json
@@ -1,6 +1,6 @@
 {
     "arg": "myrepo",
-    "command": "cd myrepo && git status -sb",
+    "command": "cd myrepo && git status --branch --porcelain",
     "output": [
         "## branch1...origin/master [behind 692]"
     ],

--- a/tests/facts/git_tracking_branch/no_branch.json
+++ b/tests/facts/git_tracking_branch/no_branch.json
@@ -1,6 +1,6 @@
 {
     "arg": "myrepo",
-    "command": "cd myrepo && git status -sb",
+    "command": "cd myrepo && git status --branch --porcelain",
     "output": [
         "## branch1"
     ],

--- a/tests/facts/git_tracking_branch/no_branch.json
+++ b/tests/facts/git_tracking_branch/no_branch.json
@@ -1,0 +1,8 @@
+{
+    "arg": "myrepo",
+    "command": "cd myrepo && git status -sb",
+    "output": [
+        "## branch1"
+    ],
+    "fact": null
+}

--- a/tests/operations/git.worktree/create_detached.json
+++ b/tests/operations/git.worktree/create_detached.json
@@ -14,6 +14,6 @@
         }
     },
     "commands": [
-        "cd /home/mainrepo && git worktree add /home/myworktree --detach"
+        "cd /home/mainrepo && git worktree add --detach /home/myworktree"
     ]
 }

--- a/tests/operations/git.worktree/create_detached_from_commitish.json
+++ b/tests/operations/git.worktree/create_detached_from_commitish.json
@@ -2,7 +2,8 @@
     "args": ["/home/myworktree"],
     "kwargs": {
         "repo": "/home/mainrepo",
-        "new_branch": "mybranch"
+        "detached": true,
+        "commitish": "70e8906a14"
     },
     "facts": {
         "directory": {
@@ -14,6 +15,6 @@
         }
     },
     "commands": [
-        "cd /home/mainrepo && git worktree add -b mybranch /home/myworktree"
+        "cd /home/mainrepo && git worktree add --detach /home/myworktree 70e8906a14"
     ]
 }

--- a/tests/operations/git.worktree/create_existing_branch.json
+++ b/tests/operations/git.worktree/create_existing_branch.json
@@ -2,7 +2,7 @@
     "args": ["/home/myworktree"],
     "kwargs": {
         "repo": "/home/mainrepo",
-        "branch": "mybranch"
+        "commitish": "mybranch"
     },
     "facts": {
         "directory": {

--- a/tests/operations/git.worktree/create_from_commitish.json
+++ b/tests/operations/git.worktree/create_from_commitish.json
@@ -2,7 +2,7 @@
     "args": ["/home/myworktree"],
     "kwargs": {
         "repo": "/home/mainrepo",
-        "new_branch": "mybranch"
+        "commitish": "70e8906a14"
     },
     "facts": {
         "directory": {
@@ -14,6 +14,6 @@
         }
     },
     "commands": [
-        "cd /home/mainrepo && git worktree add -b mybranch /home/myworktree"
+        "cd /home/mainrepo && git worktree add /home/myworktree 70e8906a14"
     ]
 }

--- a/tests/operations/git.worktree/create_new_branch_from_commitish.json
+++ b/tests/operations/git.worktree/create_new_branch_from_commitish.json
@@ -2,7 +2,8 @@
     "args": ["/home/myworktree"],
     "kwargs": {
         "repo": "/home/mainrepo",
-        "new_branch": "mybranch"
+        "new_branch": "mybranch",
+        "commitish": "origin/mybranch"
     },
     "facts": {
         "directory": {
@@ -14,6 +15,6 @@
         }
     },
     "commands": [
-        "cd /home/mainrepo && git worktree add -b mybranch /home/myworktree"
+        "cd /home/mainrepo && git worktree add -b mybranch /home/myworktree origin/mybranch"
     ]
 }

--- a/tests/operations/git.worktree/deprecated_existing_branch.json
+++ b/tests/operations/git.worktree/deprecated_existing_branch.json
@@ -2,7 +2,7 @@
     "args": ["/home/myworktree"],
     "kwargs": {
         "repo": "/home/mainrepo",
-        "new_branch": "mybranch"
+        "branch": "mybranch"
     },
     "facts": {
         "directory": {
@@ -14,6 +14,6 @@
         }
     },
     "commands": [
-        "cd /home/mainrepo && git worktree add -b mybranch /home/myworktree"
+        "cd /home/mainrepo && git worktree add /home/myworktree mybranch"
     ]
 }

--- a/tests/operations/git.worktree/deprecated_existing_branch_conflict.json
+++ b/tests/operations/git.worktree/deprecated_existing_branch_conflict.json
@@ -2,7 +2,8 @@
     "args": ["/home/myworktree"],
     "kwargs": {
         "repo": "/home/mainrepo",
-        "new_branch": "mybranch"
+        "branch": "mybranch",
+        "commitish": "0123456789"
     },
     "facts": {
         "directory": {
@@ -13,7 +14,8 @@
             "/home/myworktree": null
         }
     },
-    "commands": [
-        "cd /home/mainrepo && git worktree add -b mybranch /home/myworktree"
-    ]
+    "exception": {
+        "name": "OperationError",
+        "message": "The deprecated arguments `branch` and `create_branch` are not compatible with the new `commitish` argument. Please use the new `commitish` argument only."
+    }
 }

--- a/tests/operations/git.worktree/deprecated_new_branch.json
+++ b/tests/operations/git.worktree/deprecated_new_branch.json
@@ -2,7 +2,8 @@
     "args": ["/home/myworktree"],
     "kwargs": {
         "repo": "/home/mainrepo",
-        "new_branch": "mybranch"
+        "branch": "mybranch",
+        "create_branch": true
     },
     "facts": {
         "directory": {

--- a/tests/operations/git.worktree/deprecated_new_branch_conflict.json
+++ b/tests/operations/git.worktree/deprecated_new_branch_conflict.json
@@ -1,0 +1,22 @@
+{
+    "args": ["/home/myworktree"],
+    "kwargs": {
+        "repo": "/home/mainrepo",
+        "new_branch": "mybranch",
+        "create_branch": true,
+        "branch": "anewbranch"
+    },
+    "facts": {
+        "directory": {
+            "/home/mainrepo": {},
+            "/home/mainrepo/.git": {
+                "mode": 0
+            },
+            "/home/myworktree": null
+        }
+    },
+    "exception": {
+        "name": "OperationError",
+        "message": "The deprecated arguments `branch` and `create_branch` are not compatible with the new `branch` argument. Please use the new `branch` argument only."
+    }
+}

--- a/tests/operations/git.worktree/pull.json
+++ b/tests/operations/git.worktree/pull.json
@@ -1,0 +1,16 @@
+{
+    "args": ["/home/myworktree"],
+    "facts": {
+        "directory": {
+            "/home/myworktree": {
+                "mode": 0
+            }
+        },
+        "git_tracking_branch" : {
+            "/home/myworktree": "origin/master"
+        }
+    },
+    "commands": [
+        "cd /home/myworktree && git pull"
+    ]
+}

--- a/tests/operations/git.worktree/pull_from_bad_remote_branch.json
+++ b/tests/operations/git.worktree/pull_from_bad_remote_branch.json
@@ -1,0 +1,20 @@
+{
+    "args": ["/home/myworktree"],
+    "kwargs": {
+        "from_remote_branch": ["origin"]
+    },
+    "facts": {
+        "directory": {
+            "/home/myworktree": {
+                "mode": 0
+            }
+        },
+        "git_tracking_branch" : {
+            "/home/myworktree": null
+        }
+    },
+    "exception": {
+        "name": "OperationError",
+        "message": "The remote branch must be a 2-tuple (remote, branch) such as (\"origin\", \"master\")"
+    }
+}

--- a/tests/operations/git.worktree/pull_from_remote_branch.json
+++ b/tests/operations/git.worktree/pull_from_remote_branch.json
@@ -1,0 +1,19 @@
+{
+    "args": ["/home/myworktree"],
+    "kwargs": {
+        "from_remote_branch": ["origin", "master"]
+    },
+    "facts": {
+        "directory": {
+            "/home/myworktree": {
+                "mode": 0
+            }
+        },
+        "git_tracking_branch" : {
+            "/home/myworktree": null
+        }
+    },
+    "commands": [
+        "cd /home/myworktree && git pull origin master"
+    ]
+}

--- a/tests/operations/git.worktree/pull_rebase from_remote_branch.json
+++ b/tests/operations/git.worktree/pull_rebase from_remote_branch.json
@@ -1,0 +1,20 @@
+{
+    "args": ["/home/myworktree"],
+    "kwargs": {
+        "rebase": true,
+        "from_remote_branch": ["origin", "master"]
+    },
+    "facts": {
+        "directory": {
+            "/home/myworktree": {
+                "mode": 0
+            }
+        },
+        "git_tracking_branch" : {
+            "/home/myworktree": null
+        }
+    },
+    "commands": [
+        "cd /home/myworktree && git pull --rebase origin master"
+    ]
+}

--- a/tests/operations/git.worktree/pull_rebase.json
+++ b/tests/operations/git.worktree/pull_rebase.json
@@ -1,0 +1,19 @@
+{
+    "args": ["/home/myworktree"],
+    "kwargs": {
+        "rebase": true
+    },
+    "facts": {
+        "directory": {
+            "/home/myworktree": {
+                "mode": 0
+            }
+        },
+        "git_tracking_branch" : {
+            "/home/myworktree": "origin/master"
+        }
+    },
+    "commands": [
+        "cd /home/myworktree && git pull --rebase"
+    ]
+}


### PR DESCRIPTION
I have splitted this PR in 2 commits:
1) add a new `git.tracking_branch` fact to get the actual tracking branch configured on the repo/worktree.
2) reworking of `git.worktree` as the previous interface was not fully compatible with the `git worktree add`
operation. Now, it is and if the worktree exists, a `git pull` is done.

(See commit messages for more details). 