### PR TITLE
fix _log_operation_start to work with non-string operation arguments

### DIFF
--- a/pyinfra/api/operations.py
+++ b/pyinfra/api/operations.py
@@ -213,7 +213,7 @@ def _log_operation_start(op_meta):
 
     args = ''
     if op_meta['args']:
-        args = '({0})'.format(', '.join(arg for arg in op_meta['args']))
+        args = '({0})'.format(', '.join(str(arg) for arg in op_meta['args']))
 
     logger.info('{0} {1} {2}'.format(
         click.style('--> Starting{0}operation:'.format(


### PR DESCRIPTION
Fix for #550 - crash logging an operation with a non-string parameter.