### PR TITLE
git.GitBranch: support checking out tags

### DIFF
--- a/pyinfra/facts/git.py
+++ b/pyinfra/facts/git.py
@@ -10,7 +10,11 @@ class GitBranch(FactBase):
 
     @staticmethod
     def command(repo):
-        return '! test -d {0} || (cd {0} && git rev-parse --abbrev-ref HEAD)'.format(repo)
+        return '! test -d {0} || (cd {0} && git describe --all)'.format(repo)
+
+    @staticmethod
+    def process(output):
+        return re.sub(r'(heads|tags)/', r'', '\n'.join(output))
 
 
 class GitConfig(FactBase):

--- a/tests/facts/git.GitBranch/branch.json
+++ b/tests/facts/git.GitBranch/branch.json
@@ -1,6 +1,6 @@
 {
     "arg": "myrepo",
-    "command": "! test -d myrepo || (cd myrepo && git rev-parse --abbrev-ref HEAD)",
+    "command": "! test -d myrepo || (cd myrepo && git describe --all)",
     "requires_command": "git",
     "output": [
         "develop"

--- a/tests/facts/git.GitBranch/branch.json
+++ b/tests/facts/git.GitBranch/branch.json
@@ -3,7 +3,7 @@
     "command": "! test -d myrepo || (cd myrepo && git describe --all)",
     "requires_command": "git",
     "output": [
-        "develop"
+        "heads/develop"
     ],
     "fact": "develop"
 }


### PR DESCRIPTION
Checking out a git repo is a last resort, so I always like to pin them to tags when I do have to have one on a host.
`git describe` is considered plumbing and thus format stable. This behavior was introduced in 2005, so there are no
real concerns that a host will be running an existing version of git that doesn't support the command or the `--all`
flag.