### PR TITLE
Improve dir sync exclude

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -459,7 +459,7 @@ def sync(
 
     put_files = []
     ensure_dirnames = []
-    for dirpath, dirnames, filenames in walk(src):
+    for dirpath, dirnames, filenames in walk(src, topdown=True):
         remote_dirpath = dirpath.replace(src, '')
 
         # Filter excluded dirs

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -434,7 +434,7 @@ def sync(
         )
     '''
 
-    # If we don't enforce the source ending with /, remote_dirname below might start with
+    # If we don't enforce the source ending with /, remote_dirpath below might start with
     # a /, which makes the os_path.join cut off the destination bit.
     if not src.endswith(os_path.sep):
         src = '{0}{1}'.format(src, os_path.sep)
@@ -459,18 +459,18 @@ def sync(
 
     put_files = []
     ensure_dirnames = []
-    for dirname, _, filenames in walk(src):
-        remote_dirname = dirname.replace(src, '')
+    for dirpath, _, filenames in walk(src):
+        remote_dirpath = dirpath.replace(src, '')
 
         # Should we exclude this dir?
-        if exclude_dir and any(fnmatch(remote_dirname, match) for match in exclude_dir):
+        if exclude_dir and any(fnmatch(remote_dirpath, match) for match in exclude_dir):
             continue
 
-        if remote_dirname:
-            ensure_dirnames.append((remote_dirname, get_path_permissions_mode(dirname)))
+        if remote_dirpath:
+            ensure_dirnames.append((remote_dirpath, get_path_permissions_mode(dirpath)))
 
         for filename in filenames:
-            full_filename = os_path.join(dirname, filename)
+            full_filename = os_path.join(dirpath, filename)
 
             # Should we exclude this file?
             if exclude and any(fnmatch(full_filename, match) for match in exclude):
@@ -482,7 +482,7 @@ def sync(
                 # Join remote as unix like
                 '/'.join(
                     item for item in
-                    (dest, remote_dirname, filename)
+                    (dest, remote_dirpath, filename)
                     if item
                 ),
             ))
@@ -502,9 +502,9 @@ def sync(
     )
 
     # Ensure any remote dirnames
-    for dirname, dir_mode in ensure_dirnames:
+    for dirpath, dir_mode in ensure_dirnames:
         yield directory(
-            '/'.join((dest, dirname)),
+            '/'.join((dest, dirpath)),
             user=user, group=group, mode=dir_mode,
             state=state, host=host,
         )

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -459,12 +459,14 @@ def sync(
 
     put_files = []
     ensure_dirnames = []
-    for dirpath, _, filenames in walk(src):
+    for dirpath, dirnames, filenames in walk(src):
         remote_dirpath = dirpath.replace(src, '')
 
-        # Should we exclude this dir?
-        if exclude_dir and any(fnmatch(remote_dirpath, match) for match in exclude_dir):
-            continue
+        # Filter excluded dirs
+        for child_dir in dirnames:
+            child_path = os_path.join(remote_dirpath, child_dir)
+            if exclude_dir and any(fnmatch(child_path, match) for match in exclude_dir):
+                dirnames.remove(child_dir)
 
         if remote_dirpath:
             ensure_dirnames.append((remote_dirpath, get_path_permissions_mode(dirpath)))

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -420,6 +420,7 @@ def sync(
     + delete: delete remote files not present locally
     + exclude: string or list/tuple of strings to match & exclude files (eg *.pyc)
     + exclude_dir: string or list/tuple of strings to match & exclude directories (eg node_modules)
+    + add_deploy_dir: interpret src as relative to deploy directory instead of current directory
 
     Example:
 

--- a/tests/operations/files.sync/sync_delete_posix.json
+++ b/tests/operations/files.sync/sync_delete_posix.json
@@ -13,11 +13,15 @@
     ],
     "directories": {
         "/somedir/": {
-            "/somedir/": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
-            "/somedir/underthat": ["yet-another-file.txt"],
-            "/somedir/__pycache__": ["nope"]
+            "files": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
+            "dirs": ["underthat", "__pycache__"]
         },
-        "/somedir/underthat": {}
+        "/somedir/underthat": {
+            "files": ["yet-another-file.txt"]
+        },
+        "/somedir/__pycache__": {
+            "files": ["nope"]
+        }
     },
     "facts": {
         "files.File": {

--- a/tests/operations/files.sync/sync_delete_windows.json
+++ b/tests/operations/files.sync/sync_delete_windows.json
@@ -13,11 +13,15 @@
     ],
     "directories": {
         "\\somedir\\": {
-            "\\somedir\\": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
-            "\\somedir\\underthat": ["yet-another-file.txt"],
-            "\\somedir\\__pycache__": ["nope"]
+            "files": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
+            "dirs": ["underthat", "__pycache__"]
         },
-        "\\somedir\\underthat": {}
+        "\\somedir\\underthat": {
+            "files": ["yet-another-file.txt"]
+        },
+        "\\somedir\\__pycache__": {
+            "files": ["nope"]
+        }
     },
     "facts": {
         "files.File": {

--- a/tests/operations/files.sync/sync_destination_link.json
+++ b/tests/operations/files.sync/sync_destination_link.json
@@ -8,7 +8,9 @@
     "files": [
         "/somedir/somefile.txt",
         "/somedir/anotherfile.txt",
-        "/somedir/underthat/yet-another-file.txt"
+        "/somedir/underthat/yet-another-file.txt",
+        "/somedir/__pycache__/nope",
+        "/somedir/__pycache__/ignore_this/nope_again"
     ],
     "directories": {
         "/somedir/": {
@@ -19,7 +21,11 @@
             "files": ["yet-another-file.txt"]
         },
         "/somedir/__pycache__": {
-            "files": ["nope"]
+            "files": ["nope"],
+            "dirs": ["ignore_this"]
+        },
+        "/somedir/__pycache__/ignore_this": {
+            "files": ["nope_again"]
         }
     },
     "facts": {

--- a/tests/operations/files.sync/sync_destination_link.json
+++ b/tests/operations/files.sync/sync_destination_link.json
@@ -12,11 +12,15 @@
     ],
     "directories": {
         "/somedir/": {
-            "/somedir/": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
-            "/somedir/underthat": ["yet-another-file.txt"],
-            "/somedir/__pycache__": ["nope"]
+            "files": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
+            "dirs": ["underthat", "__pycache__"]
         },
-        "/somedir/underthat": {}
+        "/somedir/underthat": {
+            "files": ["yet-another-file.txt"]
+        },
+        "/somedir/__pycache__": {
+            "files": ["nope"]
+        }
     },
     "facts": {
         "files.File": {

--- a/tests/operations/files.sync/sync_partial_exists.json
+++ b/tests/operations/files.sync/sync_partial_exists.json
@@ -8,10 +8,12 @@
     ],
     "directories": {
         "/somedir/": {
-            "/somedir/": ["somefile.txt", "anotherfile.txt"],
-            "/somedir/underthat": ["yet-another-file.txt"]
+            "files": ["somefile.txt", "anotherfile.txt"],
+            "dirs": ["underthat"]
         },
-        "/somedir/underthat": {}
+        "/somedir/underthat": {
+            "files": ["yet-another-file.txt"]
+        }
     },
     "facts": {
         "files.File": {

--- a/tests/operations/files.sync/sync_special_chars.json
+++ b/tests/operations/files.sync/sync_special_chars.json
@@ -6,7 +6,7 @@
     ],
     "directories": {
         "/somedir/": {
-            "/somedir/": ["yet () another {} file $$ __.txt"]
+            "files": ["yet () another {} file $$ __.txt"]
         }
     },
     "facts": {

--- a/tests/util.py
+++ b/tests/util.py
@@ -294,12 +294,19 @@ class patch_files(object):
 
         return os.stat_result((mode_int, 0, 0, 0, 0, 0, 0, 0, 0, 0))
 
-    def walk(self, dirname):
+    def walk(self, dirname, topdown=True, onerror=None, followlinks=False):
         if dirname not in self.directories:
             return
+        dir_definition = self.directories[dirname]
+        child_dirs = dir_definition.get('dirs', [])
+        child_files = dir_definition.get('files', [])
 
-        for dirname, filenames in sorted(self.directories[dirname].items()):
-            yield dirname, None, filenames
+        yield dirname, child_dirs, child_files
+
+        for child in child_dirs:
+            full_child = path.join(dirname, child)
+            for recursive_return in self.walk(full_child):
+                yield recursive_return
 
 
 def create_host(name=None, facts=None, data=None):


### PR DESCRIPTION
Currently `files.sync`'s `exclude_dir` parameter doesn't seem to work properly, and it seems to be because it only ignores  matching directories _themselves_, i.e. not the files or directories they contain.

As a consequence, it only seems to be relevant for **empty** directories.

This changes this behaviour by excluding the entire directory tree below matching directories.