### PR TITLE
Using `group=group or user` instead of `group=user` in operations.server.user

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -936,7 +936,7 @@ def user(
     if ensure_home:
         yield files.directory(
             home,
-            user=user, group=user,
+            user=user, group=group or user,
             state=state, host=host,
         )
 
@@ -964,7 +964,7 @@ def user(
         yield files.directory(
             '{0}/.ssh'.format(home),
             user=user,
-            group=user,
+            group=group or user,
             mode=700,
             state=state,
             host=host,
@@ -983,7 +983,7 @@ def user(
                 src=keys_file,
                 dest=filename,
                 user=user,
-                group=user,
+                group=group or user,
                 mode=600,
                 state=state,
                 host=host,
@@ -994,7 +994,7 @@ def user(
             yield files.file(
                 path=filename,
                 user=user,
-                group=user,
+                group=group or user,
                 mode=600,
                 state=state,
                 host=host,

--- a/tests/operations/server.user/add.json
+++ b/tests/operations/server.user/add.json
@@ -19,6 +19,6 @@
     "commands": [
         "grep 'someuser:' /etc/passwd || useradd -d homedir -s shellbin -g mygroup -G secondary_group,another -r --uid 1000 -c 'Full Name' someuser",
         "mkdir -p homedir",
-        "chown someuser:someuser homedir"
+        "chown someuser:mygroup homedir"
     ]
 }

--- a/tests/operations/server.user/edit.json
+++ b/tests/operations/server.user/edit.json
@@ -22,11 +22,11 @@
         "files.Directory": {
             "path=/home/someuser": {
                 "user": "someuser",
-                "group": "someuser"
+                "group": "somegroup"
             },
             "path=/home/someotheruser": {
                 "user": "someuser",
-                "group": "someuser"
+                "group": "somegroup"
             }
         }
     },


### PR DESCRIPTION
Here's a simple (probably even naïve) fix to this particular issue.