### PR TITLE
WIP: add pipx support

### DIFF
--- a/pyinfra/facts/pipx.py
+++ b/pyinfra/facts/pipx.py
@@ -27,7 +27,7 @@ class PipxPackages(FactBase):
         return '{0} list --json'.format(pipx)
 
     def process(self, output):
-        pipx_list= json.loads(output)
+        pipx_list= json.loads('\n'.join(output))
         versions={}
         for venv in pipx_list['venvs'].values():
             package=venv['metadata']['main_package']['package']

--- a/pyinfra/facts/pipx.py
+++ b/pyinfra/facts/pipx.py
@@ -1,0 +1,36 @@
+from __future__ import unicode_literals
+
+from pyinfra.api import FactBase
+
+import json
+
+
+class PipxPackages(FactBase):
+    '''
+    Returns a dict of installed pipx packages:
+
+    .. code:: python
+
+        {
+            'package_name': ['version'],
+        }
+    '''
+
+    default = dict
+    pipx_command = 'pipx'
+
+    def requires_command(self, pipx=None):
+        return pipx or self.pipx_command
+
+    def command(self, pipx=None):
+        pipx = pipx or self.pipx_command
+        return '{0} list --json'.format(pipx)
+
+    def process(self, output):
+        pipx_list= json.loads(output)
+        versions={}
+        for venv in pipx_list['venvs'].values():
+            package=venv['metadata']['main_package']['package']
+            version=venv['metadata']['main_package']['package_version']
+            versions[package]={version}
+        return versions

--- a/pyinfra/operations/pipx.py
+++ b/pyinfra/operations/pipx.py
@@ -1,0 +1,65 @@
+'''
+Manage pip (python) packages. Compatible globally or inside
+a virtualenv (virtual environment).
+'''
+
+from __future__ import unicode_literals
+
+from pyinfra.api import operation
+from pyinfra.facts.files import File
+from pyinfra.facts.pipx import PipxPackages
+
+from . import files
+from .util.packaging import ensure_packages
+
+
+@operation
+def packages(
+    packages=None, present=True, latest=False,
+    pipx='pipx',
+    extra_install_args=None,
+    state=None, host=None,
+):
+    '''
+    Install/remove/update pipx packages.
+
+    + packages: list of packages to ensure
+    + present: whether the packages should be installed
+    + latest: whether to upgrade packages without a specified version
+    + pipx: name or path of the pipx directory to use
+    + extra_install_args: additional arguments to the pipx install command
+
+    Versions:
+        Package versions can be pinned like pip: ``<pkg>==<version>``.
+
+    Example:
+
+    .. code:: python
+
+        pipx.packages(
+            name='Install pycowsay',
+            packages=['pycowsay'],
+            latest=True,
+        )
+    '''
+
+
+    install_command = [pipx, 'install']
+    if extra_install_args:
+        install_command.append(extra_install_args)
+    install_command = ' '.join(install_command)
+
+    uninstall_command = ' '.join([pipx, 'uninstall'])
+
+    # Handle passed in packages
+    if packages:
+        current_packages = host.get_fact(PipxPackages, pipx='pipx')
+
+        yield ensure_packages(
+            host, packages, current_packages, present,
+            install_command=install_command,
+            uninstall_command=uninstall_command,
+            upgrade_command='{0} upgrade'.format(install_command),
+            version_join='==',
+            latest=latest,
+        )

--- a/pyinfra/operations/pipx.py
+++ b/pyinfra/operations/pipx.py
@@ -59,7 +59,7 @@ def packages(
             host, packages, current_packages, present,
             install_command=install_command,
             uninstall_command=uninstall_command,
-            upgrade_command='{0} upgrade'.format(install_command),
+            upgrade_command='{0} upgrade'.format(pipx),
             version_join='==',
             latest=latest,
         )


### PR DESCRIPTION
This is attempt to add pipx support. Pipx is is great tool to install many packages, I want to use it to install for example `docker-compose` and `docker-auto-labels` on hosts.

-------------

I have problem, which I can't understand how to fix. I can't run `pipx` from pyinfra, but I can run it from manual ssh session. It works ok if `pipx` is installed via `apt`, but version in `apt` is very outdated.

Example code below generates error:

```python
from pyinfra.api import Config
from pyinfra.operations import apt, pip, pipx

apt.packages(
    name='Ensure python is installed',
    packages=['python3-pip', 'python3-venv'],
    latest=True,
    sudo=True,  # use sudo when installing the packages
    update=True,
    cache_time=3600,
    upgrade=True,
)

pip.packages(
    name="Ensure pipx is installed",
    packages=["pipx"],
    pip="pip3",
    latest=True,
    # sudo=True,  # If sudo is enabled here, then error vanishes, but sudo is not recommended for pip
)

pipx.packages(
    name="Ensure pycowsay is installed",
    packages=["pycowsay"],
    latest=True,
)
```
Error message:
```
--> Starting operation: Ensure pycowsay is installed
[REDACTED_IP] >>> sudo -H -n sh -c 'pipx install pycowsay'
[REDACTED_IP] sh: 1: pipx: not found
    [REDACTED_IP] Error
No hosts remaining!
--> pyinfra error: 
```
