### PR TITLE
Add Arch Linux support for the LinuxDistribution fact

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -513,8 +513,14 @@ class LinuxDistribution(FactBase):
         for part in '\n'.join(output).strip().split('---'):
             if not part.strip():
                 continue
-            filename, content = part.strip().split('\n', 1)
-            parts[filename] = content
+            try:
+                filename, content = part.strip().split('\n', 1)
+                parts[filename] = content
+            except(ValueError):
+                # skip empty files
+                # for instance arch linux as an empty file at /etc/arch-release
+                continue
+
 
         release_info = self.default()
         if not parts:

--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -516,11 +516,10 @@ class LinuxDistribution(FactBase):
             try:
                 filename, content = part.strip().split('\n', 1)
                 parts[filename] = content
-            except(ValueError):
+            except ValueError:
                 # skip empty files
                 # for instance arch linux as an empty file at /etc/arch-release
                 continue
-
 
         release_info = self.default()
         if not parts:


### PR DESCRIPTION
Arch has an empty files at `/etc/arch-release` that was used back when arch had releases. This lead to straight up errors, I fixed those more broadly by just spiking empty files.

I hope this can get merged as I really wanna use pyinfra for my arch servers.