### PR TITLE
Unpack pacman package groups into a list of packages.

### DIFF
--- a/pyinfra/facts/pacman.py
+++ b/pyinfra/facts/pacman.py
@@ -5,6 +5,30 @@ from .util.packaging import parse_packages
 PACMAN_REGEX = r'^([a-zA-Z\-]+)\s([0-9\._+a-z\-]+)'
 
 
+class PacmanUnpackGroups(FactBase):
+    '''
+    Gets a list of packages/groups and returns the
+    packages and the groups unpacked into packages:
+
+    .. code:: python
+
+        [
+            'package_name',
+        [
+    '''
+
+    requires_command = 'pacman'
+
+    default = list
+
+    def command(self, pkg_list):
+        pkg_str = ' '.join(pkg_list)
+        return 'pacman -S --print-format "%n" {0}'.format(pkg_str)
+
+    def process(self, output):
+        return output
+
+
 class PacmanPackages(FactBase):
     '''
     Returns a dict of installed pacman packages:

--- a/pyinfra/operations/pacman.py
+++ b/pyinfra/operations/pacman.py
@@ -63,6 +63,9 @@ def packages(
     if upgrade:
         yield _upgrade(state=state, host=host)
 
+    if packages:
+        packages = host.fact.pacman_unpack_groups(packages)
+
     yield ensure_packages(
         host, packages, host.fact.pacman_packages, present,
         install_command='pacman --noconfirm -S',

--- a/tests/operations/pacman.packages/add_packages.json
+++ b/tests/operations/pacman.packages/add_packages.json
@@ -1,9 +1,16 @@
 {
-    "args": ["curl"],
+    "args": [["curl", "xorg-fonts"]],
     "facts": {
+        "pacman_unpack_groups": {
+            "curl": "curl",
+            "xorg-fonts": [
+                "xorg-font-util",
+                "xorg-fonts-encodings"
+            ]
+        },
         "pacman_packages": {}
     },
     "commands": [
-        "pacman --noconfirm -S curl"
+        "pacman --noconfirm -S curl xorg-font-util xorg-fonts-encodings"
     ]
 }

--- a/tests/operations/pacman.packages/add_packages.json
+++ b/tests/operations/pacman.packages/add_packages.json
@@ -2,8 +2,8 @@
     "args": [["curl", "xorg-fonts"]],
     "facts": {
         "pacman_unpack_groups": {
-            "curl": "curl",
-            "xorg-fonts": [
+            "['curl', 'xorg-fonts']": [
+                "curl",
                 "xorg-font-util",
                 "xorg-fonts-encodings"
             ]

--- a/tests/operations/pacman.packages/remove_packages.json
+++ b/tests/operations/pacman.packages/remove_packages.json
@@ -4,6 +4,10 @@
         "present": false
     },
     "facts": {
+        "pacman_unpack_groups": {
+            "curl": "curl",
+            "i-dont-exist": ""
+        },
         "pacman_packages": {
             "curl": "1"
         }

--- a/tests/operations/pacman.packages/remove_packages.json
+++ b/tests/operations/pacman.packages/remove_packages.json
@@ -5,8 +5,7 @@
     },
     "facts": {
         "pacman_unpack_groups": {
-            "curl": "curl",
-            "i-dont-exist": ""
+            "['curl', 'i-dont-exist']": ["curl"]
         },
         "pacman_packages": {
             "curl": "1"

--- a/tests/operations/pacman.packages/upgrade_update.json
+++ b/tests/operations/pacman.packages/upgrade_update.json
@@ -5,6 +5,9 @@
         "upgrade": true
     },
     "facts": {
+        "pacman_unpack_groups": {
+            "curl": "curl"
+        },
         "pacman_packages": {
             "curl": ["1"]
         }


### PR DESCRIPTION
Arch linux [package groups](https://wiki.archlinux.org/index.php/Meta_package_and_package_group) are not real packages and because of that are not displayed by 'pacman -Q' as installed. This causes pyinfra to reinstall them every time.

To fix that this PR expands groups into the corresponding packages before calling `ensure_packages`.
