### PR TITLE
zypper install is now case sensitive by default

### DIFF
--- a/pyinfra/operations/zypper.py
+++ b/pyinfra/operations/zypper.py
@@ -195,4 +195,5 @@ def packages(
         upgrade_command=upgrade_command,
         version_join='=',
         latest=latest,
+        lower=False,
     )

--- a/tests/operations/zypper.packages/add_packages.json
+++ b/tests/operations/zypper.packages/add_packages.json
@@ -2,6 +2,7 @@
     "args": [[
         "git",
         "python-devel",
+        "MozillaFirefox",
         "something"
     ]],
     "facts": {
@@ -10,6 +11,6 @@
         }
     },
     "commands": [
-        "zypper --non-interactive install -y git python-devel"
+        "zypper --non-interactive install -y git python-devel MozillaFirefox"
     ]
 }


### PR DESCRIPTION
Fix for #769 where zypper package installs keep case in package names.