### PR TITLE
Explicitely name CLI options with 2 long versions (#764)

### DIFF
--- a/pyinfra_cli/main.py
+++ b/pyinfra_cli/main.py
@@ -156,11 +156,14 @@ def _print_support(ctx, param, value):
 )
 # SSH connector args
 # TODO: remove the non-ssh-prefixed variants
-@click.option('--ssh-user', '--user', help='SSH user to connect as.')
-@click.option('--ssh-port', '--port', type=int, help='SSH port to connect to.')
-@click.option('--ssh-key', '--key', type=click.Path(), help='SSH Private key filename.')
-@click.option('--ssh-key-password', '--key-password', help='SSH Private key password.')
-@click.option('--ssh-password', '--password', help='SSH password.')
+@click.option('--ssh-user', '--user', 'ssh_user', help='SSH user to connect as.')
+@click.option('--ssh-port', '--port', 'ssh_port', type=int, help='SSH port to connect to.')
+@click.option('--ssh-key', '--key', 'ssh_key', type=click.Path(), help='SSH Private key filename.')
+@click.option(
+    '--ssh-key-password', '--key-password', 'ssh_key_password',
+    help='SSH Private key password.',
+)
+@click.option('--ssh-password', '--password', 'ssh_password', help='SSH password.')
 # WinRM connector args
 @click.option('--winrm-username', help='WINRM user to connect as.')
 @click.option('--winrm-password', help='WINRM password.')


### PR DESCRIPTION
This avoids issues with click<7.0 where the option name selection order was changed for this case

Fixes #764 