### PR TITLE
Bugfix fact SystemdEnabled

### DIFF
--- a/pyinfra/facts/systemd.py
+++ b/pyinfra/facts/systemd.py
@@ -92,7 +92,7 @@ class SystemdEnabled(FactBase):
         return (
             '{0} -al --plain --legend=false --state=loaded list-units | '
             'while read -r UNIT REST; do '
-            'STATE=$(systemctl -P UnitFileState show -- "$UNIT"); '
+            'STATE=$({0} -P UnitFileState show -- "$UNIT"); '
             'if [ -n "$STATE" ]; then '
             'echo "$UNIT" "$STATE"; '
             'fi; '

--- a/pyinfra/facts/systemd.py
+++ b/pyinfra/facts/systemd.py
@@ -89,15 +89,15 @@ class SystemdEnabled(FactBase):
             user_name=user_name,
         )
 
-        return '''
-            {0} -al --plain --legend=false --state=loaded list-units |
-                while read -r UNIT REST; do
-                STATE=$(systemctl -P UnitFileState show -- "$UNIT")
-                if [ -n "$STATE" ]; then
-                    echo "$UNIT" "$STATE"
-                fi
-            done
-        '''.format(fact_cmd)
+        return (
+            '{0} -al --plain --legend=false --state=loaded list-units | '
+            'while read -r UNIT REST; do '
+            'STATE=$(systemctl -P UnitFileState show -- "$UNIT"); '
+            'if [ -n "$STATE" ]; then '
+            'echo "$UNIT" "$STATE"; '
+            'fi; '
+            'done'
+        ).format(fact_cmd)
 
     def process(self, output):
         units = {}

--- a/pyinfra/facts/systemd.py
+++ b/pyinfra/facts/systemd.py
@@ -55,7 +55,7 @@ class SystemdStatus(FactBase):
             user_name=user_name,
         )
 
-        return '{0} -al list-units'.format(fact_cmd)
+        return '{0} -al --plain --legend=false list-units'.format(fact_cmd)
 
     def process(self, output):
         services = {}
@@ -90,12 +90,12 @@ class SystemdEnabled(FactBase):
         )
 
         return '''
-            {0} --no-legend -al list-unit-files | while read -r UNIT STATUS; do
-                if [ "$STATUS" = generated ] &&
-                    {0} is-enabled $UNIT >/dev/null 2>&1; then
-                    STATUS=enabled
+            {0} -al --plain --legend=false --state=loaded list-units |
+                while read -r UNIT REST; do
+                STATE=$(systemctl -P UnitFileState show -- "$UNIT")
+                if [ -n "$STATE" ]; then
+                    echo "$UNIT" "$STATE"
                 fi
-                echo $UNIT $STATUS
             done
         '''.format(fact_cmd)
 

--- a/tests/facts/systemd.SystemdEnabled/machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [false, "testmachine", "testuser"],
-    "command": "\n            systemctl --machine=testuser@testmachine --no-legend -al list-unit-files | while read -r UNIT STATUS; do\n                if [ \"$STATUS\" = generated ] &&\n                    systemctl --machine=testuser@testmachine is-enabled $UNIT >/dev/null 2>&1; then\n                    STATUS=enabled\n                fi\n                echo $UNIT $STATUS\n            done\n        ",
+    "command": "systemctl --machine=testuser@testmachine -al --plain --legend=false --state=loaded list-units | while read -r UNIT REST; do STATE=$(systemctl --machine=testuser@testmachine -P UnitFileState show -- \"$UNIT\"); if [ -n \"$STATE\" ]; then echo \"$UNIT\" \"$STATE\"; fi; done",
     "requires_command": "systemctl",
     "output": [
         "vboxadd.service enabled",

--- a/tests/facts/systemd.SystemdEnabled/root_machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/root_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [false, "testmachine"],
-    "command": "\n            systemctl --machine=testmachine --no-legend -al list-unit-files | while read -r UNIT STATUS; do\n                if [ \"$STATUS\" = generated ] &&\n                    systemctl --machine=testmachine is-enabled $UNIT >/dev/null 2>&1; then\n                    STATUS=enabled\n                fi\n                echo $UNIT $STATUS\n            done\n        ",
+    "command": "systemctl --machine=testmachine -al --plain --legend=false --state=loaded list-units | while read -r UNIT REST; do STATE=$(systemctl --machine=testmachine -P UnitFileState show -- \"$UNIT\"); if [ -n \"$STATE\" ]; then echo \"$UNIT\" \"$STATE\"; fi; done",
     "requires_command": "systemctl",
     "output": [
         "vboxadd.service enabled",

--- a/tests/facts/systemd.SystemdEnabled/services.json
+++ b/tests/facts/systemd.SystemdEnabled/services.json
@@ -1,5 +1,6 @@
 {
     "requires_command": "systemctl",
+    "command": "systemctl -al --plain --legend=false --state=loaded list-units | while read -r UNIT REST; do STATE=$(systemctl -P UnitFileState show -- \"$UNIT\"); if [ -n \"$STATE\" ]; then echo \"$UNIT\" \"$STATE\"; fi; done",
     "output": [
         "vboxadd.service enabled",
         "vgauth.timer enabled",

--- a/tests/facts/systemd.SystemdEnabled/user_machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/user_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [true, "testmachine", "testuser"],
-    "command": "\n            systemctl --user --machine=testuser@testmachine --no-legend -al list-unit-files | while read -r UNIT STATUS; do\n                if [ \"$STATUS\" = generated ] &&\n                    systemctl --user --machine=testuser@testmachine is-enabled $UNIT >/dev/null 2>&1; then\n                    STATUS=enabled\n                fi\n                echo $UNIT $STATUS\n            done\n        ",
+    "command": "systemctl --user --machine=testuser@testmachine -al --plain --legend=false --state=loaded list-units | while read -r UNIT REST; do STATE=$(systemctl --user --machine=testuser@testmachine -P UnitFileState show -- \"$UNIT\"); if [ -n \"$STATE\" ]; then echo \"$UNIT\" \"$STATE\"; fi; done",
     "requires_command": "systemctl",
     "output": [
         "vboxadd.service enabled",

--- a/tests/facts/systemd.SystemdEnabled/user_services.json
+++ b/tests/facts/systemd.SystemdEnabled/user_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [true],
-    "command": "\n            systemctl --user --no-legend -al list-unit-files | while read -r UNIT STATUS; do\n                if [ \"$STATUS\" = generated ] &&\n                    systemctl --user is-enabled $UNIT >/dev/null 2>&1; then\n                    STATUS=enabled\n                fi\n                echo $UNIT $STATUS\n            done\n        ",
+    "command": "systemctl --user -al --plain --legend=false --state=loaded list-units | while read -r UNIT REST; do STATE=$(systemctl --user -P UnitFileState show -- \"$UNIT\"); if [ -n \"$STATE\" ]; then echo \"$UNIT\" \"$STATE\"; fi; done",
     "requires_command": "systemctl",
     "output": [
         "vboxadd.service enabled",

--- a/tests/facts/systemd.SystemdStatus/machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [false, "testmachine", "testuser"],
-    "command": "systemctl --machine=testuser@testmachine -al list-units",
+    "command": "systemctl --machine=testuser@testmachine -al --plain --legend=false list-units",
     "requires_command": "systemctl",
     "output": [
         "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/root_machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/root_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [false, "testmachine"],
-    "command": "systemctl --machine=testmachine -al list-units",
+    "command": "systemctl --machine=testmachine -al --plain --legend=false list-units",
     "requires_command": "systemctl",
     "output": [
         "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/services.json
+++ b/tests/facts/systemd.SystemdStatus/services.json
@@ -1,5 +1,5 @@
 {
-    "command": "systemctl -al list-units",
+    "command": "systemctl -al --plain --legend=false list-units",
     "requires_command": "systemctl",
     "output": [
         "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/user_machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/user_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": ["True", "testmachine", "testuser"],
-    "command": "systemctl --user --machine=testuser@testmachine -al list-units",
+    "command": "systemctl --user --machine=testuser@testmachine -al --plain --legend=false list-units",
     "requires_command": "systemctl",
     "output": [
         "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/user_services.json
+++ b/tests/facts/systemd.SystemdStatus/user_services.json
@@ -1,6 +1,6 @@
 {
     "arg": ["True"],
-    "command": "systemctl --user -al list-units",
+    "command": "systemctl --user -al --plain --legend=false list-units",
     "requires_command": "systemctl",
     "output": [
         "lvm2-activation.service      not-found inactive dead    lvm2-activation.service",


### PR DESCRIPTION
The SystemdEnabled fact did not properly report the status of instantiated systemd units (IE: `kresd@1.service`) because it used `systemctl list-unit-files` to generate the list of units to check the status of. Unfortunately there is either a bug in systemd or an error in the documentation suggesting `list-unit-files` should list instantiated units, which it does not seem to do consistently.

The net effect was that sometimes operations to enable an instantiated service were not idempotent when they should have been. The changes in this PR resolve that behavioral inconsistency.

Now, `systemctl list-units` is used which provides a more complete list of units on the system and then `systemctl show` is used to obtain the unit file enabled status.