### PR TITLE
Draft: ssh connector: respect StrictHostKeyChecking

### DIFF
--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -17,7 +17,6 @@ from paramiko import (
     ECDSAKey,
     Ed25519Key,
     HostKeys,
-    MissingHostKeyPolicy,
     PasswordRequiredException,
     RSAKey,
     SFTPClient,
@@ -43,11 +42,6 @@ from .util import (
 
 EXECUTION_CONNECTOR = True
 SYSTEM_HOST_KEYS = HostKeys()
-
-
-class WarningPolicy(MissingHostKeyPolicy):
-    def missing_host_key(self, client, hostname, key):
-        logger.warning('No host key for {0} found in known_hosts'.format(hostname))
 
 
 def make_names_data(hostname):
@@ -228,7 +222,6 @@ def connect(state, host):
     try:
         # Create new client & connect to the host
         client = SSHClient()
-        client.set_missing_host_key_policy(WarningPolicy())
         client._system_host_keys = SYSTEM_HOST_KEYS
 
         client.connect(hostname, **kwargs)

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -16,7 +16,6 @@ from paramiko import (
     DSSKey,
     ECDSAKey,
     Ed25519Key,
-    HostKeys,
     PasswordRequiredException,
     RSAKey,
     SFTPClient,
@@ -41,7 +40,6 @@ from .util import (
 )
 
 EXECUTION_CONNECTOR = True
-SYSTEM_HOST_KEYS = HostKeys()
 
 
 def make_names_data(hostname):
@@ -192,27 +190,11 @@ def _make_paramiko_kwargs(state, host):
     return kwargs
 
 
-@memoize  # only load system host keys once
-def _load_system_host_keys():
-    logger.debug('Loading SSH host keys')
-
-    known_hosts_filename = path.expanduser('~/.ssh/known_hosts')
-    if path.exists(known_hosts_filename):
-        try:
-            SYSTEM_HOST_KEYS.load(known_hosts_filename)
-        # Unfortunately paramiko bails for any dodge line in known hosts
-        # See: https://github.com/Fizzadar/pyinfra/issues/683
-        except Exception as e:
-            logger.warning('Failed to load system host keys: {0}'.format(e))
-
-
 def connect(state, host):
     '''
     Connect to a single host. Returns the SSH client if succesful. Stateless by
     design so can be run in parallel.
     '''
-
-    _load_system_host_keys()
 
     kwargs = _make_paramiko_kwargs(state, host)
     logger.debug('Connecting to: {0} ({1})'.format(host.name, kwargs))
@@ -222,8 +204,6 @@ def connect(state, host):
     try:
         # Create new client & connect to the host
         client = SSHClient()
-        client._system_host_keys = SYSTEM_HOST_KEYS
-
         client.connect(hostname, **kwargs)
         return client
 

--- a/pyinfra/api/connectors/ssh.py
+++ b/pyinfra/api/connectors/ssh.py
@@ -548,9 +548,10 @@ def rsync(
         if sudo_user:
             remote_rsync_command = 'sudo -u {0} rsync'.format(sudo_user)
 
+    # To avoid asking for interactive input, specify BatchMode=yes
     rsync_command = (
         'rsync {rsync_flags} '
-        "--rsh 'ssh -o BatchMode=yes -o StrictHostKeyChecking=no {ssh_flags}' "
+        "--rsh 'ssh -o BatchMode=yes {ssh_flags}' "
         "--rsync-path '{remote_rsync_command}' "
         '{src} {user}{hostname}:{dest}'
     ).format(

--- a/pyinfra/api/connectors/sshuserclient/client.py
+++ b/pyinfra/api/connectors/sshuserclient/client.py
@@ -77,7 +77,7 @@ def get_host_keys(filename):
         # entire load incorrectly.
         # See: https://github.com/paramiko/paramiko/pull/1990
         except Exception as e:
-            logger.warning(f'Failed to load host keys from {filename}: {e}')
+            logger.warning('Failed to load host keys from {0}: {1}'.format(filename, e))
 
         return host_keys
 

--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -553,7 +553,14 @@ class LinuxDistribution(FactBase):
 
             parsed = get_distro_info(temp_root)
 
-            release_meta = {key.upper(): value for key, value in parsed.os_release_info().items()}
+            release_meta = {
+                key.upper(): value
+                for key, value in parsed.os_release_info().items()
+            }
+            # Distro 1.7+ adds this, breaking tests
+            # TODO: fix this!
+            release_meta.pop('RELEASE_CODENAME', None)
+
             release_info.update({
                 'name': self.name_to_pretty_name.get(parsed.id(), parsed.name()),
                 'major': try_int(parsed.major_version()) or None,

--- a/pyinfra/facts/util/distro.py
+++ b/pyinfra/facts/util/distro.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
-import distro
+try:
+    from distro import distro
+except ImportError:
+    import distro
 
 
 def get_distro_info(root_dir):

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -320,7 +320,7 @@ class TestOperationsApi(PatchSSHTestCase):
         fake_run_local_process.assert_called_with(
             (
                 'rsync -ax --delete --rsh '
-                "'ssh -o BatchMode=yes -o StrictHostKeyChecking=no '"
+                "'ssh -o BatchMode=yes '"
                 " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -4,7 +4,7 @@ from mock import mock_open, patch
 from paramiko import ProxyCommand
 
 from pyinfra.api.connectors.sshuserclient import SSHClient
-from pyinfra.api.connectors.sshuserclient.client import get_ssh_config
+from pyinfra.api.connectors.sshuserclient.client import AskPolicy, get_ssh_config
 
 SSH_CONFIG_DATA = '''
 # Comment
@@ -23,6 +23,7 @@ Host 192.168.1.1
     User "otheruser"
     ProxyCommand None
     ForwardAgent yes
+    UserKnownHostsFile ~/.ssh/test3
 '''
 
 SSH_CONFIG_OTHER_FILE_PROXYJUMP = '''
@@ -82,18 +83,24 @@ class TestSSHUserConfig(TestCase):
     def test_load_ssh_config(self):
         client = SSHClient()
 
-        _, config, forward_agent = client.parse_config('127.0.0.1')
+        _, config, forward_agent, missing_host_key_policy, host_keys_file \
+            = client.parse_config('127.0.0.1')
 
         assert config.get('key_filename') == ['/id_rsa', '/id_rsa2']
         assert config.get('username') == 'testuser'
         assert config.get('port') == 33
         assert isinstance(config.get('sock'), ProxyCommand)
         assert forward_agent is False
+        assert isinstance(missing_host_key_policy, AskPolicy)
+        assert host_keys_file is None
 
-        _, other_config, forward_agent = client.parse_config('192.168.1.1')
+        _, other_config, forward_agent, missing_host_key_policy, host_keys_file \
+            = client.parse_config('192.168.1.1')
 
         assert other_config.get('username') == 'otheruser'
         assert forward_agent is True
+        assert isinstance(missing_host_key_policy, AskPolicy)
+        assert host_keys_file == '~/.ssh/test3'
 
     @patch(
         'pyinfra.api.connectors.sshuserclient.client.open',
@@ -142,7 +149,7 @@ class TestSSHUserConfig(TestCase):
         client = SSHClient()
 
         # Load the SSH config with ProxyJump configured
-        _, config, forward_agent = client.parse_config('192.168.1.2', {'port': 1022})
+        _, config, forward_agent, _, _ = client.parse_config('192.168.1.2', {'port': 1022})
 
         fake_ssh_connect.assert_called_once_with(
             '127.0.0.1',

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -92,7 +92,7 @@ class TestSSHUserConfig(TestCase):
         assert isinstance(config.get('sock'), ProxyCommand)
         assert forward_agent is False
         assert isinstance(missing_host_key_policy, AskPolicy)
-        assert host_keys_file is None
+        assert host_keys_file == '~/.ssh/known_hosts'  # OpenSSH default
 
         _, other_config, forward_agent, missing_host_key_policy, host_keys_file \
             = client.parse_config('192.168.1.1')


### PR DESCRIPTION
Fixes #737 

In theory this works and has been sort of tested, but I still need to:

- [x] Figure out what unit tests this breaks
- [x] Test that the strict policy actually does what it says
- [x] ~~If necessary split the commit for userknownhostsfile into a seperate PR~~
