### PR TITLE
Prefix global arguments

### DIFF
--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -1,6 +1,9 @@
 Global Arguments
 ================
 
-In addition to each operations having its own arguments, there are a number of keyword arguments available for all operations:
+In addition to each operations having its own arguments, there are a number of keyword arguments available in all operations and deploys.
+
+.. note::
+    With the exception of ``name`` these are prefixed with ``_`` to avoid clashes with other operation and deploy arguments.
 
 .. include:: _deploy_globals.rst

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -1,0 +1,6 @@
+Global Arguments
+================
+
+In addition to each operations having its own arguments, there are a number of keyword arguments available for all operations:
+
+.. include:: _deploy_globals.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,15 +38,19 @@ Deploy Reference
 
 .. compound::
     :doc:`facts`
-        A list of all facts ``pyinfra`` can gather from hosts, e.g. ``server.Hostname``.
+        A list of all facts (data) ``pyinfra`` can gather from hosts, e.g. ``server.Hostname``.
 
 .. compound::
-    :doc:`examples`
-        A set of documented example deploys highlighting common patterns.
+    :doc:`arguments`
+        Arguments available in all operations & facts such as ``_sudo``, ``_serial`` and ``_env``.
 
 .. compound::
     :doc:`connectors`
-        Connectors allow ``pyinfra`` to seamlessly integrate with other tools.
+        Connectors deploy to different target hosts such as ``SSH``, ``Docker`` and local.
+
+.. compound::
+    :doc:`examples`
+        A set of documented example deploys that focus on common patterns and use-cases.
 
 
 How pyinfra Works
@@ -54,11 +58,11 @@ How pyinfra Works
 
 .. compound::
     :doc:`deploy_process`
-        Learn how ``pyinfra`` executes operations.
+        Learn how ``pyinfra`` executes operations against target hosts.
 
 .. compound::
     :doc:`api/connectors`
-        Build connectors to integrate ``pyinfra`` with other systems.
+        Build connectors to integrate ``pyinfra`` with other systems/tools/targets.
 
 .. compound::
     :doc:`api/operations`
@@ -93,8 +97,9 @@ How pyinfra Works
 
     operations
     facts
-    examples
+    arguments
     connectors
+    examples
 
 .. toctree::
     :hidden:

--- a/pyinfra/api/arguments.py
+++ b/pyinfra/api/arguments.py
@@ -4,39 +4,39 @@ from .util import get_call_location, memoize
 
 
 auth_kwargs = {
-    'sudo': {
+    '_sudo': {
         'description': 'Execute/apply any changes with ``sudo``.',
         'default': lambda config: config.SUDO,
     },
-    'sudo_user': {
+    '_sudo_user': {
         'description': 'Execute/apply any changes with ``sudo`` as a non-root user.',
         'default': lambda config: config.SUDO_USER,
     },
-    'use_sudo_login': {
+    '_use_sudo_login': {
         'description': 'Execute ``sudo`` with a login shell.',
         'default': lambda config: config.USE_SUDO_LOGIN,
     },
-    'use_sudo_password': {
+    '_use_sudo_password': {
         'description': 'Whether to use a password with ``sudo`` (will ask).',
         'default': lambda config: config.USE_SUDO_PASSWORD,
     },
-    'preserve_sudo_env': {
+    '_preserve_sudo_env': {
         'description': 'Preserve the shell environment when using ``sudo``.',
         'default': lambda config: config.PRESERVE_SUDO_ENV,
     },
-    'su_user': {
+    '_su_user': {
         'description': 'Execute/apply any changes with ``su``.',
         'default': lambda config: config.SU_USER,
     },
-    'use_su_login': {
+    '_use_su_login': {
         'description': 'Execute ``su`` with a login shell.',
         'default': lambda config: config.USE_SU_LOGIN,
     },
-    'preserve_su_env': {
+    '_preserve_su_env': {
         'description': 'Preserve the shell environment when using ``su``.',
         'default': lambda config: config.PRESERVE_SU_ENV,
     },
-    'su_shell': {
+    '_su_shell': {
         'description': (
             'Use this shell (instead of user login shell) when using ``su``). '
             'Only available under Linux, for use when using `su` with a user that '
@@ -44,11 +44,11 @@ auth_kwargs = {
         ),
         'default': lambda config: config.SU_SHELL,
     },
-    'doas': {
+    '_doas': {
         'description': 'Execute/apply any changes with ``doas``.',
         'defailt': lambda config: config.DOAS,
     },
-    'doas_user': {
+    '_doas_user': {
         'description': 'Execute/apply any changes with ``doas`` as a non-root user.',
         'default': lambda config: config.DOAS_USER,
     },
@@ -56,58 +56,64 @@ auth_kwargs = {
 
 
 def generate_env(config, value):
+    if value is None:
+        return config.ENV
+
+    if not isinstance(value, dict):
+        raise TypeError('Invalid env value, requires dictionary: {0}'.format(value))
+
     env = config.ENV.copy()
-    if value:
-        env.update(value)
+    env.update(value)
     return env
 
 
 shell_kwargs = {
-    'shell_executable': {
+    '_shell_executable': {
         'description': 'The shell to use. Defaults to ``sh`` (Unix) or ``cmd`` (Windows).',
         'default': lambda config: config.SHELL,
     },
-    'chdir': {
+    '_chdir': {
         'description': 'Directory to switch to before executing the command.',
     },
-    'env': {
+    '_env': {
         'description': 'Dictionary of environment variables to set.',
         'handler': generate_env,
     },
-    'success_exit_codes': {
+    '_success_exit_codes': {
         'description': 'List of exit codes to consider a success.',
         'default': lambda config: [0],
     },
-    'timeout': 'Timeout for *each* command executed during the operation.',
-    'get_pty': 'Whether to get a pseudoTTY when executing any commands.',
-    'stdin': 'String or buffer to send to the stdin of any commands.',
+    '_timeout': 'Timeout for *each* command executed during the operation.',
+    '_get_pty': 'Whether to get a pseudoTTY when executing any commands.',
+    '_stdin': 'String or buffer to send to the stdin of any commands.',
 }
 
 meta_kwargs = {
+    # NOTE: name is the only non-_-prefixed argument
     'name': {
         'description': 'Name of the operation.',
     },
-    'ignore_errors': {
+    '_ignore_errors': {
         'description': 'Ignore errors when executing the operation.',
         'default': lambda config: config.IGNORE_ERRORS,
     },
-    'precondition': 'Command to execute & check before the operation commands begin.',
-    'postcondition': 'Command to execute & check after the operation commands complete.',
-    'on_success': 'Callback function to execute on success.',
-    'on_error': 'Callback function to execute on error.',
+    '_precondition': 'Command to execute & check before the operation commands begin.',
+    '_postcondition': 'Command to execute & check after the operation commands complete.',
+    '_on_success': 'Callback function to execute on success.',
+    '_on_error': 'Callback function to execute on error.',
 }
 
 # Execution kwargs are global - ie must be identical for every host
 execution_kwargs = {
-    'parallel': {
+    '_parallel': {
         'description': 'Run this operation in batches of hosts.',
         'default': lambda config: config.PARALLEL,
     },
-    'run_once': {
+    '_run_once': {
         'description': 'Only execute this operation once, on the first host to see it.',
         'default': lambda config: False,
     },
-    'serial': {
+    '_serial': {
         'description': 'Run this operation host by host, rather than in parallel.',
         'default': lambda config: False,
     },
@@ -121,23 +127,38 @@ OPERATION_KWARGS = {
 }
 
 
+def _get_internal_key(key):
+    if key.startswith('_'):
+        return key[1:]
+    return key
+
+
+@memoize
 def get_execution_kwarg_keys():
-    return list(execution_kwargs.keys())
+    return [_get_internal_key(key) for key in execution_kwargs.keys()]
 
 
 @memoize
 def get_executor_kwarg_keys():
     keys = set()
     keys.update(auth_kwargs.keys(), shell_kwargs.keys())
-    return list(keys)
+    return [_get_internal_key(key) for key in keys]
 
 
 @memoize
-def show_legacy_global_argument_warning(key, call_location):
+def show_legacy_argument_warning(key, call_location):
     logger.warning((
         '{0}:\n\tGlobal arguments should be prefixed "_", '
         'please us the `{1}` keyword argument in place of `{2}`.'
     ).format(call_location, '_{0}'.format(key), key))
+
+
+@memoize
+def show_legacy_argument_host_data_warning(key):
+    logger.warning((
+        'Global arguments should be prefixed "_", '
+        'please us the `host.data._{0}` keyword argument in place of `host.data.{0}`.'
+    ).format(key))
 
 
 def pop_global_op_kwargs(state, host, kwargs):
@@ -150,7 +171,14 @@ def pop_global_op_kwargs(state, host, kwargs):
     + From the config variables
 
     Note this function is only called directly in the @operation & @deploy decorator
-    wrappers which the user should pass global arguments prefixed "_".
+    wrappers which the user should pass global arguments prefixed "_". This is to
+    avoid any clashes with operation and deploy functions both internal and third
+    party.
+
+    This is a bit strange because internally pyinfra uses non-_-prefixed arguments,
+    and this function is responsible for the translation between the two.
+
+    TODO: is this wird-ness acceptable? Is it worth updating internal use to _prefix?
     '''
 
     meta_kwargs = state.deploy_kwargs or {}
@@ -169,30 +197,36 @@ def pop_global_op_kwargs(state, host, kwargs):
                 if default:
                     default = default(state.config)
 
-            # TODO: why is 'name' hard-coded as the only non-_-prefixed key
-            direct_key = '_{0}'.format(key) if key != 'name' else key
+            internal_key = _get_internal_key(key)
 
-            # TODO: do we support global arguments in host data w/ or w/o the _ prefix? Or both?
-            host_default = getattr(host.data, direct_key, None) or getattr(host.data, key, None)
-            if host_default is not None:
-                default = host_default
-
-            if direct_key in kwargs:
-                found_keys.append(key)
-                value = kwargs.pop(direct_key)
+            host_default = getattr(host.data, key, None)
 
             # COMPAT w/<v3
             # TODO: remove this additional check
-            elif key in kwargs:
-                show_legacy_global_argument_warning(key, get_call_location(frame_offset=2))
-                found_keys.append(key)
+            if host_default is None and internal_key != key:
+                host_default = getattr(host.data, internal_key, None)
+                if host_default is not None:
+                    show_legacy_argument_host_data_warning(internal_key)
+
+            if host_default is not None:
+                default = host_default
+
+            if key in kwargs:
+                found_keys.append(internal_key)
                 value = kwargs.pop(key)
 
+            # COMPAT w/<v3
+            # TODO: remove this additional check
+            elif internal_key in kwargs:
+                show_legacy_argument_warning(internal_key, get_call_location(frame_offset=2))
+                found_keys.append(internal_key)
+                value = kwargs.pop(internal_key)
+
             else:
-                value = meta_kwargs.get(key, default)
+                value = meta_kwargs.get(internal_key, default)
 
             if handler:
                 value = handler(state.config, value)
 
-            global_kwargs[key] = value
+            global_kwargs[internal_key] = value
     return global_kwargs, found_keys

--- a/pyinfra/api/command.py
+++ b/pyinfra/api/command.py
@@ -6,7 +6,7 @@ import six
 
 from six.moves import shlex_quote
 
-from .operation_kwargs import get_executor_kwarg_keys
+from .arguments import get_executor_kwarg_keys
 
 
 def make_formatted_string_command(string, *args, **kwargs):

--- a/pyinfra/api/deploy.py
+++ b/pyinfra/api/deploy.py
@@ -12,9 +12,9 @@ import pyinfra
 
 from pyinfra import host, logger, pseudo_host, pseudo_state, state
 
+from .arguments import pop_global_op_kwargs
 from .exceptions import PyinfraError
 from .host import Host
-from .operation_kwargs import pop_global_op_kwargs
 from .util import get_args_kwargs_spec, get_call_location, get_caller_frameinfo, memoize
 
 

--- a/pyinfra/api/facts.py
+++ b/pyinfra/api/facts.py
@@ -35,7 +35,7 @@ from pyinfra.api.util import (
 )
 from pyinfra.progress import progress_spinner
 
-from .operation_kwargs import get_executor_kwarg_keys
+from .arguments import get_executor_kwarg_keys
 
 
 # Index of snake_case facts -> CamelCase classes

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -17,10 +17,10 @@ import pyinfra
 from pyinfra import host, state
 from pyinfra import logger, pseudo_host, pseudo_state
 
+from .arguments import get_execution_kwarg_keys, pop_global_op_kwargs
 from .command import StringCommand
 from .exceptions import OperationValueError, PyinfraError
 from .host import Host
-from .operation_kwargs import get_execution_kwarg_keys, pop_global_op_kwargs
 from .util import (
     get_arg_value,
     get_args_kwargs_spec,

--- a/pyinfra/api/operations.py
+++ b/pyinfra/api/operations.py
@@ -19,13 +19,13 @@ import pyinfra
 from pyinfra import logger
 from pyinfra.progress import progress_spinner
 
+from .arguments import get_executor_kwarg_keys
 from .command import (
     FunctionCommand,
     PyinfraCommand,
     StringCommand,
 )
 from .exceptions import PyinfraError
-from .operation_kwargs import get_executor_kwarg_keys
 from .util import (
     format_exception,
     log_error_or_warning,

--- a/pyinfra/api/util.py
+++ b/pyinfra/api/util.py
@@ -91,8 +91,8 @@ def memoize(func):
     return wrapper
 
 
-def get_call_location():
-    frame = get_caller_frameinfo(frame_offset=1)  # escape *this* function
+def get_call_location(frame_offset=1):
+    frame = get_caller_frameinfo(frame_offset=frame_offset)  # escape *this* function
     return 'line {0} in {1}'.format(
         frame.lineno,
         path.relpath(frame.filename),

--- a/pyinfra/api/util.py
+++ b/pyinfra/api/util.py
@@ -93,10 +93,16 @@ def memoize(func):
 
 def get_call_location(frame_offset=1):
     frame = get_caller_frameinfo(frame_offset=frame_offset)  # escape *this* function
-    return 'line {0} in {1}'.format(
-        frame.lineno,
-        path.relpath(frame.filename),
-    )
+    relpath = frame.filename
+
+    try:
+        # On Windows if pyinfra is on a different drive to the filename here, this will
+        # error as there's no way to do relative paths between drives.
+        relpath = path.relpath(frame.filename)
+    except ValueError:
+        pass
+
+    return 'line {0} in {1}'.format(frame.lineno, relpath)
 
 
 def get_caller_frameinfo(frame_offset=0):

--- a/scripts/generate_global_kwargs_doc.py
+++ b/scripts/generate_global_kwargs_doc.py
@@ -3,7 +3,7 @@
 from os import path
 
 from pyinfra.api import Config
-from pyinfra.api.operation_kwargs import OPERATION_KWARGS
+from pyinfra.api.arguments import OPERATION_KWARGS
 
 
 def build_global_kwargs_doc():

--- a/tests/test_api/test_api_arguments.py
+++ b/tests/test_api/test_api_arguments.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from pyinfra.api import Config, Inventory, State
-from pyinfra.api.operation_kwargs import pop_global_op_kwargs
+from pyinfra.api.arguments import pop_global_op_kwargs
 
 
 class TestOperationKwargs(TestCase):

--- a/tests/test_global_arguments.py
+++ b/tests/test_global_arguments.py
@@ -11,7 +11,7 @@ except ImportError:
     from inspect import getargspec as getfullargspec
 
 from pyinfra import operations
-from pyinfra.api.operation_kwargs import OPERATION_KWARGS
+from pyinfra.api.arguments import OPERATION_KWARGS
 
 
 def _is_pyinfra_operation(module, key, value):


### PR DESCRIPTION
Exploring #695 options/development

This raises a few additional questions:

+ Why is `name` special, and not `_` prefixed
+ Do we support global args in `host.data` under the keys with or without the `_` prefix