### PR TITLE
Transfer ownership of files over ssh with sudo/su

### DIFF
--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -422,7 +422,7 @@ def put_file(
 
         # Make sure our sudo/su user can access the file
         if su_user:
-            command = StringCommand('setfacl -m u:{0}:r'.format(su_user), temp_file)
+            command = StringCommand('setfacl', '-m', 'u:{0}:r'.format(su_user), temp_file)
         elif sudo_user:
             command = StringCommand('setfacl -m u:{0}:r'.format(sudo_user), temp_file)
         status, _, stderr = run_shell_command(

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -452,9 +452,9 @@ def put_file(
         if status is False:
             logger.error('File upload error: {0}'.format('\n'.join(stderr)))
             return False
-    
+
         # Delete the temporary file now that we've successfully copied it
-        command = StringCommand('rm', '-f', temp_file) 
+        command = StringCommand('rm', '-f', temp_file)
 
         status, _, stderr = run_shell_command(
             state, host, command,

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -441,14 +441,6 @@ def put_file(
         # Execute run_shell_command w/sudo and/or su_user
         command = StringCommand('cp', temp_file, QuoteString(remote_filename))
 
-        # Move it to the su_user if present
-        if su_user:
-            command = StringCommand(command, '&&', 'chown', su_user, QuoteString(remote_filename))
-
-        # Otherwise any sudo_user
-        elif sudo_user:
-            command = StringCommand(command, '&&', 'chown', sudo_user, QuoteString(remote_filename))
-
         status, _, stderr = run_shell_command(
             state, host, command,
             sudo=sudo, sudo_user=sudo_user, su_user=su_user,

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -452,6 +452,21 @@ def put_file(
         if status is False:
             logger.error('File upload error: {0}'.format('\n'.join(stderr)))
             return False
+    
+        # Delete the temporary file now that we've successfully copied it
+        command = StringCommand('rm', '-f', temp_file) 
+
+        status, _, stderr = run_shell_command(
+            state, host, command,
+            sudo=False,
+            print_output=print_output,
+            print_input=print_input,
+            **command_kwargs
+        )
+
+        if status is False:
+            logger.error('Unable to remove temporary file: {0}'.format('\n'.join(stderr)))
+            return False
 
     # No sudo and no su_user, so just upload it!
     else:

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -425,17 +425,18 @@ def put_file(
             command = StringCommand('setfacl -m u:{0}:r'.format(su_user), temp_file)
         elif sudo_user:
             command = StringCommand('setfacl -m u:{0}:r'.format(sudo_user), temp_file)
-        status, _, stderr = run_shell_command(
-            state, host, command,
-            sudo=False,
-            print_output=print_output,
-            print_input=print_input,
-            **command_kwargs
-        )
+        if su_user or sudo_user:
+            status, _, stderr = run_shell_command(
+                state, host, command,
+                sudo=False,
+                print_output=print_output,
+                print_input=print_input,
+                **command_kwargs
+            )
 
-        if status is False:
-            logger.error('Error on handover to sudo/su user: {0}'.format('\n'.join(stderr)))
-            return False
+            if status is False:
+                logger.error('Error on handover to sudo/su user: {0}'.format('\n'.join(stderr)))
+                return False
 
         # Execute run_shell_command w/sudo and/or su_user
         command = StringCommand('cp', temp_file, QuoteString(remote_filename))

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -422,9 +422,9 @@ def put_file(
 
         # Make sure our sudo/su user can access the file
         if su_user:
-            command = StringCommand(f'setfacl -m u:{su_user}:r', temp_file)
+            command = StringCommand('setfacl -m u:{0}:r'.format(su_user), temp_file)
         elif sudo_user:
-            command = StringCommand(f'setfacl -m u:{sudo_user}:r', temp_file)
+            command = StringCommand('setfacl -m u:{0}:r'.format(sudo_user), temp_file)
         status, _, stderr = run_shell_command(
             state, host, command,
             sudo=False,

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -424,7 +424,7 @@ def put_file(
         if su_user:
             command = StringCommand('setfacl', '-m', 'u:{0}:r'.format(su_user), temp_file)
         elif sudo_user:
-            command = StringCommand('setfacl -m u:{0}:r'.format(sudo_user), temp_file)
+            command = StringCommand('setfacl', '-m', 'u:{0}:r'.format(sudo_user), temp_file)
         status, _, stderr = run_shell_command(
             state, host, command,
             sudo=False,

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -507,7 +507,7 @@ class TestSSHConnector(TestCase):
         assert status is True
 
         fake_ssh_client().exec_command.assert_called_with((
-            "sudo -H -n -u ubuntu sh -c 'mv "
+            "sudo -H -n -u ubuntu sh -c 'cp "
             '/tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24 '
             "\'\"\'\"\'not another file\'\"\'\"\' && chown ubuntu "
             "\'\"\'\"\'not another file\'\"\'\"\'\'"
@@ -540,7 +540,7 @@ class TestSSHConnector(TestCase):
         assert status is False
 
         fake_ssh_client().exec_command.assert_called_with((
-            "su centos -c 'sh -c '\"'\"'mv "
+            "su centos -c 'sh -c '\"'\"'cp "
             '/tmp/pyinfra-43db9984686317089fefcf2e38de527e4cb44487 '
             "not-another-file && chown centos not-another-file'\"'\"''"
         ), get_pty=False)

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -507,10 +507,8 @@ class TestSSHConnector(TestCase):
         assert status is True
 
         fake_ssh_client().exec_command.assert_called_with((
-            "sudo -H -n -u ubuntu sh -c 'cp "
-            '/tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24 '
-            "\'\"\'\"\'not another file\'\"\'\"\' && chown ubuntu "
-            "\'\"\'\"\'not another file\'\"\'\"\'\'"
+            "sh -c 'rm -f "
+            "/tmp/pyinfra-de01e82cb691e8a31369da3c7c8f17341c44ac24'"
         ), get_pty=False)
 
         fake_sftp_client.from_transport().putfo.assert_called_with(
@@ -540,9 +538,9 @@ class TestSSHConnector(TestCase):
         assert status is False
 
         fake_ssh_client().exec_command.assert_called_with((
-            "su centos -c 'sh -c '\"'\"'cp "
-            '/tmp/pyinfra-43db9984686317089fefcf2e38de527e4cb44487 '
-            "not-another-file && chown centos not-another-file'\"'\"''"
+            "sh -c "
+            "'setfacl -m u:centos:r "
+            "/tmp/pyinfra-43db9984686317089fefcf2e38de527e4cb44487'"
         ), get_pty=False)
 
         fake_sftp_client.from_transport().putfo.assert_called_with(

--- a/words.txt
+++ b/words.txt
@@ -6,6 +6,7 @@
 4
 64kb
 700
+acl
 addrs
 addsitedir
 adhoc


### PR DESCRIPTION
This PR addresses #614 by using the SSH user to assign a read-only ACL to the uploaded file, before switching to the sudo/su user and copying the file to the intended destination rather than attempting to `mv` it.

This allows a file uploaded by an unprivileged user to be 'handed over' to another unprivileged user. 

I've created this PR as a draft because there's a few issues worth discussing:
- This approach relies on the ability to use filesystem ACLs. Most modern filesystems support this but not all of them do, so I wanted to make sure this fits with pyinfra's philosophy. We can always try this and fall back to another approach as well.
- This introduces `cp` instead of `mv` when transferring the file out of the temp directory on upload, so for large files this could be a significant amount of extra storage consumed during the upload process.

I've also tried to update the tests, one of them updated ok but another is failing because it's asserting against the wrong call (it's using the `setfacl` call rather than the `cp` call). Happy to fix this up if I can get some assistance. 