### PR TITLE
Nested operations

### DIFF
--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -178,7 +178,7 @@ Nested Operations
 
 .. important::
 
-    Nested operations should be kept to a minimum as they cannot be tracked as changes prior to execution.
+    **Nested operations are currently in beta**. Nested operations should be kept to a minimum as they cannot be tracked as changes prior to execution.
 
 Nested operations are called during the execution phase within a callback function passed into a :ref:`operations:python.call`. Calling a nested operation generates and immediately executes it on the target machine. This is useful in complex scenarios where one operation output is required in another.
 

--- a/pyinfra/api/host.py
+++ b/pyinfra/api/host.py
@@ -80,17 +80,21 @@ class Host(object):
     connection = None
     state = None
 
-    # Current context inside an @operation function
+    # Current context inside an @operation function (op gen stage)
     in_op = False
     current_op_hash = None
     current_op_global_kwargs = None
 
-    # Current context inside a @deploy function
+    # Current context inside a @deploy function (op gen stage)
     in_deploy = False
     current_deploy_name = None
     current_deploy_kwargs = None
     current_deploy_data = None
     current_deploy_op_order = None
+
+    # Current context during operation execution
+    executing_op_hash = None
+    nested_executing_op_hash = None
 
     def __init__(
         self,
@@ -142,6 +146,13 @@ class Host(object):
 
     @property
     def print_prefix(self):
+        if self.nested_executing_op_hash:
+            return "{0}[{1}] {2} ".format(
+                click.style(""),  # reset
+                click.style(self.name, bold=True),
+                click.style("nested", "blue"),
+            )
+
         return "{0}[{1}] ".format(
             click.style(""),  # reset
             click.style(self.name, bold=True),

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -250,6 +250,13 @@ def operation(
                     ),
                 )
 
+        # This a nested operation, so place the line order underneath the parent
+        # operation lines so the final order makes sense. Nested operations are
+        # executed immediately so the order is only for debugging purposes.
+        if host.executing_op_hash:
+            executing_lines = state.op_meta[host.executing_op_hash]["op_order"]
+            op_order = executing_lines + tuple(op_order)
+
         # Make a hash from the call stack lines
         op_hash = make_hash(op_order)
 
@@ -286,6 +293,7 @@ def operation(
             {
                 "names": set(),
                 "args": [],
+                "op_order": op_order,
             },
         )
 

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -240,11 +240,13 @@ def operation(
             if host.in_deploy:
                 frameinfo = get_caller_frameinfo()
                 op_order = host.current_deploy_op_order + [frameinfo.lineno]
+            elif host.nested_executing_op_hash:
+                raise PyinfraError("Nested operations are not supported in API mode")
             else:
                 raise PyinfraError(
                     (
                         "Operation order number not provided in API mode - "
-                        "you must use `add_op` to add operations."
+                        "you must use `add_op` to add operations"
                     ),
                 )
 

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -379,6 +379,11 @@ def operation(
 
         # If we're already in the execution phase, execute this operation immediately
         if state.is_executing:
+            logger.warning(
+                f"Note: nested operations are currently in beta ({get_call_location()})\n"
+                "    More information: "
+                "https://docs.pyinfra.com/en/latest/using-operations.html#nested-operations",
+            )
             op_data["parent_op_hash"] = host.executing_op_hash
             log_operation_start(op_meta, op_types=["nested"], prefix="")
             run_host_op(state, host, op_hash)

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -30,6 +30,8 @@ op_meta_default = object()
 
 
 class OperationMeta(object):
+    combined_output_lines = None
+
     def __init__(self, hash=None, commands=None):
         # Wrap all the attributes
         commands = commands or []
@@ -40,8 +42,39 @@ class OperationMeta(object):
         self.changed = len(self.commands) > 0
 
     def __repr__(self):
-        """Return Operation object as a string."""
-        return "commands:{} changed:{} hash:{}".format(self.commands, self.changed, self.hash)
+        """
+        Return Operation object as a string.
+        """
+
+        return (
+            f"OperationMeta(commands={len(self.commands)}, "
+            f"changed={self.changed}, hash={self.hash})"
+        )
+
+    def set_combined_output_lines(self, combined_output_lines):
+        self.combined_output_lines = combined_output_lines
+
+    def _get_lines(self, types=("stdout", "stderr")):
+        if self.combined_output_lines is None:
+            raise AttributeError("Output is not available until operations have been executed")
+
+        return [line for type_, line in self.combined_output_lines if type_ in types]
+
+    @property
+    def stdout_lines(self):
+        return self._get_lines(types=("stdout",))
+
+    @property
+    def stderr_lines(self):
+        return self._get_lines(types=("stderr",))
+
+    @property
+    def stdout(self):
+        return "\n".join(self.stdout_lines)
+
+    @property
+    def stderr(self):
+        return "\n".join(self.stderr_lines)
 
 
 def add_op(state, op_func, *args, **kwargs):

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -258,6 +258,9 @@ class State(object):
     def get_op_data(self, host, op_hash):
         return self.ops[host][op_hash]
 
+    def set_op_data(self, host, op_hash, op_data):
+        self.ops[host][op_hash] = op_data
+
     def activate_host(self, host):
         """
         Flag a host as active.

--- a/pyinfra/operations/python.py
+++ b/pyinfra/operations/python.py
@@ -2,7 +2,11 @@
 The Python module allows you to execute Python code within the context of a deploy.
 """
 
+from inspect import getfullargspec
+
+from pyinfra import logger
 from pyinfra.api import FunctionCommand, operation
+from pyinfra.api.util import get_call_location
 
 
 @operation(is_idempotent=False)
@@ -39,6 +43,13 @@ def call(function, *args, **kwargs):
         )
 
     """
+
+    argspec = getfullargspec(function)
+    if "state" in argspec.args and "host" in argspec.args:
+        logger.warning(
+            "Callback functions used in `python.call` operations no "
+            f"longer take `state` and `host` arguments: {get_call_location(frame_offset=3)}",
+        )
 
     kwargs.pop("state", None)
     kwargs.pop("host", None)

--- a/pyinfra_cli/util.py
+++ b/pyinfra_cli/util.py
@@ -26,6 +26,7 @@ from pyinfra import logger, state
 from pyinfra.api.command import PyinfraCommand
 from pyinfra.api.exceptions import PyinfraError
 from pyinfra.api.host import HostData
+from pyinfra.api.operation import OperationMeta
 from pyinfra.context import ctx_config, ctx_host
 from pyinfra.progress import progress_spinner
 
@@ -80,6 +81,9 @@ def json_encode(obj):
         return obj.dict()
 
     elif isinstance(obj, PyinfraCommand):
+        return repr(obj)
+
+    elif isinstance(obj, OperationMeta):
         return repr(obj)
 
     # Python types

--- a/tests/deploy/deploy_random.py
+++ b/tests/deploy/deploy_random.py
@@ -7,7 +7,7 @@ from time import sleep
 
 from pyinfra import config, host, inventory
 from pyinfra.facts.server import Arch, Os
-from pyinfra.operations import server
+from pyinfra.operations import python, server
 
 config.SUDO = True
 
@@ -50,6 +50,31 @@ else:  # some other host
     somehost.get_fact(Os)
 
     assert config.SUDO is True
+
+
+def nested_op():
+    sleep(randint(1, 10) * 0.01)
+    server.shell(
+        name="First nested operation",
+        commands="echo first_nested_operation",
+    )
+
+    if host.name == "anotherhost":
+        sleep(randint(1, 10) * 0.01)
+        server.shell(
+            name="Second nested anotherhost operation",
+            commands="echo first_nested_operation",
+        )
+
+    if host.name == "somehost":
+        server.shell(
+            name="Second nested somehost operation",
+            commands="echo first_nested_operation",
+        )
+
+
+python.call(name="Function call operation", function=nested_op)
+
 
 sleep(randint(1, 10) * 0.01)
 server.shell(

--- a/tests/test_cli/test_cli_deploy.py
+++ b/tests/test_cli/test_cli_deploy.py
@@ -105,6 +105,10 @@ class TestCliDeployState(PatchSSHTestCase):
             ("First main operation", True),
             ("Second main somehost operation", ("somehost",)),
             ("Second main anotherhost operation", ("anotherhost",)),
+            ("Function call operation", True),
+            ("First nested operation", True),
+            ("Second nested anotherhost operation", ("anotherhost",)),
+            ("Second nested somehost operation", ("somehost",)),
             ("Third main operation", True),
         ]
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -4,7 +4,7 @@ import warnings
 from importlib import import_module
 from os import listdir, path
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from pyinfra.api import FileDownloadCommand, FileUploadCommand, FunctionCommand, StringCommand
 from pyinfra_cli.util import json_encode
@@ -89,6 +89,7 @@ def make_operation_tests(arg):
     # Generate a test class
     @patch("pyinfra.operations.files.get_timestamp", lambda: "a-timestamp")
     @patch("pyinfra.operations.util.files.get_timestamp", lambda: "a-timestamp")
+    @patch("pyinfra.operations.python.getfullargspec", lambda x: MagicMock())
     class TestTests(TestCase, metaclass=JsonTest):
         jsontest_files = path.join("tests", "operations", arg)
         jsontest_prefix = "test_{0}_{1}_".format(module_name, op_name)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -4,7 +4,7 @@ import warnings
 from importlib import import_module
 from os import listdir, path
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from pyinfra.api import FileDownloadCommand, FileUploadCommand, FunctionCommand, StringCommand
 from pyinfra_cli.util import json_encode


### PR DESCRIPTION
Nested operations are called during the execution phase within a callback
function passed into a `python.call` operation. Calling a nested operation
generates and immediately executes it on the target machine.

This is useful in complex scenarios where one operation output is
required in another. Nested operation calls should be kept to a minimunm
as they cannot be tracked as changes pre-execution.

In addition, this changes enables accessing operation output within callback
functions (via `stdout` and `stderr` attributes).

Example:

```py
from pyinfra import host, logger, operations

outer = operations.server.shell(
    commands=["echo outer"],
)
# outer.stdout raises exception here, works inside inner()


def inner():
    inner = operations.server.shell(
        commands=["echo inner"],
    )

    logger.info(f"Got host: {host}")
    logger.info(f"Got outer: {outer.stdout}")
    logger.info(f"Got inner: {inner.stdout}")


operations.python.call(
    function=inner,
)
```

TODO:

- [x] tests
- [x] documentation