### PR TITLE
[FIX]#571 suite

### DIFF
--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -79,10 +79,13 @@ def _load_private_key_file(filename, key_filename, key_password):
                         'use this key'.format(key_filename),
                     )
 
-            return key_cls.from_private_key_file(
-                filename=filename,
-                password=key_password,
-            )
+            try:
+                return key_cls.from_private_key_file(
+                    filename=filename,
+                    password=key_password,
+                )
+            except SSHException as e:  # key does not match key_cls type
+                exception = e
         except SSHException as e:  # key does not match key_cls type
             exception = e
     raise exception
@@ -103,6 +106,7 @@ def _get_private_key(state, key_filename, key_password):
             path.join(state.deploy_dir, key_filename),
         )
 
+    key = False
     key_file_exists = False
 
     for filename in ssh_key_filenames:
@@ -118,7 +122,7 @@ def _get_private_key(state, key_filename, key_password):
             pass
 
     # No break, so no key found
-    else:
+    if not key:
         if not key_file_exists:
             raise PyinfraError('No such private key file: {0}'.format(key_filename))
 


### PR DESCRIPTION
* Ensures loop will continue for all SSH types ;
* Do not raise invalid private key file when key is valid.

The proposed commit 0ba5ecf sadly has not fixed for the use of other types of key (besides RSA).
This pull request tries to ensure all types of keys are tried before raising. Also, it seems that even in this case, `invalid private key` will always be thrown if the key type is not RSA (and so if it's not OK at the first pass).

The MR had been tested locally with RSA and Ed25519 keys. As I only barely know pyinfra internals I'll let you check if you think this is OK or not.

Thanks for your work, have a nice day.