### PR TITLE
Pyinstaller binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,13 @@ jobs:
       matrix:
         include:
           - os: ubuntu-18.04
-            python-version: 3.9
+            python-version: "3.10"
             filename: pyinfra
           - os: macos-10.15
-            python-version: 3.9
+            python-version: "3.10"
             filename: pyinfra
           - os: windows-2019
-            python-version: 3.9
+            python-version: "3.10"
             filename: pyinfra.exe
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: "Build pyinfra Binary"
+
+on:
+  push:
+    branches:
+    - pyinstaller-binaries
+
+jobs:
+  Test:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            python-version: 3.9
+            filename: pyinfra
+          - os: macos-10.15
+            python-version: 3.9
+            filename: pyinfra
+          - os: windows-2019
+            python-version: 3.9
+            filename: pyinfra.exe
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        run: pip install '.[build]'
+
+      - name: Build pyinfra Binary
+        run: pyinstaller scripts/pyinfra-pyinstaller.spec
+
+      - name: Upload pyinfra Binary Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: pyinfra-${{ matrix.os }}
+          path: dist/${{ matrix.filename }}

--- a/pyinfra_cli/__main__.py
+++ b/pyinfra_cli/__main__.py
@@ -39,4 +39,7 @@ signal.signal(signal.SIGINT, _handle_interrupt)  # print the message and exit ma
 
 
 if __name__ == "pyinfra_cli.__main__":
+    if getattr(sys, "frozen", False):
+        click.echo(click.style("Warning: running alpha pyinfra binary build", "yellow"), err=True)
+
     cli()

--- a/pyinfra_cli/__main__.py
+++ b/pyinfra_cli/__main__.py
@@ -39,7 +39,4 @@ signal.signal(signal.SIGINT, _handle_interrupt)  # print the message and exit ma
 
 
 if __name__ == "pyinfra_cli.__main__":
-    if getattr(sys, "frozen", False):
-        click.echo(click.style("Warning: running alpha pyinfra binary build", "yellow"), err=True)
-
     cli()

--- a/scripts/pyinfra-pyinstaller-entrypoint.py
+++ b/scripts/pyinfra-pyinstaller-entrypoint.py
@@ -1,2 +1,3 @@
 from pyinfra_cli.__main__ import cli
+
 cli()

--- a/scripts/pyinfra-pyinstaller-entrypoint.py
+++ b/scripts/pyinfra-pyinstaller-entrypoint.py
@@ -1,0 +1,2 @@
+from pyinfra_cli.__main__ import cli
+cli()

--- a/scripts/pyinfra-pyinstaller-entrypoint.py
+++ b/scripts/pyinfra-pyinstaller-entrypoint.py
@@ -1,3 +1,6 @@
+import click
+
 from pyinfra_cli.__main__ import cli
 
+click.echo(click.style("Warning: running alpha pyinfra binary build", "yellow"), err=True)
 cli()

--- a/scripts/pyinfra-pyinstaller.spec
+++ b/scripts/pyinfra-pyinstaller.spec
@@ -1,0 +1,99 @@
+from os import environ
+
+import pkg_resources
+
+from PyInstaller.utils.hooks import collect_all, copy_metadata
+
+
+ONE_FILE_MODE = environ.get('PYINFRA_BUILD_ONEDIR') != 'true'
+
+
+datas, binaries, hidden_imports = collect_all('pyinfra')
+
+
+def get_package_dependencies(package_name):
+    package = pkg_resources.working_set.by_key[package_name]
+
+    for require in package.requires():
+        yield require.name
+        yield from get_package_dependencies(require.name.lower())
+
+
+for missing_metadata in get_package_dependencies('pyinfra'):
+    datas.extend(copy_metadata(missing_metadata))
+
+
+a = Analysis(  # noqa
+    ['pyinfra-pyinstaller-entrypoint.py'],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hidden_imports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=None,
+    noarchive=False,
+)
+
+pyz = PYZ(  # noqa
+    a.pure,
+    a.zipped_data,
+    cipher=None,
+)
+
+
+if ONE_FILE_MODE:
+    exe = EXE(  # noqa
+        pyz,
+        a.scripts,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        [],
+        name='pyinfra',
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=True,
+        upx_exclude=[],
+        runtime_tmpdir=None,
+        console=True,
+        disable_windowed_traceback=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+    )
+
+# One directory mode (debugging)
+else:
+    exe = EXE(  # noqa
+        pyz,
+        a.scripts,
+        [],
+        exclude_binaries=True,
+        name='pyinfra-onedir',
+        debug=False,
+        bootloader_ignore_signals=False,
+        strip=False,
+        upx=True,
+        console=True,
+        disable_windowed_traceback=False,
+        target_arch=None,
+        codesign_identity=None,
+        entitlements_file=None,
+    )
+
+    coll = COLLECT(  # noqa
+        exe,
+        a.binaries,
+        a.zipfiles,
+        a.datas,
+        strip=False,
+        upx=True,
+        upx_exclude=[],
+        name='pyinfra-onedir',
+    )

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,12 @@ DOCS_REQUIRES = (
     "docutils==0.17.1",
 )
 
+BUILD_REQUIRES = ("pyinstaller==4.9",)
+
 DEV_REQUIRES = (
     TEST_REQUIRES
     + DOCS_REQUIRES
+    + BUILD_REQUIRES
     + (
         # Releasing
         "wheel",
@@ -130,6 +133,7 @@ if __name__ == "__main__":
             "docs": DOCS_REQUIRES,
             "dev": DEV_REQUIRES,
             "ansible": ANSIBLE_REQUIRES,
+            "build": BUILD_REQUIRES,
         },
         include_package_data=True,
         classifiers=[

--- a/tests/words.txt
+++ b/tests/words.txt
@@ -46,6 +46,7 @@ baseurl
 basic
 benchmarking
 blocksize
+bootloader
 bsdinit
 build
 bytecode
@@ -61,6 +62,7 @@ chocolately
 chown
 chroot
 cim
+codesign
 commitish
 comparator
 compat
@@ -150,9 +152,12 @@ greenlets
 groupname
 hacky
 hashability
+hiddenimports
 hklm
 homedir
 homepath
+hooksconfig
+hookspath
 hostnames
 hostport
 hotfixes
@@ -216,6 +221,7 @@ netsh
 nettools
 networkadapterconfiguration
 nl
+noarchive
 nobest
 nofile
 none
@@ -235,6 +241,7 @@ osversion
 pacman
 paramiko
 pardir
+pathex
 pathlib
 pathname
 perf
@@ -267,6 +274,7 @@ pyi
 pyinfra
 pyinfrawinrmsession
 pywinrm
+pyz
 quickfixengineering
 rcd
 readlink
@@ -343,6 +351,7 @@ testpass
 testuser
 tftp
 tls
+tmpdir
 todo
 topdown
 tty
@@ -357,6 +366,7 @@ unitialised
 unmount
 up
 up2
+upx
 useradd
 utf16
 v
@@ -387,4 +397,5 @@ xbps
 yaml
 yarn
 zfill
+zipfiles
 zypper


### PR DESCRIPTION
Sometimes it's desirable to have a single binary instead of a `pip`/whatever package. Unfortunately in the Python world this isn't a simple task and the resulting binary is pretty slow to execute (10s to start cold). But it works!