### PR TITLE
Using `grep '^{0}:'` instead of `grep '{0}:'` for group/user lookup

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -770,7 +770,7 @@ def group(group, present=True, system=False, gid=None, state=None, host=None):
 
         # Groups are often added by other operations (package installs), so check
         # for the group at runtime before adding.
-        yield "grep -E '^{0}:' /etc/group || groupadd {1}".format(
+        yield "grep '^{0}:' /etc/group || groupadd {1}".format(
             group,
             ' '.join(args),
         )
@@ -883,7 +883,7 @@ def user(
 
         # Users are often added by other operations (package installs), so check
         # for the user at runtime before adding.
-        yield "grep -E '^{1}:' /etc/passwd || useradd {0} {1}".format(
+        yield "grep '^{1}:' /etc/passwd || useradd {0} {1}".format(
             ' '.join(args),
             user,
         )

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -770,7 +770,7 @@ def group(group, present=True, system=False, gid=None, state=None, host=None):
 
         # Groups are often added by other operations (package installs), so check
         # for the group at runtime before adding.
-        yield "grep '{0}:' /etc/group || groupadd {1}".format(
+        yield "grep -E '^{0}:' /etc/group || groupadd {1}".format(
             group,
             ' '.join(args),
         )
@@ -883,7 +883,7 @@ def user(
 
         # Users are often added by other operations (package installs), so check
         # for the user at runtime before adding.
-        yield "grep '{1}:' /etc/passwd || useradd {0} {1}".format(
+        yield "grep -E '^{1}:' /etc/passwd || useradd {0} {1}".format(
             ' '.join(args),
             user,
         )

--- a/tests/operations/server.group/add.json
+++ b/tests/operations/server.group/add.json
@@ -9,6 +9,6 @@
         "server.Os": "Linux"
     },
     "commands": [
-        "grep 'somegroup:' /etc/group || groupadd -r somegroup --gid 1000"
+        "grep '^somegroup:' /etc/group || groupadd -r somegroup --gid 1000"
     ]
 }

--- a/tests/operations/server.user/add.json
+++ b/tests/operations/server.user/add.json
@@ -17,7 +17,7 @@
         "server.Os": "Linux"
     },
     "commands": [
-        "grep 'someuser:' /etc/passwd || useradd -d homedir -s shellbin -g mygroup -G secondary_group,another -r --uid 1000 -c 'Full Name' someuser",
+        "grep '^someuser:' /etc/passwd || useradd -d homedir -s shellbin -g mygroup -G secondary_group,another -r --uid 1000 -c 'Full Name' someuser",
         "mkdir -p homedir",
         "chown someuser:someuser homedir"
     ]

--- a/tests/operations/server.user/add_non_unique.json
+++ b/tests/operations/server.user/add_non_unique.json
@@ -8,6 +8,6 @@
         "server.Users": {}
     },
     "commands": [
-        "grep 'someuser:' /etc/passwd || useradd -d /home/someuser -o someuser"
+        "grep '^someuser:' /etc/passwd || useradd -d /home/someuser -o someuser"
     ]
 }


### PR DESCRIPTION
This commit contains a fix for a regular expression that is used in group/user lookup in group/user create operations.
NB: while this will work fine in the vast majority of cases, the particular applicability of `-E` flag might need to be discussed.
