### PR TITLE
Fixed apk uninstall command

### DIFF
--- a/pyinfra/operations/apk.py
+++ b/pyinfra/operations/apk.py
@@ -75,7 +75,7 @@ def packages(
     yield ensure_packages(
         host, packages, host.fact.apk_packages, present,
         install_command='apk add',
-        uninstall_command='apk remove',
+        uninstall_command='apk del',
         upgrade_command='apk upgrade',
         version_join='=',
         latest=latest,

--- a/tests/operations/apk.packages/remove_packages.json
+++ b/tests/operations/apk.packages/remove_packages.json
@@ -9,6 +9,6 @@
         }
     },
     "commands": [
-        "apk remove curl"
+        "apk del curl"
     ]
 }


### PR DESCRIPTION
APK uses "apk del" instead of "apk remove" to uninstall packages. I fixed it.