### PR TITLE
Fix brew casks fact for non-mac platforms

### DIFF
--- a/pyinfra/facts/brew.py
+++ b/pyinfra/facts/brew.py
@@ -81,7 +81,7 @@ class BrewCasks(BrewPackages):
         }
     '''
 
-    command = (r'if [[ "$(brew --version)" =~ Homebrew\ +(1\.|2\.[0-5]).* ]];'
+    command = (r'if brew --version | grep -q -e "Homebrew\ +(1\.|2\.[0-5]).*" 1>/dev/null;'
                r'then brew cask list --versions; else brew list --cask --versions; fi')
     requires_command = 'brew'
 

--- a/tests/facts/brew_casks/casks.json
+++ b/tests/facts/brew_casks/casks.json
@@ -1,5 +1,5 @@
 {
-    "command": "if brew --version | grep -q -e "Homebrew\ +(1\.|2\.[0-5]).*" 1>/dev/null;then brew cask list --versions; else brew list --cask --versions; fi",
+    "command": "if brew --version | grep -q -e \"Homebrew\ +(1\.|2\.[0-5]).*\" 1>/dev/null;then brew cask list --versions; else brew list --cask --versions; fi",
     "output": [
         "1password-cli 0.10.0",
         "google-chrome 76.0.3809.132",

--- a/tests/facts/brew_casks/casks.json
+++ b/tests/facts/brew_casks/casks.json
@@ -1,5 +1,5 @@
 {
-    "command": "if brew --version | grep -q -e \"Homebrew\ +(1\.|2\.[0-5]).*\" 1>/dev/null;then brew cask list --versions; else brew list --cask --versions; fi",
+    "command": "if brew --version | grep -q -e \"Homebrew\\ +(1\\.|2\\.[0-5]).*\" 1>/dev/null;then brew cask list --versions; else brew list --cask --versions; fi",
     "output": [
         "1password-cli 0.10.0",
         "google-chrome 76.0.3809.132",

--- a/tests/facts/brew_casks/casks.json
+++ b/tests/facts/brew_casks/casks.json
@@ -1,5 +1,5 @@
 {
-    "command": "if [[ \"$(brew --version)\" =~ Homebrew\\ +(1\\.|2\\.[0-5]).* ]];then brew cask list --versions; else brew list --cask --versions; fi",
+    "command": "if brew --version | grep -q -e "Homebrew\ +(1\.|2\.[0-5]).*" 1>/dev/null;then brew cask list --versions; else brew list --cask --versions; fi",
     "output": [
         "1password-cli 0.10.0",
         "google-chrome 76.0.3809.132",


### PR DESCRIPTION
This command contains a bashism which causes parsing errors for some shells (for example dash as included in raspbian).
POSIX test doesn't include any pattern matching, so fall back on grep as the next best thing.

tested against both a mac (running bigsur) and an rpi (running raspbian)