### PR TITLE
Use uname -m instead of -p for fact server.Arch

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -51,7 +51,9 @@ class Arch(FactBase):
     Returns the system architecture according to ``uname``.
     '''
 
-    command = 'uname -p'
+    # ``uname -p`` is not portable and returns ``unknown`` on Debian.
+    # ``uname -m`` works on most Linux and BSD systems.
+    command = 'uname -m'
 
 
 class Command(FactBase):


### PR DESCRIPTION
since uname -m is more portable than uname -p.