### PR TITLE
Add 'available' as an argument to apk.upgrade

### DIFF
--- a/pyinfra/operations/apk.py
+++ b/pyinfra/operations/apk.py
@@ -12,6 +12,8 @@ from .util.packaging import ensure_packages
 def upgrade(available=False, state=None, host=None):
     '''
     Upgrades all apk packages.
+
+    + available: force all packages to be upgraded (recommended on whole Alpine version upgrades)
     '''
 
     if available:

--- a/pyinfra/operations/apk.py
+++ b/pyinfra/operations/apk.py
@@ -9,12 +9,15 @@ from .util.packaging import ensure_packages
 
 
 @operation
-def upgrade(state=None, host=None):
+def upgrade(available=False, state=None, host=None):
     '''
     Upgrades all apk packages.
     '''
 
-    yield 'apk upgrade'
+    if available:
+        yield 'apk upgrade --available'
+    else:
+        yield 'apk upgrade'
 
 _upgrade = upgrade  # noqa: E305
 

--- a/tests/operations/apk.upgrade/upgrade_available.json
+++ b/tests/operations/apk.upgrade/upgrade_available.json
@@ -1,0 +1,11 @@
+{
+    "args": [],
+    "kwargs": {
+        "available": true
+    },
+    "commands": [
+        "apk upgrade --available"
+    ],
+    "idempotent": false,
+    "disable_itempotent_warning_reason": "package upgrades are always executed"
+}


### PR DESCRIPTION
From the [Upgrading Alpine](https://wiki.alpinelinux.org/wiki/Upgrading_Alpine) wiki page:

> The --available switch is used to force all packages to be upgraded, even if they have the same version numbers. Sometimes changes in uClibc require doing this.

Thought it would be a good option to add. I'm unsure on how to write a JSON test for it, though!