### PR TITLE
docker fact: fix exception on unexisting container/image/network

### DIFF
--- a/pyinfra/facts/docker.py
+++ b/pyinfra/facts/docker.py
@@ -53,7 +53,7 @@ class DockerNetworks(DockerFactBase):
 
 class DockerSingleMixin(DockerFactBase):
     def command(self, object_id):
-        return 'docker {0} inspect {1}'.format(
+        return 'docker {0} inspect {1} 2>&- || true'.format(
             self.docker_type, object_id,
         )
 

--- a/tests/facts/docker.DockerContainer/container.json
+++ b/tests/facts/docker.DockerContainer/container.json
@@ -1,6 +1,6 @@
 {
     "arg": "myid",
-    "command": "docker container inspect myid",
+    "command": "docker container inspect myid 2>&- || true",
     "requires_command": "docker",
     "output": [
         "{\"hello\": \"world\"}"


### PR DESCRIPTION
*Fix https://github.com/Fizzadar/pyinfra/issues/684*

Checking fact for an unexisting container/image/network will raise an exception. Shell commands runned to inspect item is exiting with status 1, making it invalid.

This fix allow having the runned command exiting with status 0 and an empty list generated by `docker (image|container|network) inspect`as stdout.