### PR TITLE
Unconditionally add os.getcwd() into sys.path

### DIFF
--- a/pyinfra_cli/main.py
+++ b/pyinfra_cli/main.py
@@ -289,6 +289,9 @@ def _main(
     init_virtualenv()
 
     cwd = getcwd()
+    # Unconditionally adding cwd into sys.path
+    sys.path.append(cwd)
+
     deploy_dir = cwd
     potential_deploy_dirs = []
 
@@ -322,7 +325,8 @@ def _main(
         logger.debug('Deploy directory remains as cwd')
 
     # Make sure imported files (deploy.py/etc) behave as if imported from the cwd
-    sys.path.append(deploy_dir)
+    if not deploy_dir in sys.path:
+        sys.path.append(deploy_dir)
 
     # Create an empty/unitialised state object
     state = State()

--- a/pyinfra_cli/main.py
+++ b/pyinfra_cli/main.py
@@ -325,7 +325,7 @@ def _main(
         logger.debug('Deploy directory remains as cwd')
 
     # Make sure imported files (deploy.py/etc) behave as if imported from the cwd
-    if not deploy_dir in sys.path:
+    if deploy_dir not in sys.path:
         sys.path.append(deploy_dir)
 
     # Create an empty/unitialised state object


### PR DESCRIPTION
This commit contains a quick fix for relative Python imports from the top-level project directory.
It simply unconditionally adds os.getcwd() into sys.path right at the beginning, while still allowing deploy_dir to override things later, if necessary.

This commit doesn't fix relative paths for files, like templates, locally referenced deploys/tasks etc. Looks like this functionality needs to be completely revisited, along with merging data from multiple levels of group_data (both top-level and inventory-level).