### PR TITLE
fix(ssh.upload): fix wrong connection string when using use_remote_sudo and user

### DIFF
--- a/pyinfra/operations/ssh.py
+++ b/pyinfra/operations/ssh.py
@@ -157,7 +157,7 @@ def upload(
 
         # And sudo sudo to move it
         yield command(
-            hostname=connection_target,
+            hostname=hostname,
             command='sudo mv {0} {1}'.format(temp_remote_filename, remote_filename),
             port=port,
             user=user,

--- a/tests/operations/ssh.upload/upload_remote_sudo_user.json
+++ b/tests/operations/ssh.upload/upload_remote_sudo_user.json
@@ -1,0 +1,12 @@
+{
+    "args": ["remote-host.net", "local_filename"],
+    "kwargs": {
+        "user": "test",
+        "use_remote_sudo": true
+    },
+    "commands": [
+        "scp -P 22 local_filename test@remote-host.net:_tempfile_",
+        "ssh -p 22 test@remote-host.net 'sudo mv _tempfile_ local_filename'"
+    ],
+    "idempotent": false
+}


### PR DESCRIPTION
Fixes the ssh connection string when setting the use_remote_sudo and user options for the ssh.upload operation

Before: sets twice the username
```json
[
  "scp -P 22 local_filename test@remote-host.net:_tempfile_",
  "ssh -p 22 test@test@remote-host.net 'sudo mv _tempfile_ local_filename'"
]
```

After:
```json
[
  "scp -P 22 local_filename test@remote-host.net:_tempfile_",
  "ssh -p 22 test@remote-host.net 'sudo mv _tempfile_ local_filename'"
]
```