### PR TITLE
files.download: fix cache_time test

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -112,7 +112,7 @@ def download(
             # Time on files is not tz-aware, and will be the same tz as the server's time,
             # so we can safely remove the tzinfo from the Date fact before comparison.
             cache_time = host.get_fact(Date).replace(tzinfo=None) - timedelta(seconds=cache_time)
-            if info['mtime'] and info['mtime'] > cache_time:
+            if info['mtime'] and info['mtime'] < cache_time:
                 download = True
 
         if sha1sum:

--- a/tests/operations/files.download/download_cache_time_needs_refresh.json
+++ b/tests/operations/files.download/download_cache_time_needs_refresh.json
@@ -5,7 +5,7 @@
         "cache_time": 3600
     },
     "facts": {
-        "server.Date": "datetime:2015-01-01T00:30:00",
+        "server.Date": "datetime:2015-01-01T02:00:00",
         "files.File": {
             "path=/home/myfile": {
                 "mtime": "datetime:2015-01-01T00:00:00"
@@ -15,6 +15,8 @@
             "command=curl": "yes"
         }
     },
-    "commands": [],
+    "commands": [
+        "curl -sSLf http://myfile -o /home/myfile"
+    ],
     "idempotent": false
 }


### PR DESCRIPTION
the condition was flipped. We want to re-download the file only if it hasn't been modified since `cache_time`.