### PR TITLE
Adding Debian to the list of prettified names in LinuxDistribution

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -505,6 +505,7 @@ class LinuxDistribution(FactBase):
         'opensuse': 'openSUSE',
         'rhel': 'RedHat',
         'ubuntu': 'Ubuntu',
+        'debian': 'Debian',
     }
 
     @staticmethod


### PR DESCRIPTION
The LinuxDistribution fact didn't have an entry for Debian in the mapping of `name_to_pretty_name` meaning that the `name` attribute of the returned map requires additional parsing by the end user if running on Debian. This adds that mapping.