### PR TITLE
ssh: don't disable host key checking when performing rsync

### DIFF
--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -548,9 +548,10 @@ def rsync(
         if sudo_user:
             remote_rsync_command = 'sudo -u {0} rsync'.format(sudo_user)
 
+    # To avoid asking for interactive input, specify BatchMode=yes
     rsync_command = (
         'rsync {rsync_flags} '
-        "--rsh 'ssh -o BatchMode=yes -o StrictHostKeyChecking=no {ssh_flags}' "
+        "--rsh 'ssh -o BatchMode=yes {ssh_flags}' "
         "--rsync-path '{remote_rsync_command}' "
         '{src} {user}{hostname}:{dest}'
     ).format(

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -320,7 +320,7 @@ class TestOperationsApi(PatchSSHTestCase):
         fake_run_local_process.assert_called_with(
             (
                 'rsync -ax --delete --rsh '
-                "'ssh -o BatchMode=yes -o StrictHostKeyChecking=no '"
+                "'ssh -o BatchMode=yes '"
                 " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,


### PR DESCRIPTION
This will make ssh behave as configured when invoking rsync.

Fixes parts of #737 

Tested.