### PR TITLE
operation.server.user: allow adding a user with duplicate UID

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -682,6 +682,7 @@ def user(
     present=True, home=None, shell=None, group=None, groups=None,
     public_keys=None, delete_keys=False, ensure_home=True,
     system=False, uid=None, comment=None, add_deploy_dir=True,
+    unique=True,
     state=None, host=None,
 ):
     '''
@@ -699,6 +700,7 @@ def user(
     + system: whether to create a system account
     + comment: the user GECOS comment
     + add_deploy_dir: any public_key filenames are relative to the deploy directory
+    + unique: prevent creating users with duplicate UID
 
     Home directory:
         When ``ensure_home`` or ``public_keys`` are provided, ``home`` defaults to
@@ -774,6 +776,9 @@ def user(
 
         if comment:
             args.append("-c '{0}'".format(comment))
+
+        if not unique:
+            args.append('-o')
 
         # Users are often added by other operations (package installs), so check
         # for the user at runtime before adding.


### PR DESCRIPTION
Sometimes, one would like to add a user with a duplicate UID. This change would allow this functionality, yet maintain backward compatibility.

I didn't see if and where `operation.server.user` is being properly tested, thus I haven't added a test case for this one.