### PR TITLE
Tentative bugfix to have consistent results in host.fact.deb_package

### DIFF
--- a/pyinfra/facts/deb.py
+++ b/pyinfra/facts/deb.py
@@ -44,7 +44,7 @@ class DebPackage(FactBase):
     requires_command = 'dpkg'
 
     def command(self, name):
-        return '! test -e {0} || (dpkg -I {0} 2> /dev/null || dpkg -s {0})'.format(name)
+        return '! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}'.format(name)
 
     def process(self, output):
         data = {}

--- a/tests/facts/deb_package/package.json
+++ b/tests/facts/deb_package/package.json
@@ -1,6 +1,6 @@
 {
     "arg": "package-name",
-    "command": "! test -e package-name || (dpkg -I package-name 2> /dev/null || dpkg -s package-name)",
+    "command": "! test -e package-name && (dpkg -s package-name 2>/dev/null || true) || dpkg -I package-name",
     "output": [
         "Package: package-name",
         "Version: 1"


### PR DESCRIPTION
I've noticed that facts were empty when querying for a specific package in `deb_package` but actual results were returned by `deb_packages`. Based on the documentation https://docs.pyinfra.com/en/1.x/facts/deb.html deb_package:  

> Returns information on a .deb archive or installed package.  

I came up with the following quick test to validate what was going on:  
```
from pyinfra.api import deploy
import click

@deploy("test_deb_fact")
def test_deb_fact(state=None, host=None):
    entries = [
        'acl',
        'foobar-package',
        '/tmp/exists.deb',
        '/tmp/does-not-exist.deb'
    ]

    for e in entries:
        click.echo(f"deb_packages.get({e}): {host.fact.deb_packages.get(e)}", err=True)
        click.echo(f"deb_package({e}): {host.fact.deb_package(e)}", err=True)

test_deb_fact()
```

Running on branch master / version 1.3.2: 

```
deb_packages.get(acl): {'2.2.53-6'}
deb_package(acl): **None** # <-- this is the unexpected info based on 
deb_packages.get(foobar-package): None
deb_package(foobar-package): None
deb_packages.get(/tmp/exists.deb): None
deb_package(/tmp/exists.deb): {'name': 'code', 'version': '1.52.1-1608136922'}
deb_packages.get(/tmp/does-not-exist.deb): None
deb_package(/tmp/does-not-exist.deb): None
```

On this branch: 
```
deb_packages.get(acl): {'2.2.53-6'}
deb_package(acl): {'name': 'acl', 'version': '2.2.53-6'}
deb_packages.get(foobar-package): None
deb_package(foobar-package): None
deb_packages.get(/tmp/exists.deb): None
deb_package(/tmp/exists.deb): {'name': 'code', 'version': '1.52.1-1608136922'}
deb_packages.get(/tmp/does-not-exist.deb): None
deb_package(/tmp/does-not-exist.deb): None
```
I made changes to the associated `package.json` file and ran the tests locally, but better double check the test do what they should as this is fairly new to me. 

Cheers! 


