### PR TITLE
Add support for additional winrm transport types and options

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -154,6 +154,8 @@ pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant -
 pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant --winrm-port 5985 exec -- write-host hello
 # Run a command using the command prompt:
 pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant --winrm-port 5985 --shell-executable cmd exec -- date /T
+# Run a command using the winrm ntlm transport
+pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant --winrm-port 5985 --winrm-transport ntlm exec -- hostname
 ```
 
 **Available Data**:
@@ -162,4 +164,5 @@ pyinfra @winrm/192.168.3.232 --winrm-username vagrant --winrm-password vagrant -
 winrm_port = 22
 winrm_user = 'ubuntu'
 winrm_password = 'password for user'
+winrm_transport = 'ntlm'
 ```

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -94,7 +94,7 @@ def connect(state, host):
             '{0}={1}'.format(key, value)
             for key, value in auth_kwargs.items()
         )
-        logger.debug("%s", e)
+        logger.debug('%s', e)
         _raise_connect_error(host, 'Authentication error', auth_args)
 
 

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -29,14 +29,12 @@ def _make_winrm_kwargs(state, host):
         ('username', host.data.winrm_user),
         ('password', host.data.winrm_password),
         ('winrm_port', int(host.data.winrm_port or 0)),
-        ('timeout', state.config.CONNECT_TIMEOUT),
+        ('winrm_transport', host.data.winrm_transport or 'plaintext'),
+        ('winrm_read_timeout_sec', host.data.winrm_read_timeout_sec or 30),
+        ('winrm_operation_timeout_sec', host.data.winrm_operation_timeout_sec or 20),
     ):
         if value:
             kwargs[key] = value
-
-    # Password auth (boo!)
-    if host.data.winrm_password:
-        kwargs['password'] = host.data.winrm_password
 
     # FUTURE: add more auth
     # pywinrm supports: basic, certificate, ntlm, kerberos, plaintext, ssl, credssp
@@ -58,7 +56,7 @@ def connect(state, host):
     '''
 
     kwargs = _make_winrm_kwargs(state, host)
-    logger.debug('Connecting to: {0} ({1})'.format(host.name, kwargs))
+    logger.debug('Connecting to: %s (%s)', host.name, kwargs)
 
     # Hostname can be provided via winrm config (alias), data, or the hosts name
     hostname = kwargs.pop(
@@ -66,21 +64,20 @@ def connect(state, host):
         host.data.winrm_hostname or host.name,
     )
 
-    logger.debug('winrm_username:{} winrm_password:{} '
-                 'winrm_port:{}'.format(host.data.winrm_username, host.data.winrm_password,
-                                        host.data.winrm_port))
-
     try:
         # Create new session
         host_and_port = '{}:{}'.format(hostname, host.data.winrm_port)
-        logger.debug('host_and_port: {}'.format(host_and_port))
+        logger.debug('host_and_port: %s', host_and_port)
 
         session = winrm.Session(
             host_and_port,
             auth=(
-                host.data.winrm_username,
-                host.data.winrm_password,
+                kwargs['username'],
+                kwargs['password'],
             ),
+            transport=kwargs['winrm_transport'],
+            read_timeout_sec=kwargs['winrm_read_timeout_sec'],
+            operation_timeout_sec=kwargs['winrm_operation_timeout_sec'],
         )
 
         return session
@@ -92,13 +89,12 @@ def connect(state, host):
         for key, value in kwargs.items():
             if key in ('username', 'password'):
                 auth_kwargs[key] = value
-                continue
 
         auth_args = ', '.join(
             '{0}={1}'.format(key, value)
             for key, value in auth_kwargs.items()
         )
-        logger.debug(str(e))
+        logger.debug("%s", e)
         _raise_connect_error(host, 'Authentication error', auth_args)
 
 
@@ -133,7 +129,7 @@ def run_shell_command(
 
     command = make_win_command(command, env=env)
 
-    logger.debug('Running command on {0}: {1}'.format(host.name, command))
+    logger.debug('Running command on %s: %s', host.name, command)
 
     if print_input:
         click.echo('{0}>>> {1}'.format(host.print_prefix, command), err=True)
@@ -149,7 +145,7 @@ def run_shell_command(
 
     if not shell_executable:
         shell_executable = 'ps'
-    logger.debug('shell_executable:{0}'.format(shell_executable))
+    logger.debug('shell_executable:%s', shell_executable)
 
     # default windows to use ps, but allow it to be overridden
     if shell_executable in ['cmd']:
@@ -158,7 +154,7 @@ def run_shell_command(
         response = host.connection.run_ps(tmp_command)
 
     return_code = response.status_code
-    logger.debug('response:{}'.format(response))
+    logger.debug('response:%s', response)
 
     std_out_str = response.std_out.decode('utf-8')
     std_err_str = response.std_err.decode('utf-8')
@@ -167,8 +163,8 @@ def run_shell_command(
     std_out = std_out_str.split('\r\n')
     std_err = std_err_str.split('\r\n')
 
-    logger.debug('std_out:{}'.format(std_out))
-    logger.debug('std_err:{}'.format(std_err))
+    logger.debug('std_out:%s', std_out)
+    logger.debug('std_err:%s', std_err)
 
     if print_output:
         click.echo(
@@ -181,7 +177,7 @@ def run_shell_command(
     else:
         status = return_code == 0
 
-    logger.debug('Command exit status: {0}'.format(status))
+    logger.debug('Command exit status: %s', status)
 
     if return_combined_output:
         std_out = [('stdout', line) for line in std_out]

--- a/pyinfra/api/inventory.py
+++ b/pyinfra/api/inventory.py
@@ -36,6 +36,7 @@ class Inventory(object):
         winrm_username: override WINRM username
         winrm_password: override WINRM pasword
         winrm_port: override WINRM port
+        winrm_transport: override WINRM transport
         **groups: map of group names -> ``(names, data)``
     '''
 
@@ -46,7 +47,7 @@ class Inventory(object):
         ssh_user=None, ssh_port=None, ssh_key=None,
         ssh_key_password=None, ssh_password=None,
         winrm_username=None, winrm_password=None,
-        winrm_port=None,
+        winrm_port=None, winrm_transport=None,
         **groups
     ):
         # Setup basics
@@ -64,6 +65,7 @@ class Inventory(object):
             'winrm_username': winrm_username,
             'winrm_password': winrm_password,
             'winrm_port': winrm_port,
+            'winrm_transport': winrm_transport,
         }
         # Strip None values
         override_data = {

--- a/pyinfra_cli/inventory.py
+++ b/pyinfra_cli/inventory.py
@@ -88,6 +88,7 @@ def make_inventory(
     winrm_username=None,
     winrm_password=None,
     winrm_port=None,
+    winrm_transport=None,
 ):
     '''
     Builds a ``pyinfra.api.Inventory`` from the filesystem. If the file does not exist
@@ -188,5 +189,6 @@ def make_inventory(
         winrm_username=winrm_username,
         winrm_password=winrm_password,
         winrm_port=winrm_port,
+        winrm_transport=winrm_transport,
         **groups
     ), file_groupname and file_groupname.lower()

--- a/pyinfra_cli/main.py
+++ b/pyinfra_cli/main.py
@@ -139,6 +139,7 @@ def _print_support(ctx, param, value):
 @click.option('--winrm-username', help='WINRM user to connect as.')
 @click.option('--winrm-password', help='WINRM password.')
 @click.option('--winrm-port', help='WINRM port to connect to.')
+@click.option('--winrm-transport', help='WINRM transport for use.')
 # Eager commands (pyinfra [--facts | --operations | --support | --version])
 @click.option(
     '--facts', is_flag=True, is_eager=True, callback=_print_facts,
@@ -246,7 +247,7 @@ def _main(
     inventory, operations, verbosity,
     user, port, key, key_password, password,
     winrm_username, winrm_password, winrm_port,
-    shell_executable,
+    winrm_transport, shell_executable,
     sudo, sudo_user, use_sudo_password, su_user,
     parallel, fail_percent,
     dry, limit, no_wait, serial, quiet,
@@ -444,6 +445,7 @@ def _main(
         winrm_username=winrm_username,
         winrm_password=winrm_password,
         winrm_port=winrm_port,
+        winrm_transport=winrm_transport,
     )
 
     # Attach to pseudo inventory

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -278,7 +278,7 @@ class TestDirectMainExecution(PatchSSHTestCase):
                 verbosity=0, user=None, port=None, key=None, key_password=None,
                 password=None, sudo=False, sudo_user=None, use_sudo_password=False, su_user=None,
                 parallel=None, fail_percent=0, dry=False, limit=None, no_wait=False, serial=False,
-                winrm_username=None, winrm_password=None, winrm_port=None,
+                winrm_username=None, winrm_password=None, winrm_port=None, winrm_transport=None,
                 shell_executable=None, quiet=False,
                 debug=False, debug_data=False, debug_facts=False, debug_operations=False,
             )


### PR DESCRIPTION
Some additional winrm option support, mainly transport usage and timeouts (only transport on the cli though).  More to do here but this is a start.