### PR TITLE
Fix use of get_sudo_password() with less arguments

### DIFF
--- a/pyinfra/api/connectors/chroot.py
+++ b/pyinfra/api/connectors/chroot.py
@@ -63,11 +63,8 @@ def run_shell_command(
 
     if use_sudo_password:
         command_kwargs['use_sudo_password'] = get_sudo_password(
-            state,
             host,
             use_sudo_password,
-            run_shell_command=run_shell_command,
-            put_file=put_file,
         )
 
     chroot_directory = host.host_data['chroot_directory']

--- a/pyinfra/api/connectors/local.py
+++ b/pyinfra/api/connectors/local.py
@@ -65,9 +65,7 @@ def run_shell_command(
 
     if use_sudo_password:
         command_kwargs['use_sudo_password'] = get_sudo_password(
-            state, host, use_sudo_password,
-            run_shell_command=run_shell_command,
-            put_file=put_file,
+            host, use_sudo_password
         )
 
     def execute_command():

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -271,9 +271,7 @@ def run_shell_command(
 
     if use_sudo_password:
         command_kwargs['use_sudo_password'] = get_sudo_password(
-            state, host, use_sudo_password,
-            run_shell_command=run_shell_command,
-            put_file=put_file,
+            host, use_sudo_password
         )
 
     def execute_command():


### PR DESCRIPTION
`get_sudo_password()` seems have been refactored, but the modules that call it don't seem to have been refactored.

This small change fixes that.