### PR TITLE
propagate return value from @deploy decorator

### DIFF
--- a/pyinfra/api/deploy.py
+++ b/pyinfra/api/deploy.py
@@ -139,6 +139,6 @@ def deploy(func_or_name, data_defaults=None):
             data=deploy_data,
             deploy_op_order=deploy_op_order,
         ):
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
 
     return decorated_func


### PR DESCRIPTION
e.g. this allows writing code like:

```
  @deploy
  def ripgrep(**kwargs):
      return apt.packages('ripgrep', **kwargs)

  res = ripgrep()
  if res.changed:
       # do something else
```

hopefully it doesn't break anything else? 