### PR TITLE
winrm env var support

### DIFF
--- a/pyinfra/api/connectors/pyinfrawinrmsession/__init__.py
+++ b/pyinfra/api/connectors/pyinfrawinrmsession/__init__.py
@@ -1,0 +1,28 @@
+import base64
+
+import winrm
+
+
+class PyinfraWinrmSession(winrm.Session):
+    ''' This is our subclassed Session that allows for env setting '''
+
+    def run_cmd(self, command, args=(), env=None):
+        shell_id = self.protocol.open_shell(env_vars=env)
+        command_id = self.protocol.run_command(shell_id, command, args)
+        rs = winrm.Response(self.protocol.get_command_output(shell_id, command_id))
+        self.protocol.cleanup_command(shell_id, command_id)
+        self.protocol.close_shell(shell_id)
+        return rs
+
+    def run_ps(self, script, env=None):
+        '''base64 encodes a Powershell script and executes the powershell
+        encoded script command
+        '''
+        # must use utf16 little endian on windows
+        encoded_ps = base64.b64encode(script.encode('utf_16_le')).decode('ascii')
+        rs = self.run_cmd('powershell -encodedcommand {0}'.format(encoded_ps), env=env)
+        if len(rs.std_err):
+            # if there was an error message, clean it it up and make it human
+            # readable
+            rs.std_err = self._clean_error_msg(rs.std_err)
+        return rs

--- a/pyinfra/api/connectors/util.py
+++ b/pyinfra/api/connectors/util.py
@@ -320,7 +320,7 @@ def make_win_command(command):
     '''
     Builds a windows command with various kwargs.
     '''
-    
+
     # Quote the command as a string
     command = shlex_quote(str(command))
     command = '{0}'.format(command)

--- a/pyinfra/api/connectors/util.py
+++ b/pyinfra/api/connectors/util.py
@@ -316,19 +316,11 @@ def make_unix_command(
     return StringCommand(*command_bits)
 
 
-def make_win_command(command, env=None):
+def make_win_command(command):
     '''
     Builds a windows command with various kwargs.
     '''
-
-    # TODO: This is not correct, needs to be fixed.
-    if env:
-        env_string = ' '.join([
-            '{0}={1}'.format(key, value)
-            for key, value in six.iteritems(env)
-        ])
-        command = 'export {0}; {1}'.format(env_string, command)
-
+    
     # Quote the command as a string
     command = shlex_quote(str(command))
     command = '{0}'.format(command)

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -4,39 +4,14 @@ import base64
 import ntpath
 
 import click
-import winrm
 
 from pyinfra import logger
 from pyinfra.api import Config
 from pyinfra.api.exceptions import ConnectError, PyinfraError
 from pyinfra.api.util import get_file_io, memoize, sha1_hash
 
+from .pyinfrawinrmsession import PyinfraWinrmSession
 from .util import make_win_command
-
-
-class PyinfraWinrmSession(winrm.Session):
-    ''' This is our subclassed Session that allows for env setting '''
-
-    def run_cmd(self, command, args=(), env=None):
-        shell_id = self.protocol.open_shell(env_vars=env)
-        command_id = self.protocol.run_command(shell_id, command, args)
-        rs = winrm.Response(self.protocol.get_command_output(shell_id, command_id))
-        self.protocol.cleanup_command(shell_id, command_id)
-        self.protocol.close_shell(shell_id)
-        return rs
-
-    def run_ps(self, script, env=None):
-        '''base64 encodes a Powershell script and executes the powershell
-        encoded script command
-        '''
-        # must use utf16 little endian on windows
-        encoded_ps = base64.b64encode(script.encode('utf_16_le')).decode('ascii')
-        rs = self.run_cmd('powershell -encodedcommand {0}'.format(encoded_ps), env=env)
-        if len(rs.std_err):
-            # if there was an error message, clean it it up and make it human
-            # readable
-            rs.std_err = self._clean_error_msg(rs.std_err)
-        return rs
 
 
 def _raise_connect_error(host, message, data):

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -13,6 +13,7 @@ from pyinfra.api.util import get_file_io, memoize, sha1_hash
 
 from .util import make_win_command
 
+
 class PyinfraWinrmSession(winrm.Session):
     ''' This is our subclassed Session that allows for env setting '''
 
@@ -36,6 +37,7 @@ class PyinfraWinrmSession(winrm.Session):
             # readable
             rs.std_err = self._clean_error_msg(rs.std_err)
         return rs
+
 
 def _raise_connect_error(host, message, data):
     message = '{0} ({1})'.format(message, data)
@@ -173,11 +175,7 @@ def run_shell_command(
         shell_executable = 'ps'
     logger.debug('shell_executable:%s', shell_executable)
 
-    # default windows to use ps, but allow it to be overridden
-
-    # we implement our own run_ps and run_cmd that allows for env setting 
-    # form open_shell.  just like in pywinrm's impls we do not re-use the shell
-    # for now.
+    # we use our own subclassed session that allows for env setting from open_shell.
     if shell_executable in ['cmd']:
         response = host.connection.run_cmd(tmp_command, env=env)
     else:

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -14,7 +14,7 @@ from pyinfra.api.util import get_file_io, memoize, sha1_hash
 from .util import make_win_command
 
 class PyinfraWinrmSession(winrm.Session):
-    ''' This is out subclassed Session so that allows for env setting '''
+    ''' This is our subclassed Session that allows for env setting '''
 
     def run_cmd(self, command, args=(), env=None):
         shell_id = self.protocol.open_shell(env_vars=env)

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -19,7 +19,7 @@ class PyinfraWinrmSession(winrm.Session):
     def run_cmd(self, command, args=(), env=None):
         shell_id = self.protocol.open_shell(env=env)
         command_id = self.protocol.run_command(shell_id, command, args)
-        rs = Response(self.protocol.get_command_output(shell_id, command_id))
+        rs = winrm.Response(self.protocol.get_command_output(shell_id, command_id))
         self.protocol.cleanup_command(shell_id, command_id)
         self.protocol.close_shell(shell_id)
         return rs
@@ -29,7 +29,7 @@ class PyinfraWinrmSession(winrm.Session):
         encoded script command
         '''
         # must use utf16 little endian on windows
-        encoded_ps = b64encode(script.encode('utf_16_le')).decode('ascii')
+        encoded_ps = base64.b64encode(script.encode('utf_16_le')).decode('ascii')
         rs = self.run_cmd('powershell -encodedcommand {0}'.format(encoded_ps), env=env)
         if len(rs.std_err):
             # if there was an error message, clean it it up and make it human
@@ -145,7 +145,7 @@ def run_shell_command(
         print_output (boolean): print the output
         print_intput (boolean): print the input
         return_combined_output (boolean): combine the stdout and stderr lists
-        shell_executable (string): shell to use - 'sh'=cmd, 'ps'=powershell(default)
+        shell_executable (string): shell to use - 'cmd'=cmd, 'ps'=powershell(default)
         env (dict): environment variables to set
 
     Returns:

--- a/pyinfra/api/connectors/winrm.py
+++ b/pyinfra/api/connectors/winrm.py
@@ -17,7 +17,7 @@ class PyinfraWinrmSession(winrm.Session):
     ''' This is out subclassed Session so that allows for env setting '''
 
     def run_cmd(self, command, args=(), env=None):
-        shell_id = self.protocol.open_shell(env=env)
+        shell_id = self.protocol.open_shell(env_vars=env)
         command_id = self.protocol.run_command(shell_id, command, args)
         rs = winrm.Response(self.protocol.get_command_output(shell_id, command_id))
         self.protocol.cleanup_command(shell_id, command_id)


### PR DESCRIPTION
This fixes the TODO with env vars not working in winrm.  This should work fine for both cmd and powershell and won't change the shell open/close behavior that pywinrm currently provides.