### PR TITLE
apt: add dist_upgrade operation

### DIFF
--- a/pyinfra/operations/apt.py
+++ b/pyinfra/operations/apt.py
@@ -354,6 +354,23 @@ _upgrade = upgrade  # noqa: E305 (for use below where update is a kwarg)
 
 
 @operation
+def dist_upgrade(state, host):
+    '''
+    Updates all apt packages, employing dist-upgrade.
+
+    Example:
+
+    .. code:: python
+
+        apt.dist_upgrade(
+            name='Upgrade apt packages using dist-upgrade',
+        )
+    '''
+
+    yield noninteractive_apt('dist-upgrade')
+
+
+@operation
 def packages(
     packages=None, present=True, latest=False,
     update=False, cache_time=None, upgrade=False,


### PR DESCRIPTION
Sometimes, just `apt-get upgrade` is not enough, e.g. when upgrading the kernel.

Tested that it does what it says:

```
Dec 09 13:33:29 de-fra0 sudo[15904]: sysadmin : PWD=/home/sysadmin ; USER=root ; COMMAND=/usr/bin/sh -c DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
```