### PR TITLE
fix: add missing mysql connection parameters

### DIFF
--- a/pyinfra/operations/mysql.py
+++ b/pyinfra/operations/mysql.py
@@ -226,6 +226,10 @@ def database(
             database=database,
             state=state,
             host=host,
+            mysql_user=mysql_user,
+            mysql_password=mysql_password,
+            mysql_host=mysql_host,
+            mysql_port=mysql_port,
         )
 
 


### PR DESCRIPTION
This fixes a failure to run the `mysql.create` operation when using non-default connection parameters.