### PR TITLE
Use best practice to check empty output

### DIFF
--- a/pyinfra/facts/windows_files.py
+++ b/pyinfra/facts/windows_files.py
@@ -60,7 +60,7 @@ class WindowsSha1File(FactBase):
         ).format(name)
 
     def process(self, output):
-        return output[0] if len(output[0]) > 0 else None
+        return output[0] if not output else None
 
 
 class WindowsSha256File(FactBase):


### PR DESCRIPTION
It is a Python best practice to use 'if not val' to check if container is empty.