### PR TITLE
Enhance systemd operation and facts with full support for `--user` and `--machine` flags

### DIFF
--- a/pyinfra/facts/systemd.py
+++ b/pyinfra/facts/systemd.py
@@ -20,6 +20,22 @@ SYSTEMD_UNIT_NAME_REGEX = (
 )
 
 
+def _make_systemctl_cmd(user_mode=False, machine=None, user_name=None):
+    # base command for normal and user mode
+    systemctl_cmd = 'systemctl --user' if user_mode else 'systemctl'
+
+    # add user and machine flag if given in args
+    if machine is not None:
+        if user_name is not None:
+            machine_opt = '--machine={1}@{0}'.format(machine, user_name)
+        else:
+            machine_opt = '--machine={0}'.format(machine)
+
+        systemctl_cmd = '{0} {1}'.format(systemctl_cmd, machine_opt)
+
+    return systemctl_cmd
+
+
 class SystemdStatus(FactBase):
     '''
     Returns a dict of name -> status for systemd managed services.
@@ -33,15 +49,11 @@ class SystemdStatus(FactBase):
         systemd_unit_name_regex=SYSTEMD_UNIT_NAME_REGEX)
 
     def command(self, user_mode=False, machine=None, user_name=None):
-        fact_cmd = 'systemctl --user' if user_mode else 'systemctl'
-
-        if machine is not None:
-            if user_name is not None:
-                machine_opt = '--machine={1}@{0}'.format(machine, user_name)
-            else:
-                machine_opt = '--machine={0}'.format(machine)
-
-            fact_cmd = '{0} {1}'.format(fact_cmd, machine_opt)
+        fact_cmd = _make_systemctl_cmd(
+            user_mode=user_mode,
+            machine=machine,
+            user_name=user_name,
+        )
 
         return '{0} -al list-units'.format(fact_cmd)
 
@@ -71,15 +83,11 @@ class SystemdEnabled(FactBase):
         systemd_unit_name_regex=SYSTEMD_UNIT_NAME_REGEX)
 
     def command(self, user_mode=False, machine=None, user_name=None):
-        fact_cmd = 'systemctl --user' if user_mode else 'systemctl'
-
-        if machine is not None:
-            if user_name is not None:
-                machine_opt = '--machine={1}@{0}'.format(machine, user_name)
-            else:
-                machine_opt = '--machine={0}'.format(machine)
-
-            fact_cmd = '{0} {1}'.format(fact_cmd, machine_opt)
+        fact_cmd = _make_systemctl_cmd(
+            user_mode=user_mode,
+            machine=machine,
+            user_name=user_name,
+        )
 
         return '''
             {0} --no-legend -al list-unit-files | while read -r UNIT STATUS; do

--- a/pyinfra/operations/systemd.py
+++ b/pyinfra/operations/systemd.py
@@ -5,25 +5,9 @@ Manage systemd services.
 from __future__ import unicode_literals
 
 from pyinfra.api import operation
-from pyinfra.facts.systemd import SystemdEnabled, SystemdStatus
+from pyinfra.facts.systemd import _make_systemctl_cmd, SystemdEnabled, SystemdStatus
 
 from .util.service import handle_service_control
-
-
-def _make_systemctl_cmd(user_mode=False, machine=None, user_name=None):
-    # base command for normal and user mode
-    systemctl_cmd = 'systemctl --user' if user_mode else 'systemctl'
-
-    # add user and machine flag if given in args
-    if machine is not None:
-        if user_name is not None:
-            machine_opt = '--machine={1}@{0}'.format(machine, user_name)
-        else:
-            machine_opt = '--machine={0}'.format(machine)
-
-        systemctl_cmd = '{0} {1}'.format(systemctl_cmd, machine_opt)
-
-    return systemctl_cmd
 
 
 @operation

--- a/pyinfra/operations/systemd.py
+++ b/pyinfra/operations/systemd.py
@@ -10,6 +10,22 @@ from pyinfra.facts.systemd import SystemdEnabled, SystemdStatus
 from .util.service import handle_service_control
 
 
+def _make_systemctl_cmd(user_mode=False, machine=None, user_name=None):
+    # base command for normal and user mode
+    systemctl_cmd = 'systemctl --user' if user_mode else 'systemctl'
+
+    # add user and machine flag if given in args
+    if machine is not None:
+        if user_name is not None:
+            machine_opt = '--machine={1}@{0}'.format(machine, user_name)
+        else:
+            machine_opt = '--machine={0}'.format(machine)
+
+        systemctl_cmd = '{0} {1}'.format(systemctl_cmd, machine_opt)
+
+    return systemctl_cmd
+
+
 @operation
 def daemon_reload(
     user_mode=False, machine=None, user_name=None, state=None, host=None,
@@ -22,15 +38,11 @@ def daemon_reload(
     + user_name: connect to a specific user's systemd session
     '''
 
-    systemctl_cmd = 'systemctl --user' if user_mode else 'systemctl'
-
-    if machine is not None:
-        if user_name is not None:
-            machine_opt = '--machine={1}@{0}'.format(machine, user_name)
-        else:
-            machine_opt = '--machine={0}'.format(machine)
-
-        systemctl_cmd = '{0} {1}'.format(systemctl_cmd, machine_opt)
+    systemctl_cmd = _make_systemctl_cmd(
+        user_mode=user_mode,
+        machine=machine,
+        user_name=user_name,
+    )
 
     yield '{0} daemon-reload'.format(systemctl_cmd)
 
@@ -81,15 +93,11 @@ def service(
 
     '''
 
-    systemctl_cmd = 'systemctl --user' if user_mode else 'systemctl'
-
-    if machine is not None:
-        if user_name is not None:
-            machine_opt = '--machine={1}@{0}'.format(machine, user_name)
-        else:
-            machine_opt = '--machine={0}'.format(machine)
-
-        systemctl_cmd = '{0} {1}'.format(systemctl_cmd, machine_opt)
+    systemctl_cmd = _make_systemctl_cmd(
+        user_mode=user_mode,
+        machine=machine,
+        user_name=user_name,
+    )
 
     if '.' not in service:
         service = '{0}.service'.format(service)

--- a/pyinfra/operations/systemd.py
+++ b/pyinfra/operations/systemd.py
@@ -87,7 +87,13 @@ def service(
         service = '{0}.service'.format(service)
 
     if daemon_reload:
-        yield _daemon_reload(user_mode=user_mode, state=state, host=host)
+        yield _daemon_reload(
+            user_mode=user_mode,
+            machine=machine,
+            user_name=user_name,
+            state=state,
+            host=host,
+        )
 
     yield handle_service_control(
         host,

--- a/tests/facts/systemd.SystemdEnabled/machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/machine_services.json
@@ -1,0 +1,15 @@
+{
+    "arg": [false, "testmachine", "testuser"],
+    "command": "\n            systemctl --machine=testuser@testmachine --no-legend -al list-unit-files | while read -r UNIT STATUS; do\n                if [ \"$STATUS\" = generated ] &&\n                    systemctl --machine=testuser@testmachine is-enabled $UNIT >/dev/null 2>&1; then\n                    STATUS=enabled\n                fi\n                echo $UNIT $STATUS\n            done\n        ",
+    "requires_command": "systemctl",
+    "output": [
+        "vboxadd.service enabled",
+        "vgauth.timer enabled",
+        "x11-common.service masked"
+    ],
+    "fact":  {
+        "vboxadd.service": true,
+        "vgauth.timer": true,
+        "x11-common.service": false
+    }
+}

--- a/tests/facts/systemd.SystemdEnabled/root_machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/root_machine_services.json
@@ -1,0 +1,15 @@
+{
+    "arg": [false, "testmachine"],
+    "command": "\n            systemctl --machine=testmachine --no-legend -al list-unit-files | while read -r UNIT STATUS; do\n                if [ \"$STATUS\" = generated ] &&\n                    systemctl --machine=testmachine is-enabled $UNIT >/dev/null 2>&1; then\n                    STATUS=enabled\n                fi\n                echo $UNIT $STATUS\n            done\n        ",
+    "requires_command": "systemctl",
+    "output": [
+        "vboxadd.service enabled",
+        "vgauth.timer enabled",
+        "x11-common.service masked"
+    ],
+    "fact":  {
+        "vboxadd.service": true,
+        "vgauth.timer": true,
+        "x11-common.service": false
+    }
+}

--- a/tests/facts/systemd.SystemdEnabled/user_machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/user_machine_services.json
@@ -1,0 +1,15 @@
+{
+    "arg": [true, "testmachine", "testuser"],
+    "command": "\n            systemctl --user --machine=testuser@testmachine --no-legend -al list-unit-files | while read -r UNIT STATUS; do\n                if [ \"$STATUS\" = generated ] &&\n                    systemctl --user --machine=testuser@testmachine is-enabled $UNIT >/dev/null 2>&1; then\n                    STATUS=enabled\n                fi\n                echo $UNIT $STATUS\n            done\n        ",
+    "requires_command": "systemctl",
+    "output": [
+        "vboxadd.service enabled",
+        "vgauth.timer enabled",
+        "x11-common.service masked"
+    ],
+    "fact":  {
+        "vboxadd.service": true,
+        "vgauth.timer": true,
+        "x11-common.service": false
+    }
+}

--- a/tests/facts/systemd.SystemdEnabled/user_services.json
+++ b/tests/facts/systemd.SystemdEnabled/user_services.json
@@ -1,0 +1,15 @@
+{
+    "arg": [true],
+    "command": "\n            systemctl --user --no-legend -al list-unit-files | while read -r UNIT STATUS; do\n                if [ \"$STATUS\" = generated ] &&\n                    systemctl --user is-enabled $UNIT >/dev/null 2>&1; then\n                    STATUS=enabled\n                fi\n                echo $UNIT $STATUS\n            done\n        ",
+    "requires_command": "systemctl",
+    "output": [
+        "vboxadd.service enabled",
+        "vgauth.timer enabled",
+        "x11-common.service masked"
+    ],
+    "fact":  {
+        "vboxadd.service": true,
+        "vgauth.timer": true,
+        "x11-common.service": false
+    }
+}

--- a/tests/facts/systemd.SystemdStatus/machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/machine_services.json
@@ -1,0 +1,17 @@
+{
+    "arg": [false, "testmachine", "testuser"],
+    "command": "systemctl --machine=testuser@testmachine -al list-units",
+    "requires_command": "systemctl",
+    "output": [
+        "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",
+        "lvm2-lvmetad.service         loaded    active   running LVM2 metadata daemon",
+        "lvm2-lvmpolld.service        loaded    inactive dead    LVM2 poll daemon",
+        "ebtables.timer             loaded    active   exited  ebtables ruleset management"
+    ],
+    "fact":  {
+        "lvm2-activation.service": false,
+        "lvm2-lvmetad.service": true,
+        "lvm2-lvmpolld.service": false,
+        "ebtables.timer": true
+    }
+}

--- a/tests/facts/systemd.SystemdStatus/root_machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/root_machine_services.json
@@ -1,0 +1,17 @@
+{
+    "arg": [false, "testmachine"],
+    "command": "systemctl --machine=testmachine -al list-units",
+    "requires_command": "systemctl",
+    "output": [
+        "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",
+        "lvm2-lvmetad.service         loaded    active   running LVM2 metadata daemon",
+        "lvm2-lvmpolld.service        loaded    inactive dead    LVM2 poll daemon",
+        "ebtables.timer             loaded    active   exited  ebtables ruleset management"
+    ],
+    "fact":  {
+        "lvm2-activation.service": false,
+        "lvm2-lvmetad.service": true,
+        "lvm2-lvmpolld.service": false,
+        "ebtables.timer": true
+    }
+}

--- a/tests/facts/systemd.SystemdStatus/user_machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/user_machine_services.json
@@ -1,0 +1,17 @@
+{
+    "arg": ["True", "testmachine", "testuser"],
+    "command": "systemctl --user --machine=testuser@testmachine -al list-units",
+    "requires_command": "systemctl",
+    "output": [
+        "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",
+        "lvm2-lvmetad.service         loaded    active   running LVM2 metadata daemon",
+        "lvm2-lvmpolld.service        loaded    inactive dead    LVM2 poll daemon",
+        "ebtables.timer             loaded    active   exited  ebtables ruleset management"
+    ],
+    "fact":  {
+        "lvm2-activation.service": false,
+        "lvm2-lvmetad.service": true,
+        "lvm2-lvmpolld.service": false,
+        "ebtables.timer": true
+    }
+}

--- a/tests/facts/systemd.SystemdStatus/user_services.json
+++ b/tests/facts/systemd.SystemdStatus/user_services.json
@@ -1,0 +1,17 @@
+{
+    "arg": ["True"],
+    "command": "systemctl --user -al list-units",
+    "requires_command": "systemctl",
+    "output": [
+        "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",
+        "lvm2-lvmetad.service         loaded    active   running LVM2 metadata daemon",
+        "lvm2-lvmpolld.service        loaded    inactive dead    LVM2 poll daemon",
+        "ebtables.timer             loaded    active   exited  ebtables ruleset management"
+    ],
+    "fact":  {
+        "lvm2-activation.service": false,
+        "lvm2-lvmetad.service": true,
+        "lvm2-lvmpolld.service": false,
+        "ebtables.timer": true
+    }
+}

--- a/tests/operations/server.service/start_systemd.json
+++ b/tests/operations/server.service/start_systemd.json
@@ -2,7 +2,9 @@
     "args": ["nginx.service"],
     "facts": {
         "systemd.SystemdStatus": {
-            "nginx.service": false
+            "user_mode=False, machine=None, user_name=None": {
+                "nginx.service": false
+            }
         },
         "server.Which": {
             "command=systemctl": true,

--- a/tests/operations/systemd.service/daemon_reload.json
+++ b/tests/operations/systemd.service/daemon_reload.json
@@ -5,7 +5,9 @@
     },
     "facts": {
         "systemd.SystemdStatus": {
-            "redis-server.service": true
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
         }
     },
     "commands": [

--- a/tests/operations/systemd.service/disabled.json
+++ b/tests/operations/systemd.service/disabled.json
@@ -5,10 +5,14 @@
     },
     "facts": {
         "systemd.SystemdStatus": {
-            "redis-server.service": true
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
         },
         "systemd.SystemdEnabled": {
-            "redis-server.service": true
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
         }
     },
     "commands": [

--- a/tests/operations/systemd.service/enabled.json
+++ b/tests/operations/systemd.service/enabled.json
@@ -5,10 +5,14 @@
     },
     "facts": {
         "systemd.SystemdStatus": {
-            "redis-server.service": true
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
         },
         "systemd.SystemdEnabled": {
-            "redis-server.service": false
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": false
+            }
         }
     },
     "commands": [

--- a/tests/operations/systemd.service/machine_daemon_reload.json
+++ b/tests/operations/systemd.service/machine_daemon_reload.json
@@ -1,0 +1,20 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "daemon_reload": true,
+        "user_mode": false,
+        "machine": "testmachine"
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=False, machine=testmachine, user_name=None": {
+                "redis-server.service": true
+            }
+        }
+    },
+    "commands": [
+        "systemctl --machine=testmachine daemon-reload"
+    ],
+    "idempotent": false,
+    "disable_idempotent_warning_reason": "daemon reloads are always triggered"
+}

--- a/tests/operations/systemd.service/machine_disabled.json
+++ b/tests/operations/systemd.service/machine_disabled.json
@@ -1,0 +1,22 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "enabled": false,
+        "machine": "testmachine"
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=False, machine=testmachine, user_name=None": {
+                "redis-server.service": true
+            }
+        },
+        "systemd.SystemdEnabled": {
+            "user_mode=False, machine=testmachine, user_name=None": {
+                "redis-server.service": true
+            }
+        }
+    },
+    "commands": [
+        "systemctl --machine=testmachine disable redis-server.service"
+    ]
+}

--- a/tests/operations/systemd.service/machine_enabled.json
+++ b/tests/operations/systemd.service/machine_enabled.json
@@ -1,0 +1,22 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "enabled": true,
+        "machine": "testmachine"
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=False, machine=testmachine, user_name=None": {
+                "redis-server.service": true
+            }
+        },
+        "systemd.SystemdEnabled": {
+            "user_mode=False, machine=testmachine, user_name=None": {
+                "redis-server.service": false
+            }
+        }
+    },
+    "commands": [
+        "systemctl --machine=testmachine enable redis-server.service"
+    ]
+}

--- a/tests/operations/systemd.service/machine_start.json
+++ b/tests/operations/systemd.service/machine_start.json
@@ -1,0 +1,17 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "user_mode": false,
+        "machine": "testmachine"
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=False, machine=testmachine, user_name=None": {
+                "redis-server.service": false
+            }
+        }
+    },
+    "commands": [
+        "systemctl --machine=testmachine start redis-server.service"
+    ]
+}

--- a/tests/operations/systemd.service/reload_unknown.json
+++ b/tests/operations/systemd.service/reload_unknown.json
@@ -4,7 +4,9 @@
         "reloaded": true
     },
     "facts": {
-        "systemd.SystemdStatus": {}
+        "systemd.SystemdStatus": {
+            "user_mode=False, machine=None, user_name=None": {}
+        }
     },
     "commands": [
         "if (systemctl status redis-server.service); then (true); (true); (systemctl reload redis-server.service); else (systemctl start redis-server.service); fi"

--- a/tests/operations/systemd.service/running_ambiguous_unit.json
+++ b/tests/operations/systemd.service/running_ambiguous_unit.json
@@ -2,7 +2,9 @@
     "args": ["redis-server"],
     "facts": {
         "systemd.SystemdStatus": {
-            "redis-server.service": false
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": false
+            }
         }
     },
     "commands": [

--- a/tests/operations/systemd.service/running_noop.json
+++ b/tests/operations/systemd.service/running_noop.json
@@ -2,7 +2,9 @@
     "args": ["redis-server.service"],
     "facts": {
         "systemd.SystemdStatus": {
-            "redis-server.service": true
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
         }
     },
     "commands": [],

--- a/tests/operations/systemd.service/running_timer.json
+++ b/tests/operations/systemd.service/running_timer.json
@@ -2,7 +2,9 @@
     "args": ["some-timer.timer"],
     "facts": {
         "systemd.SystemdStatus": {
-            "some-timer.timer": false
+            "user_mode=False, machine=None, user_name=None": {
+                "some-timer.timer": false
+            }
         }
     },
     "commands": [

--- a/tests/operations/systemd.service/start.json
+++ b/tests/operations/systemd.service/start.json
@@ -2,7 +2,9 @@
     "args": ["redis-server.service"],
     "facts": {
         "systemd.SystemdStatus": {
-            "redis-server.service": false
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": false
+            }
         }
     },
     "commands": [

--- a/tests/operations/systemd.service/stopped_noop.json
+++ b/tests/operations/systemd.service/stopped_noop.json
@@ -5,7 +5,9 @@
     },
     "facts": {
         "systemd.SystemdStatus": {
-            "redis-server.service": false
+            "user_mode=False, machine=None, user_name=None": {
+                "redis-server.service": false
+            }
         }
     },
     "commands": [],

--- a/tests/operations/systemd.service/timer.json
+++ b/tests/operations/systemd.service/timer.json
@@ -2,7 +2,9 @@
     "args": ["logrotate.timer"],
     "facts": {
         "systemd.SystemdStatus": {
-            "logrotate.timer": false
+            "user_mode=False, machine=None, user_name=None": {
+                "logrotate.timer": false
+            }
         }
     },
     "commands": [

--- a/tests/operations/systemd.service/user_daemon_reload.json
+++ b/tests/operations/systemd.service/user_daemon_reload.json
@@ -1,0 +1,19 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "daemon_reload": true,
+        "user_mode": true
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=True, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
+        }
+    },
+    "commands": [
+        "systemctl --user daemon-reload"
+    ],
+    "idempotent": false,
+    "disable_idempotent_warning_reason": "daemon reloads are always triggered"
+}

--- a/tests/operations/systemd.service/user_disabled.json
+++ b/tests/operations/systemd.service/user_disabled.json
@@ -1,0 +1,22 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "enabled": false,
+        "user_mode": true
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=True, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
+        },
+        "systemd.SystemdEnabled": {
+            "user_mode=True, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
+        }
+    },
+    "commands": [
+        "systemctl --user disable redis-server.service"
+    ]
+}

--- a/tests/operations/systemd.service/user_enabled.json
+++ b/tests/operations/systemd.service/user_enabled.json
@@ -1,0 +1,22 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "enabled": true,
+        "user_mode": true
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=True, machine=None, user_name=None": {
+                "redis-server.service": true
+            }
+        },
+        "systemd.SystemdEnabled": {
+            "user_mode=True, machine=None, user_name=None": {
+                "redis-server.service": false
+            }
+        }
+    },
+    "commands": [
+        "systemctl --user enable redis-server.service"
+    ]
+}

--- a/tests/operations/systemd.service/user_machine_daemon_reload.json
+++ b/tests/operations/systemd.service/user_machine_daemon_reload.json
@@ -1,0 +1,21 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "daemon_reload": true,
+        "user_mode": true,
+        "machine": "testmachine",
+        "user_name": "testuser"
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=True, machine=testmachine, user_name=testuser": {
+                "redis-server.service": true
+            }
+        }
+    },
+    "commands": [
+        "systemctl --user --machine=testuser@testmachine daemon-reload"
+    ],
+    "idempotent": false,
+    "disable_idempotent_warning_reason": "daemon reloads are always triggered"
+}

--- a/tests/operations/systemd.service/user_machine_disabled.json
+++ b/tests/operations/systemd.service/user_machine_disabled.json
@@ -1,0 +1,24 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "enabled": false,
+        "user_mode": true,
+        "machine": "testmachine",
+        "user_name": "testuser"
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=True, machine=testmachine, user_name=testuser": {
+                "redis-server.service": true
+            }
+        },
+        "systemd.SystemdEnabled": {
+            "user_mode=True, machine=testmachine, user_name=testuser": {
+                "redis-server.service": true
+            }
+        }
+    },
+    "commands": [
+        "systemctl --user --machine=testuser@testmachine disable redis-server.service"
+    ]
+}

--- a/tests/operations/systemd.service/user_machine_enabled.json
+++ b/tests/operations/systemd.service/user_machine_enabled.json
@@ -1,0 +1,24 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "enabled": true,
+        "user_mode": true,
+        "machine": "testmachine",
+        "user_name": "testuser"
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=True, machine=testmachine, user_name=testuser": {
+                "redis-server.service": true
+            }
+        },
+        "systemd.SystemdEnabled": {
+            "user_mode=True, machine=testmachine, user_name=testuser": {
+                "redis-server.service": false
+            }
+        }
+    },
+    "commands": [
+        "systemctl --user --machine=testuser@testmachine enable redis-server.service"
+    ]
+}

--- a/tests/operations/systemd.service/user_machine_start.json
+++ b/tests/operations/systemd.service/user_machine_start.json
@@ -1,0 +1,18 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "user_mode": true,
+        "machine": "testmachine",
+        "user_name": "testuser"
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=True, machine=testmachine, user_name=testuser": {
+                "redis-server.service": false
+            }
+        }
+    },
+    "commands": [
+        "systemctl --user --machine=testuser@testmachine start redis-server.service"
+    ]
+}

--- a/tests/operations/systemd.service/user_start.json
+++ b/tests/operations/systemd.service/user_start.json
@@ -1,0 +1,16 @@
+{
+    "args": ["redis-server.service"],
+    "kwargs": {
+        "user_mode": true
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "user_mode=True, machine=None, user_name=None": {
+                "redis-server.service": false
+            }
+        }
+    },
+    "commands": [
+        "systemctl --user start redis-server.service"
+    ]
+}


### PR DESCRIPTION
This PR completes support for interacting with systemd user sessions, to include those of users other than the calling user by way of the [`--machine`][0] flag.

Previously, the systemd facts did not properly check the status of systemd user units despite the presence of the `user_mode` kwarg in the systemd.daemon_reload and systemd.service operations. This led to inconsistent behavior when interacting with user units as opposed to system units. The systemd facts now also accept an argument to indicate user mode is desired and this is incorporated into the systemd operations.

A new feature introduced is the ability to specify both a `machine` and `user_name` to the systemd facts and operations which adds a constructed `--machine=user_name@machine` flag to the systemctl command. This tells systemctl to access the bus of the specified user on the specified machine. This is targeted towards use with systemd-nspawn but most critically can be used to manage service units running as unprivileged systemd user services on the same host when `.host` is specified as the machine.

Possible areas for improvement: tests could/should be enhanced to cover the user mode and machine use cases

[0]: https://www.freedesktop.org/software/systemd/man/systemctl.html#-M

cc: @storrgie @jkl92