### PR TITLE
Fix: don't fail if dest in files.put is a directory

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -706,6 +706,9 @@ def put(
     mode = ensure_mode_int(mode)
     remote_file = host.get_fact(File, path=dest)
 
+    if not remote_file and host.get_fact(Directory, path=dest):
+        dest = os_path.join(dest, os_path.basename(src))
+
     if create_remote_dir:
         yield _create_remote_dir(state, host, dest, user, group)
 

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -666,6 +666,10 @@ def put(
     + force: always upload the file, even if the remote copy matches
     + assume_exists: whether to assume the local file exists
 
+    ``dest``:
+        If this is a directory that already exists on the remote side, the local
+        file will be uploaded to that directory with the same filename.
+
     ``create_remote_dir``:
         If the remote directory does not exist it will be created using the same
         user & group as passed to ``files.put``. The mode will *not* be copied over,

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -711,7 +711,7 @@ def put(
     remote_file = host.get_fact(File, path=dest)
 
     if not remote_file and host.get_fact(Directory, path=dest):
-        dest = os_path.join(dest, os_path.basename(src))
+        dest = '/'.join((dest.rstrip('/'), os_path.basename(src)))
 
     if create_remote_dir:
         yield _create_remote_dir(state, host, dest, user, group)

--- a/tests/operations/files.put/upload_to_directory.json
+++ b/tests/operations/files.put/upload_to_directory.json
@@ -1,0 +1,23 @@
+{
+    "args": ["somefile.txt", "/home"],
+    "kwargs": {
+        "user": "testuser",
+        "group": "testgroup",
+        "mode": 644
+    },
+    "files": ["somefile.txt"],
+    "facts": {
+        "files.File": {
+            "path=/home/somefile.txt": null
+        },
+        "files.Directory": {
+            "path=/home": true
+        }
+    },
+    "commands": [
+        ["upload", "/somefile.txt", "/home/somefile.txt"],
+        "chown testuser:testgroup /home/somefile.txt",
+        "chmod 644 /home/somefile.txt"
+    ],
+    "idempotent": false
+}

--- a/tests/operations/server.script/upload_run.json
+++ b/tests/operations/server.script/upload_run.json
@@ -6,7 +6,8 @@
     "facts": {
         "files.File": {
             "path=_tempfile_": null
-        }
+        },
+        "files.Directory": {}
     },
     "commands": [
         ["upload", "/somescript.sh", "_tempfile_"],

--- a/tests/operations/server.script_template/script.json
+++ b/tests/operations/server.script_template/script.json
@@ -4,7 +4,8 @@
     "facts": {
         "files.File": {
             "path=_tempfile_": null
-        }
+        },
+        "files.Directory": {}
     },
     "commands": [
         ["upload", "_test_data_", "_tempfile_"],


### PR DESCRIPTION
See #663.

Thanks for publishing this project. It makes me happy when I think I don't have to use ansible anymore!
This is one possible approach. Another would be to specify the issue in the documentation.