### PR TITLE
Escape PostgresSQL ROLE and DATABASE

### DIFF
--- a/pyinfra/operations/postgresql.py
+++ b/pyinfra/operations/postgresql.py
@@ -101,7 +101,7 @@ def role(
     if not present:
         if is_present:
             yield make_execute_psql_command(
-                'DROP ROLE {0}'.format(role),
+                'DROP ROLE "{0}"'.format(role),
                 user=postgresql_user,
                 password=postgresql_password,
                 host=postgresql_host,
@@ -113,7 +113,7 @@ def role(
 
     # If we want the user and they don't exist
     if not is_present:
-        sql_bits = ['CREATE ROLE {0}'.format(role)]
+        sql_bits = ['CREATE ROLE "{0}"'.format(role)]
 
         for key, value in (
             ('LOGIN', login),
@@ -198,7 +198,7 @@ def database(
     if not present:
         if is_present:
             yield make_execute_psql_command(
-                'DROP DATABASE {0}'.format(database),
+                'DROP DATABASE "{0}"'.format(database),
                 user=postgresql_user,
                 password=postgresql_password,
                 host=postgresql_host,
@@ -210,10 +210,10 @@ def database(
 
     # We want the database but it doesn't exist
     if present and not is_present:
-        sql_bits = ['CREATE DATABASE {0}'.format(database)]
+        sql_bits = ['CREATE DATABASE "{0}"'.format(database)]
 
         for key, value in (
-            ('OWNER', owner),
+            ('OWNER', '"{0}"'.format(owner) if owner else owner),
             ('TEMPLATE', template),
             ('ENCODING', encoding),
             ('LC_COLLATE', lc_collate),

--- a/tests/operations/postgresql.database/add_database.json
+++ b/tests/operations/postgresql.database/add_database.json
@@ -4,6 +4,6 @@
         "postgresql_databases": {}
     },
     "commands": [
-        "psql -Ac 'CREATE DATABASE somedb'"
+        "psql -Ac 'CREATE DATABASE \"somedb\"'"
     ]
 }

--- a/tests/operations/postgresql.database/add_database_owner.json
+++ b/tests/operations/postgresql.database/add_database_owner.json
@@ -7,6 +7,6 @@
         "postgresql_databases": {}
     },
     "commands": [
-        "psql -Ac 'CREATE DATABASE somedb OWNER someowner'"
+        "psql -Ac 'CREATE DATABASE \"somedb\" OWNER \"someowner\"'"
     ]
 }

--- a/tests/operations/postgresql.database/remove_database.json
+++ b/tests/operations/postgresql.database/remove_database.json
@@ -9,6 +9,6 @@
         }
     },
     "commands": [
-        "psql -Ac 'DROP DATABASE somedb'"
+        "psql -Ac 'DROP DATABASE \"somedb\"'"
     ]
 }

--- a/tests/operations/postgresql.role/user_add.json
+++ b/tests/operations/postgresql.role/user_add.json
@@ -9,8 +9,8 @@
     },
     "commands": [
         [
-            "psql -Ac 'CREATE ROLE testuser LOGIN CONNECTION LIMIT 15 PASSWORD '\"'\"'abc'\"'\"''",
-            "psql -Ac 'CREATE ROLE testuser LOGIN CONNECTION LIMIT 15 ***'"
+            "psql -Ac 'CREATE ROLE \"testuser\" LOGIN CONNECTION LIMIT 15 PASSWORD '\"'\"'abc'\"'\"''",
+            "psql -Ac 'CREATE ROLE \"testuser\" LOGIN CONNECTION LIMIT 15 ***'"
         ]
     ]
 }

--- a/tests/operations/postgresql.role/user_add_no_login.json
+++ b/tests/operations/postgresql.role/user_add_no_login.json
@@ -8,6 +8,6 @@
         }
     },
     "commands": [
-        "psql -Ac 'CREATE ROLE testuser'"
+        "psql -Ac 'CREATE ROLE \"testuser\"'"
     ]
 }

--- a/tests/operations/postgresql.role/user_add_privileges.json
+++ b/tests/operations/postgresql.role/user_add_privileges.json
@@ -11,6 +11,6 @@
         }
     },
     "commands": [
-        "psql -Ac 'CREATE ROLE testuser LOGIN SUPERUSER CREATEDB CREATEROLE REPLICATION'"
+        "psql -Ac 'CREATE ROLE \"testuser\" LOGIN SUPERUSER CREATEDB CREATEROLE REPLICATION'"
     ]
 }

--- a/tests/operations/postgresql.role/user_add_replication.json
+++ b/tests/operations/postgresql.role/user_add_replication.json
@@ -9,6 +9,6 @@
         }
     },
     "commands": [
-        "psql -Ac 'CREATE ROLE testuser REPLICATION'"
+        "psql -Ac 'CREATE ROLE \"testuser\" REPLICATION'"
     ]
 }

--- a/tests/operations/postgresql.role/user_add_super.json
+++ b/tests/operations/postgresql.role/user_add_super.json
@@ -8,6 +8,6 @@
         }
     },
     "commands": [
-        "psql -Ac 'CREATE ROLE testuser LOGIN SUPERUSER'"
+        "psql -Ac 'CREATE ROLE \"testuser\" LOGIN SUPERUSER'"
     ]
 }

--- a/tests/operations/postgresql.role/user_remove.json
+++ b/tests/operations/postgresql.role/user_remove.json
@@ -8,5 +8,5 @@
             "testuser": {}
         }
     },
-    "commands": ["psql -Ac 'DROP ROLE testuser'"]
+    "commands": ["psql -Ac 'DROP ROLE \"testuser\"'"]
 }


### PR DESCRIPTION
`postgres.role()` and `postgres.database()` fail if role, database or owner
contains a dash (-) for example.