### PR TITLE
feat: fetch held deb packages' version

### DIFF
--- a/pyinfra/api/deploy.py
+++ b/pyinfra/api/deploy.py
@@ -139,6 +139,6 @@ def deploy(func_or_name, data_defaults=None):
             data=deploy_data,
             deploy_op_order=deploy_op_order,
         ):
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
 
     return decorated_func

--- a/pyinfra/facts/deb.py
+++ b/pyinfra/facts/deb.py
@@ -25,7 +25,7 @@ class DebPackages(FactBase):
 
     default = dict
 
-    regex = r'^ii\s+([a-zA-Z0-9\+\-\.]+):?[a-zA-Z0-9]*\s+([a-zA-Z0-9:~\.\-\+]+).+$'
+    regex = r'^[i|h]i\s+([a-zA-Z0-9\+\-\.]+):?[a-zA-Z0-9]*\s+([a-zA-Z0-9:~\.\-\+]+).+$'
 
     def process(self, output):
         return parse_packages(self.regex, output)

--- a/tests/facts/deb_packages/hold_packages.json
+++ b/tests/facts/deb_packages/hold_packages.json
@@ -1,0 +1,13 @@
+{
+    "command": "dpkg -l",
+    "output": [
+        "hi  matrix-synapse-py3 1.37.1+bionic1 amd64 Open federated Instant Messaging and VoIP server",
+        "hi  miniflux 2.0.31 amd64 Minimalist Feed Reader",
+        "hi  wireguard 1.0.20200513-1~18.04.2 all fast, modern, secure kernel VPN tunnel (metapackage)"
+    ],
+    "fact": {
+        "matrix-synapse-py3": ["1.37.1+bionic1"],
+        "miniflux": ["2.0.31"],
+        "wireguard": ["1.0.20200513-1~18.04.2"]
+    }
+}


### PR DESCRIPTION
It would be useful to fetch the version number of held deb packages to have scripts that manually unhold them to be able to upgrade if the need be.