### PR TITLE
Fix files.sync exclude dir multiple

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -464,8 +464,8 @@ def sync(
         remote_dirpath = dirpath.replace(src, '')
 
         # Filter excluded dirs
-        for child_dir in dirnames:
-            child_path = os_path.join(remote_dirpath, child_dir)
+        for child_dir in dirnames[:]:
+            child_path = os_path.normpath(os_path.join(remote_dirpath, child_dir))
             if exclude_dir and any(fnmatch(child_path, match) for match in exclude_dir):
                 dirnames.remove(child_dir)
 

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -433,6 +433,15 @@ def sync(
             src='files/tempdir',
             dest='/tmp/tempdir',
         )
+
+    Note: ``exclude`` and ``exclude_dir`` use ``fnmatch`` behind the scenes to do the filtering.
+
+    + ``exclude`` matches against the filename.
+    + ``exclude_dir`` matches against the path of the directory, relative to ``src``.
+      Since fnmatch does not treat path separators (``/`` or ``\\``) as special characters,
+      excluding all directories matching a given name, however deep under ``src`` they are,
+      can be done for example with ``exclude_dir=["__pycache__", "*/__pycache__"]``
+
     '''
     original_src = src  # Keep a copy to reference in errors
     src = os_path.normpath(src)

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -479,16 +479,12 @@ def sync(
             if exclude and any(fnmatch(full_filename, match) for match in exclude):
                 continue
 
-            put_files.append((
-                # Join local as normal (unix, win)
-                full_filename,
-                # Join remote as unix like
-                unix_path_join(*[
-                    item for item in
-                    (dest, remote_dirpath, filename)
-                    if item
-                ]),
-            ))
+            remote_full_filename = unix_path_join(*[
+                item for item in
+                (dest, remote_dirpath, filename)
+                if item
+            ])
+            put_files.append((full_filename, remote_full_filename))
 
     # Ensure the destination directory - if the destination is a link, ensure
     # the link target is a directory.

--- a/tests/operations/files.get/create_directory.json
+++ b/tests/operations/files.get/create_directory.json
@@ -9,7 +9,7 @@
         }
     },
     "directories": {
-        "/somedir/": {}
+        "/somedir": {}
     },
     "commands": [
         ["download", "/home/somefile.txt", "/somedir/somefile.txt"]

--- a/tests/operations/files.get/different_remote.json
+++ b/tests/operations/files.get/different_remote.json
@@ -1,6 +1,11 @@
 {
     "args": ["/home/somefile.txt", "somefile.txt"],
-    "files": ["/somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/somefile.txt": {

--- a/tests/operations/files.put/change_mode_owner.json
+++ b/tests/operations/files.put/change_mode_owner.json
@@ -5,7 +5,12 @@
         "group": "another-testgroup",
         "mode": 644
     },
-    "files": ["somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/somefile.txt": {

--- a/tests/operations/files.put/change_mode_owner_with_spaces.json
+++ b/tests/operations/files.put/change_mode_owner_with_spaces.json
@@ -5,7 +5,12 @@
         "group": "another-testgroup",
         "mode": 644
     },
-    "files": ["some file.txt"],
+    "local_files": {
+        "files": {
+            "some file.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/some file.txt": {

--- a/tests/operations/files.put/create_directory.json
+++ b/tests/operations/files.put/create_directory.json
@@ -5,7 +5,12 @@
         "group": "testgroup",
         "create_remote_dir": true
     },
-    "files": ["somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/somefile.txt": null

--- a/tests/operations/files.put/different_remote.json
+++ b/tests/operations/files.put/different_remote.json
@@ -5,7 +5,12 @@
         "group": "testgroup",
         "mode": 644
     },
-    "files": ["somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/somefile.txt": {

--- a/tests/operations/files.put/no_change.json
+++ b/tests/operations/files.put/no_change.json
@@ -1,6 +1,11 @@
 {
     "args": ["somefile.txt", "/home/somefile.txt"],
-    "files": ["somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/somefile.txt": true

--- a/tests/operations/files.put/no_remote.json
+++ b/tests/operations/files.put/no_remote.json
@@ -5,7 +5,12 @@
         "group": "testgroup",
         "mode": 644
     },
-    "files": ["somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/somefile.txt": null

--- a/tests/operations/files.put/path_with_spaces.json
+++ b/tests/operations/files.put/path_with_spaces.json
@@ -1,6 +1,11 @@
 {
     "args": ["somefile.txt", "/home/some file.txt"],
-    "files": ["somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/some\\ file.txt": null

--- a/tests/operations/files.put/path_with_spaces_already_escaped.json
+++ b/tests/operations/files.put/path_with_spaces_already_escaped.json
@@ -1,6 +1,11 @@
 {
     "args": ["somefile.txt", "/home/some\\ file.txt"],
-    "files": ["somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/some\\ file.txt": null

--- a/tests/operations/files.put/upload_to_directory.json
+++ b/tests/operations/files.put/upload_to_directory.json
@@ -5,7 +5,12 @@
         "group": "testgroup",
         "mode": 644
     },
-    "files": ["somefile.txt"],
+    "local_files": {
+        "files": {
+            "somefile.txt": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/somefile.txt": null

--- a/tests/operations/files.sync/sync_delete_posix.json
+++ b/tests/operations/files.sync/sync_delete_posix.json
@@ -12,7 +12,7 @@
         "/somedir/underthat/yet-another-file.txt"
     ],
     "directories": {
-        "/somedir/": {
+        "/somedir": {
             "files": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
             "dirs": ["underthat", "__pycache__"]
         },

--- a/tests/operations/files.sync/sync_delete_posix.json
+++ b/tests/operations/files.sync/sync_delete_posix.json
@@ -6,21 +6,30 @@
         "exclude": "*.pyc",
         "exclude_dir": "__pycache__"
     },
-    "files": [
-        "/somedir/somefile.txt",
-        "/somedir/anotherfile.txt",
-        "/somedir/underthat/yet-another-file.txt"
-    ],
-    "directories": {
-        "/somedir": {
-            "files": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
-            "dirs": ["underthat", "__pycache__"]
-        },
-        "/somedir/underthat": {
-            "files": ["yet-another-file.txt"]
-        },
-        "/somedir/__pycache__": {
-            "files": ["nope"]
+    "local_files": {
+        "files": {},
+        "dirs": {
+            "somedir": {
+                "files": {
+                    "somefile.txt": null,
+                    "anotherfile.txt": null,
+                    "thing.pyc": null
+                },
+                "dirs": {
+                    "underthat": {
+                        "files": {
+                            "yet-another-file.txt": null
+                        },
+                        "dirs": {}
+                    },
+                    "__pycache__": {
+                        "files": {
+                            "nope": null
+                        },
+                        "dirs": {}
+                    }
+                }
+            }
         }
     },
     "facts": {

--- a/tests/operations/files.sync/sync_delete_windows.json
+++ b/tests/operations/files.sync/sync_delete_windows.json
@@ -6,21 +6,30 @@
         "exclude": "*.pyc",
         "exclude_dir": "__pycache__"
     },
-    "files": [
-        "\\somedir\\somefile.txt",
-        "\\somedir\\anotherfile.txt",
-        "\\somedir\\underthat\\yet-another-file.txt"
-    ],
-    "directories": {
-        "\\somedir\\": {
-            "files": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
-            "dirs": ["underthat", "__pycache__"]
-        },
-        "\\somedir\\underthat": {
-            "files": ["yet-another-file.txt"]
-        },
-        "\\somedir\\__pycache__": {
-            "files": ["nope"]
+    "local_files": {
+        "files": {},
+        "dirs": {
+            "somedir": {
+                "files": {
+                    "somefile.txt": null,
+                    "anotherfile.txt": null,
+                    "thing.pyc": null
+                },
+                "dirs": {
+                    "underthat": {
+                        "files": {
+                            "yet-another-file.txt": null
+                        },
+                        "dirs": {}
+                    },
+                    "__pycache__": {
+                        "files": {
+                            "nope": null
+                        },
+                        "dirs": {}
+                    }
+                }
+            }
         }
     },
     "facts": {

--- a/tests/operations/files.sync/sync_destination_link.json
+++ b/tests/operations/files.sync/sync_destination_link.json
@@ -5,27 +5,37 @@
         "exclude": "*.pyc",
         "exclude_dir": "__pycache__"
     },
-    "files": [
-        "/somedir/somefile.txt",
-        "/somedir/anotherfile.txt",
-        "/somedir/underthat/yet-another-file.txt",
-        "/somedir/__pycache__/nope",
-        "/somedir/__pycache__/ignore_this/nope_again"
-    ],
-    "directories": {
-        "/somedir/": {
-            "files": ["somefile.txt", "anotherfile.txt", "thing.pyc"],
-            "dirs": ["underthat", "__pycache__"]
-        },
-        "/somedir/underthat": {
-            "files": ["yet-another-file.txt"]
-        },
-        "/somedir/__pycache__": {
-            "files": ["nope"],
-            "dirs": ["ignore_this"]
-        },
-        "/somedir/__pycache__/ignore_this": {
-            "files": ["nope_again"]
+    "local_files": {
+        "files": {},
+        "dirs": {
+            "somedir": {
+                "files": {
+                    "somefile.txt": null,
+                    "anotherfile.txt": null,
+                    "thing.pyc": null
+                },
+                "dirs": {
+                    "underthat": {
+                        "files": {
+                            "yet-another-file.txt": null
+                        },
+                        "dirs": {}
+                    },
+                    "__pycache__": {
+                        "files": {
+                            "nope": null
+                        },
+                        "dirs": {
+                            "ignore_this": {
+                                "files": {
+                                    "nope_again": null
+                                },
+                                "dirs": {}
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "facts": {

--- a/tests/operations/files.sync/sync_exclude_multiple.json
+++ b/tests/operations/files.sync/sync_exclude_multiple.json
@@ -3,7 +3,7 @@
     "args": ["/somedir", "/home/somedir"],
     "kwargs": {
         "exclude": ["*.pyc", "*.log"],
-        "exclude_dir": ["__pycache__", ".git"]
+        "exclude_dir": ["__pycache__", "*/__pycache__", ".git"]
     },
     "local_files": {
         "files": {},

--- a/tests/operations/files.sync/sync_exclude_multiple.json
+++ b/tests/operations/files.sync/sync_exclude_multiple.json
@@ -1,0 +1,97 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["/somedir", "/home/somedir"],
+    "kwargs": {
+        "exclude": ["*.pyc", "*.log"],
+        "exclude_dir": ["__pycache__", ".git"]
+    },
+    "local_files": {
+        "files": {},
+        "dirs": {
+            "somedir": {
+                "files": {
+                    "somefile.txt": null,
+                    "build.log": null,
+                    "local_ignore.pyc": null
+                },
+                "dirs": {
+                    "__pycache__": {
+                        "files": {
+                            "nope": null
+                        },
+                        "dirs": {
+                            "ignore_this": {
+                                "files": {
+                                    "nope_again": null
+                                },
+                                "dirs": {}
+                            }
+                        }
+                    },
+                    ".git": {
+                        "files": {
+                            "ignore_too": null
+                        },
+                        "dirs": {}
+                    },
+                    "underthat": {
+                        "files": {
+                            "another_file.txt": null,
+                            "script_output.log": null,
+                            "script.pyc": null
+                        },
+                        "dirs": {
+                            "__pycache__": {
+                                "files": {},
+                                "dirs": {
+                                    "dont_want_this": {
+                                        "files": {
+                                            "still_no": null
+                                        },
+                                        "dirs": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "facts": {
+        "files.File": {
+            "path=/home/somedir/somefile.txt": null,
+            "path=/home/somedir/build.log": null,
+            "path=/home/somedir/local_ignore.pyc": null,
+            "path=/home/somedir/deleteme.txt": true,
+            "path=/home/somedir/nodelete.pyc": {"mode": 644},
+            "path=/home/somedir/underthat/another_file.txt": null
+        },
+        "files.Directory": {
+            "path=/home/somedir": {
+                "mode": 755
+            },
+            "path=/home/somedir/underthat": null
+        },
+        "files.FindFiles": {
+            "path=/home/somedir": [
+                "/home/somedir/deleteme.txt",
+                "/home/somedir/nodelete.pyc"
+            ],
+            "path=/home/somedir/underthat": []
+        },
+        "files.Link": {}
+    },
+    "commands": [
+        "mkdir -p /home/somedir/underthat",
+        "chmod 755 /home/somedir/underthat",
+        ["upload", "/somedir/somefile.txt", "/home/somedir/somefile.txt"],
+        "chmod 644 /home/somedir/somefile.txt",
+        [
+            "upload", "/somedir/underthat/another_file.txt",
+            "/home/somedir/underthat/another_file.txt"
+        ],
+        "chmod 644 /home/somedir/underthat/another_file.txt"
+    ],
+    "idempotent": false
+}

--- a/tests/operations/files.sync/sync_no_destination_exist.json
+++ b/tests/operations/files.sync/sync_no_destination_exist.json
@@ -1,0 +1,55 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["/somedir", "/home/somedir"],
+    "local_files": {
+        "files": {},
+        "dirs": {
+            "somedir": {
+                "files": {
+                    "somefile.txt": null
+                },
+                "dirs": {
+                    "underthat": {
+                        "files": {
+                            "another-file.txt": null
+                        },
+                        "dirs": {}
+                    }
+                }
+            }
+        }
+    },
+    "facts": {
+        "files.File": {
+            "path=/home/somedir/somefile.txt": null,
+            "path=/home/somedir/underthat/another-file.txt": null
+        },
+        "files.Directory": {
+            "path=/home/somedir": null,
+            "path=/home/somedir/underthat": null
+        },
+        "files.FindFiles": {
+            "path=/home/somedir": [],
+            "path=/home/somedir/underthat": []
+        },
+        "files.Link": {},
+        "files.Sha1File": {
+            "path=/home/somedir/somefile.txt": "ac2cd59a622114712b5b21081763c54bf0caacb8"
+        }
+    },
+    "commands": [
+        "mkdir -p /home/somedir",
+        "chmod 755 /home/somedir",
+        "mkdir -p /home/somedir/underthat",
+        "chmod 755 /home/somedir/underthat",
+        ["upload", "/somedir/somefile.txt", "/home/somedir/somefile.txt"],
+        "chmod 644 /home/somedir/somefile.txt",
+        [
+            "upload",
+            "/somedir/underthat/another-file.txt",
+            "/home/somedir/underthat/another-file.txt"
+        ],
+        "chmod 644 /home/somedir/underthat/another-file.txt"
+    ],
+    "idempotent": false
+}

--- a/tests/operations/files.sync/sync_no_local_exist_posix.json
+++ b/tests/operations/files.sync/sync_no_local_exist_posix.json
@@ -11,6 +11,6 @@
     },
     "exception": {
         "names": ["OSError", "IOError"],
-        "message": "No such directory: /i-do-not-exist/"
+        "message": "No such directory: /i-do-not-exist"
     }
 }

--- a/tests/operations/files.sync/sync_no_local_exist_windows.json
+++ b/tests/operations/files.sync/sync_no_local_exist_windows.json
@@ -11,6 +11,6 @@
     },
     "exception": {
         "names": ["OSError", "IOError"],
-        "message": "No such directory: \\i-do-not-exist\\"
+        "message": "No such directory: \\i-do-not-exist"
     }
 }

--- a/tests/operations/files.sync/sync_partial_exists.json
+++ b/tests/operations/files.sync/sync_partial_exists.json
@@ -1,18 +1,23 @@
 {
     "require_platform": ["Darwin", "Linux"],
     "args": ["/somedir/", "/home/somedir"],
-    "files": [
-        "/somedir/somefile.txt",
-        "/somedir/anotherfile.txt",
-        "/somedir/underthat/yet-another-file.txt"
-    ],
-    "directories": {
-        "/somedir": {
-            "files": ["somefile.txt", "anotherfile.txt"],
-            "dirs": ["underthat"]
-        },
-        "/somedir/underthat": {
-            "files": ["yet-another-file.txt"]
+    "local_files": {
+        "files": {},
+        "dirs": {
+            "somedir": {
+                "files": {
+                    "somefile.txt": null,
+                    "anotherfile.txt": null
+                },
+                "dirs": {
+                    "underthat": {
+                        "files": {
+                            "yet-another-file.txt": null
+                        },
+                        "dirs": {}
+                    }
+                }
+            }
         }
     },
     "facts": {

--- a/tests/operations/files.sync/sync_partial_exists.json
+++ b/tests/operations/files.sync/sync_partial_exists.json
@@ -7,7 +7,7 @@
         "/somedir/underthat/yet-another-file.txt"
     ],
     "directories": {
-        "/somedir/": {
+        "/somedir": {
             "files": ["somefile.txt", "anotherfile.txt"],
             "dirs": ["underthat"]
         },

--- a/tests/operations/files.sync/sync_special_chars.json
+++ b/tests/operations/files.sync/sync_special_chars.json
@@ -5,7 +5,7 @@
         "/somedir/yet () another {} file $$ __.txt"
     ],
     "directories": {
-        "/somedir/": {
+        "/somedir": {
             "files": ["yet () another {} file $$ __.txt"]
         }
     },

--- a/tests/operations/files.sync/sync_special_chars.json
+++ b/tests/operations/files.sync/sync_special_chars.json
@@ -1,12 +1,15 @@
 {
     "require_platform": ["Darwin", "Linux"],
     "args": ["/somedir/", "/home/somedir"],
-    "files": [
-        "/somedir/yet () another {} file $$ __.txt"
-    ],
-    "directories": {
-        "/somedir": {
-            "files": ["yet () another {} file $$ __.txt"]
+    "local_files": {
+        "files": {},
+        "dirs": {
+            "somedir": {
+                "files": {
+                    "yet () another {} file $$ __.txt": null
+                },
+                "dirs": {}
+            }
         }
     },
     "facts": {

--- a/tests/operations/files.template/invalid_template_syntax.json
+++ b/tests/operations/files.template/invalid_template_syntax.json
@@ -5,9 +5,12 @@
         "group": "testgroup",
         "mode": 644
     },
-    "files": [
-        ["brokenfile.txt.j2", "{% forr something in something %}{% endfor %}"]
-    ],
+    "local_files": {
+        "files": {
+            "brokenfile.txt.j2": "{% forr something in something %}{% endfor %}"
+        },
+        "dirs": {}
+    },
     "exception": {
         "name": "OperationError",
         "message": "Error in template: /brokenfile.txt.j2 (L1): Encountered unknown tag 'forr'.\n...\n{%\nforr\n..."

--- a/tests/operations/files.template/no_remote.json
+++ b/tests/operations/files.template/no_remote.json
@@ -5,7 +5,12 @@
         "group": "testgroup",
         "mode": 644
     },
-    "files": ["somefile.txt.j2"],
+    "local_files": {
+        "files": {
+            "somefile.txt.j2": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=/home/somefile.txt.j2": null

--- a/tests/operations/files.template/undefined_template_variable.json
+++ b/tests/operations/files.template/undefined_template_variable.json
@@ -5,9 +5,12 @@
         "group": "testgroup",
         "mode": 644
     },
-    "files": [
-        ["brokenfile.txt.j2", "{{ something_does_not_exist }}"]
-    ],
+    "local_files": {
+        "files": {
+            "brokenfile.txt.j2": "{{ something_does_not_exist }}"
+        },
+        "dirs": {}
+    },
     "exception": {
         "name": "OperationError",
         "message": "Error in template: /brokenfile.txt.j2 (L1): 'something_does_not_exist' is undefined\n...\n{{\nsomething_does_not_exist\n..."

--- a/tests/operations/server.script/upload_run.json
+++ b/tests/operations/server.script/upload_run.json
@@ -1,8 +1,11 @@
 {
     "args": ["somescript.sh"],
-    "files": [
-        "somescript.sh"
-    ],
+    "local_files": {
+        "files": {
+            "somescript.sh": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=_tempfile_": null

--- a/tests/operations/server.script_template/script.json
+++ b/tests/operations/server.script_template/script.json
@@ -1,6 +1,11 @@
 {
     "args": ["somefile.txt.j2"],
-    "files": ["somefile.txt.j2"],
+    "local_files": {
+        "files": {
+            "somefile.txt.j2": null
+        },
+        "dirs": {}
+    },
     "facts": {
         "files.File": {
             "path=_tempfile_": null

--- a/tests/operations/server.user/key_files.json
+++ b/tests/operations/server.user/key_files.json
@@ -4,10 +4,13 @@
         "home": "homedir",
         "public_keys": ["abc", "somefile.pub", "anotherfile.pub"]
     },
-    "files": [
-        ["somefile.pub", "somekeydata"],
-        ["anotherfile.pub", "someotherkeydata"]
-    ],
+    "local_files": {
+        "files": {
+            "somefile.pub": "somekeydata",
+            "anotherfile.pub": "someotherkeydata"
+        },
+        "dirs": {}
+    },
     "facts": {
         "server.Users": {
             "someuser": {

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -121,7 +121,11 @@ def make_operation_tests(arg):
             kwargs['state'] = self.state
             kwargs['host'] = host
 
-            with patch_files(test_data.get('files', []), test_data.get('directories', [])):
+            with patch_files(
+                    test_data.get('files', []),
+                    test_data.get('directories', []),
+                    test_data.get('local_files'),
+            ):
                 try:
                     output_commands = unroll_generators(op._pyinfra_op(
                         *test_data.get('args', []),

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -121,11 +121,7 @@ def make_operation_tests(arg):
             kwargs['state'] = self.state
             kwargs['host'] = host
 
-            with patch_files(
-                    test_data.get('files', []),
-                    test_data.get('directories', []),
-                    test_data.get('local_files'),
-            ):
+            with patch_files(test_data.get('local_files', {})):
                 try:
                     output_commands = unroll_generators(op._pyinfra_op(
                         *test_data.get('args', []),

--- a/tests/util.py
+++ b/tests/util.py
@@ -236,11 +236,6 @@ class patch_files(object):
                 patch_directories,
             )
         else:
-            print(self._parse_files_and_directories(
-                patch_files,
-                patch_directories,
-            ))
-            print(self._parse_local_files(local_files))
             directories, files, files_data = self._parse_local_files(local_files)
 
         self._files = files

--- a/tests/util.py
+++ b/tests/util.py
@@ -242,6 +242,8 @@ class patch_files(object):
         files_data = {}
         directories = {}
 
+        prefix = path.normpath(prefix)
+
         for filename, file_data in local_files.get('files', {}).items():
             filepath = path.join(prefix, filename)
             files.append(filepath)

--- a/tests/util.py
+++ b/tests/util.py
@@ -230,9 +230,20 @@ class FakeFile(object):
 
 class patch_files(object):
     def __init__(self, patch_files, patch_directories):
+        directories, files, files_data = self._parse_files_and_directories(
+            patch_files,
+            patch_directories,
+        )
+
+        self._files = files
+        self._files_data = files_data
+        self._directories = directories
+
+    @staticmethod
+    def _parse_files_and_directories(patch_files, patch_directories):
         files = []
         files_data = {}
-
+        directories = patch_directories
         for filename_data in patch_files:
             if isinstance(filename_data, list):
                 filename, data = filename_data
@@ -247,11 +258,7 @@ class patch_files(object):
 
             if data:
                 files_data[filename] = data
-
-        self._files = files
-        self._files_data = files_data
-
-        self._directories = patch_directories
+        return directories, files, files_data
 
     def __enter__(self):
         self.patches = [

--- a/tests/util.py
+++ b/tests/util.py
@@ -248,10 +248,10 @@ class patch_files(object):
             if data:
                 files_data[filename] = data
 
-        self.files = files
-        self.files_data = files_data
+        self._files = files
+        self._files_data = files_data
 
-        self.directories = patch_directories
+        self._directories = patch_directories
 
     def __enter__(self):
         self.patches = [
@@ -275,24 +275,24 @@ class patch_files(object):
             patched.stop()
 
     def get_file(self, filename, *args):
-        if filename in self.files:
-            return FakeFile(filename, self.files_data.get(filename))
+        if filename in self._files:
+            return FakeFile(filename, self._files_data.get(filename))
 
         raise IOError('Missing FakeFile: {0}'.format(filename))
 
     def exists(self, filename, *args):
-        return filename in self.files or filename in self.directories
+        return filename in self._files or filename in self._directories
 
     def isfile(self, filename, *args):
-        return filename in self.files
+        return filename in self._files
 
     def isdir(self, dirname, *args):
-        return dirname in self.directories
+        return dirname in self._directories
 
     def stat(self, pathname):
-        if pathname in self.files:
+        if pathname in self._files:
             mode_int = 33188  # 644 file
-        elif pathname in self.directories:
+        elif pathname in self._directories:
             mode_int = 16877  # 755 directory
         else:
             raise IOError('No such file or directory: {0}'.format(pathname))
@@ -300,9 +300,9 @@ class patch_files(object):
         return os.stat_result((mode_int, 0, 0, 0, 0, 0, 0, 0, 0, 0))
 
     def walk(self, dirname, topdown=True, onerror=None, followlinks=False):
-        if dirname not in self.directories:
+        if dirname not in self._directories:
             return
-        dir_definition = self.directories[dirname]
+        dir_definition = self._directories[dirname]
         child_dirs = dir_definition.get('dirs', [])
         child_files = dir_definition.get('files', [])
 


### PR DESCRIPTION
This contains some fixing and clean-up of the `files.sync` operation, with most importantly:
* c43c1df + 278d1a8 -> Fixing handling of list in `exclude_dir` argument
* c41490d and 2b90e80 are 2 distinct solutions to handle excluding "sub-directories"

Discussion is needed around the solutions for excluding "sub-directories". To be more explicit, the question is:

What behaviour do we want when the deploy specifies `exclude_dir="__pycache__"` (for example)? Do we want this to be enough to exclude any directory with this name in the `src` tree, or only the one possibly present right under `src` directory? 

Note that a very similar question should apply to the `exclude=...` argument, in order to keep both arguments behaviour consistent. 