### PR TITLE
Fix missing _bash for creating the completion

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -143,6 +143,6 @@ Add the following to your `~/.bash_profile` or `~/.profile` files:
 These files were generated using these commands:
 
 ```
-env _PYINFRA_COMPLETE=source pyinfra > pyinfra-complete.sh
+env _PYINFRA_COMPLETE=source_bash pyinfra > pyinfra-complete.sh
 env _PYINFRA_COMPLETE=source_zsh pyinfra > pyinfra-complete.zsh
 ```


### PR DESCRIPTION
Somehow this got dropped. Without this click does not
do the completion for bash.