### PR TITLE
Fix: Remove state/host arguments from apt.dist_upgrade operation

### DIFF
--- a/pyinfra/operations/apt.py
+++ b/pyinfra/operations/apt.py
@@ -360,7 +360,7 @@ _upgrade = upgrade  # noqa: E305 (for use below where update is a kwarg)
 
 
 @operation(is_idempotent=False)
-def dist_upgrade(state, host):
+def dist_upgrade():
     """
     Updates all apt packages, employing dist-upgrade.
 

--- a/tests/operations/apt.dist_upgrade/dist_upgrade.json
+++ b/tests/operations/apt.dist_upgrade/dist_upgrade.json
@@ -1,0 +1,7 @@
+{
+    "args": [],
+    "commands": [
+        "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" dist-upgrade"
+    ],
+    "idempotent": false
+}


### PR DESCRIPTION
This PR fixes the following issue with `apt.dist_upgrade()` operation

```bash
TypeError: dist_upgrade() missing 2 required positional arguments: 'state' and 'host'
```