### PR TITLE
Escape exported variables

### DIFF
--- a/pyinfra/api/connectors/util.py
+++ b/pyinfra/api/connectors/util.py
@@ -275,7 +275,7 @@ def make_unix_command(
 
     if env:
         env_string = ' '.join([
-            '{0}={1}'.format(key, value)
+            '"{0}={1}"'.format(key, value)
             for key, value in six.iteritems(env)
         ])
         command = StringCommand('export', env_string, '&&', command)

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -117,7 +117,8 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         assert command.get_raw_value() == (
             'sudo -H -n -E -u root '  # sudo bit
             'su pyinfra -c '  # su bit
-            "'bash -c '\"'\"'cd /opt/somedir && export \"key=value\" && echo hi'\"'\"''"  # command bit
+            "'bash -c '\"'\"'cd /opt/somedir && export \"key=value\" "  # shell and export bit
+            "&& echo hi'\"'\"''"  # command bit
         )
 
     def test_command_exists_su_config_only(self):

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -91,8 +91,8 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
             'anotherkey': 'anothervalue',
         })
         assert command.get_raw_value() in [
-            "sh -c 'export key=value anotherkey=anothervalue && uptime'",
-            "sh -c 'export anotherkey=anothervalue key=value && uptime'",
+            "sh -c 'export \"key=value\" \"anotherkey=anothervalue\" && uptime'",
+            "sh -c 'export \"anotherkey=anothervalue\" \"key=value\" && uptime'",
         ]
 
     def test_command_chdir(self):
@@ -117,7 +117,7 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         assert command.get_raw_value() == (
             'sudo -H -n -E -u root '  # sudo bit
             'su pyinfra -c '  # su bit
-            "'bash -c '\"'\"'cd /opt/somedir && export key=value && echo hi'\"'\"''"  # command bit
+            "'bash -c '\"'\"'cd /opt/somedir && export \"key=value\" && echo hi'\"'\"''"  # command bit
         )
 
     def test_command_exists_su_config_only(self):


### PR DESCRIPTION
Environment variables with URL values that have query parameters e.g `https://example.com?a=b&c=d` are interpreted differently than intended, since the `&` turns the export command into a background command, and strips off `c=d` from the variable.

This was manually tested on my deployment scripts, but I'm relying on CI for the test suite this time due to issues trying to spin up a local environment.