### PR TITLE
DAG operation ordering

### DIFF
--- a/pyinfra/api/host.py
+++ b/pyinfra/api/host.py
@@ -90,7 +90,6 @@ class Host(object):
     current_deploy_name = None
     current_deploy_kwargs = None
     current_deploy_data = None
-    current_deploy_op_order = None
 
     # Current context during operation execution
     executing_op_hash = None
@@ -183,7 +182,7 @@ class Host(object):
         handler("{0}noop: {1}".format(self.print_prefix, description))
 
     @contextmanager
-    def deploy(self, name, kwargs, data, in_deploy=True, deploy_op_order=None):
+    def deploy(self, name, kwargs, data, in_deploy=True):
         """
         Wraps a group of operations as a deploy, this should not be used
         directly, instead use ``pyinfra.api.deploy.deploy``.
@@ -198,14 +197,12 @@ class Host(object):
         old_deploy_name = self.current_deploy_name
         old_deploy_kwargs = self.current_deploy_kwargs
         old_deploy_data = self.current_deploy_data
-        old_deploy_op_order = self.current_deploy_op_order
         self.in_deploy = in_deploy
 
         # Set the new values
         self.current_deploy_name = name
         self.current_deploy_kwargs = kwargs
         self.current_deploy_data = data
-        self.current_deploy_op_order = deploy_op_order
         logger.debug(
             "Starting deploy {0} (args={1}, data={2})".format(
                 name,
@@ -221,7 +218,6 @@ class Host(object):
         self.current_deploy_name = old_deploy_name
         self.current_deploy_kwargs = old_deploy_kwargs
         self.current_deploy_data = old_deploy_data
-        self.current_deploy_op_order = old_deploy_op_order
 
         logger.debug(
             "Reset deploy to {0} (args={1}, data={2})".format(

--- a/pyinfra/api/host.py
+++ b/pyinfra/api/host.py
@@ -115,6 +115,10 @@ class Host(object):
         self.facts = {}
         self.facts_lock = BoundedSemaphore()
 
+        # Append only list of operation hashes as called on this host, used to
+        # generate a DAG to create the final operation order.
+        self.op_hash_order = []
+
         # Create the (waterfall data: override, host, group, global)
         self.data = HostData(
             self,

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -264,14 +264,13 @@ def operation(
         # a loop - such that the filename/lineno/code _are_ the same, but the
         # arguments might be different. We just append an increasing number to
         # the op hash and also handle below with the op order.
-        host_op_hashes = state.meta[host]["op_hashes"]
         duplicate_op_count = 0
-        while op_hash in host_op_hashes:
+        while op_hash in host.op_hash_order:
             logger.debug("Duplicate hash ({0}) detected!".format(op_hash))
             op_hash = "{0}-{1}".format(op_hash, duplicate_op_count)
             duplicate_op_count += 1
 
-        host_op_hashes.add(op_hash)
+        host.op_hash_order.append(op_hash)
 
         if duplicate_op_count:
             op_order.append(duplicate_op_count)
@@ -285,7 +284,6 @@ def operation(
                 op_hash,
             ),
         )
-        state.op_line_numbers_to_hash[op_order] = op_hash
 
         # Ensure shared (between servers) operation meta
         op_meta = state.op_meta.setdefault(

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -9,7 +9,7 @@ from pyinfra import logger
 
 from .config import Config
 from .exceptions import PyinfraError
-from .util import get_caller_frameinfo, sha1_hash
+from .util import sha1_hash
 
 # Work out the max parallel we can achieve with the open files limit of the user/process,
 # take 10 for opening Python files and /3 for ~3 files per host during op runs.
@@ -88,10 +88,6 @@ class State(object):
 
     # Whether we are executing operations (ie hosts are all ready)
     is_executing = False
-
-    loop_counter = None
-    loop_line = None
-    loop_filename = None
 
     print_noop_info = False  # print "[host] noop: reason for noop"
     print_fact_info = False  # print "loaded fact X"
@@ -231,20 +227,13 @@ class State(object):
 
     @contextmanager
     def preserve_loop_order(self, items):
-        frameinfo = get_caller_frameinfo(frame_offset=1)  # escape contextlib
-        self.loop_line = frameinfo.lineno
-        self.loop_filename = frameinfo.filename
-
-        def item_generator():
-            for i, item in enumerate(items, 1):
-                self.loop_counter = i
-                yield item
-
-        yield item_generator
-
-        self.loop_counter = None
-        self.loop_line = None
-        self.loop_filename = None
+        logger.warning(
+            (
+                "Using `state.preserve_loop_order` is not longer required for operations to be "
+                "executed in correct loop order and can be safely removed."
+            ),
+        )
+        yield lambda: items
 
     def get_op_order(self):
         ts = TopologicalSorter()

--- a/pyinfra/api/util.py
+++ b/pyinfra/api/util.py
@@ -143,9 +143,6 @@ def get_operation_order_from_stack(state):
         if frame.filename.startswith(PYINFRA_API_DIR):
             continue
 
-        if state.loop_filename and frame.filename == state.loop_filename:
-            line_numbers.extend([state.loop_line, state.loop_counter])
-
         line_numbers.append(frame.lineno)
 
     del stack_items

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ INSTALL_REQUIRES = (
     "configparser",
     "pywinrm",
     "distro>=1.5,<2",
+    # Backport of graphlib used for DAG operation ordering
+    'graphlib_backport ; python_version < "3.9"',
 )
 
 ANSIBLE_REQUIRES = ("pyyaml",)  # extras for parsing Ansible inventory

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from inspect import currentframe, getframeinfo
 from os import path
 from unittest import TestCase
 from unittest.mock import mock_open, patch
@@ -484,13 +483,11 @@ class TestOperationOrdering(PatchSSHTestCase):
         # it replicates a deploy file.
         ctx_host.set(inventory.get_host("anotherhost"))
         first_context_hash = server.user("anotherhost_user").hash
-        first_context_call_line = getframeinfo(currentframe()).lineno - 1
 
         # Add op to just the first host - using the context modules such that
         # it replicates a deploy file.
         ctx_host.set(inventory.get_host("somehost"))
         second_context_hash = server.user("somehost_user").hash
-        second_context_call_line = getframeinfo(currentframe()).lineno - 1
 
         ctx_state.reset()
         ctx_host.reset()
@@ -504,12 +501,6 @@ class TestOperationOrdering(PatchSSHTestCase):
         # And that the two ops above were called in the expected order
         assert op_order[1] == first_context_hash
         assert op_order[2] == second_context_hash
-
-        # And that they have the expected line numbers
-        assert state.op_line_numbers_to_hash.get((0, first_context_call_line)) == first_context_hash
-        assert (
-            state.op_line_numbers_to_hash.get((0, second_context_call_line)) == second_context_hash
-        )
 
         # Ensure somehost has two ops and anotherhost only has the one
         assert len(state.ops[inventory.get_host("somehost")]) == 2

--- a/tests/test_cli/test_cli_deploy.py
+++ b/tests/test_cli/test_cli_deploy.py
@@ -43,11 +43,10 @@ class TestCliDeployState(PatchSSHTestCase):
             assert list(op_meta["names"])[0] == correct_op_name
 
             for host in state.inventory:
-                op_hashes = state.meta[host]["op_hashes"]
                 if correct_host_names is True or host.name in correct_host_names:
-                    self.assertIn(op_hash, op_hashes)
+                    self.assertIn(op_hash, host.op_hash_order)
                 else:
-                    self.assertNotIn(op_hash, op_hashes)
+                    self.assertNotIn(op_hash, host.op_hash_order)
 
     def test_deploy(self):
         task_file_path = path.join("tasks", "a_task.py")
@@ -106,10 +105,10 @@ class TestCliDeployState(PatchSSHTestCase):
             ("Second main somehost operation", ("somehost",)),
             ("Second main anotherhost operation", ("anotherhost",)),
             ("Function call operation", True),
+            ("Third main operation", True),
             ("First nested operation", True),
             ("Second nested anotherhost operation", ("anotherhost",)),
             ("Second nested somehost operation", ("somehost",)),
-            ("Third main operation", True),
         ]
 
         # Run 3 iterations of the test - each time shuffling the order of the

--- a/tests/util.py
+++ b/tests/util.py
@@ -168,7 +168,6 @@ class FakeHost(object):
     current_deploy_name = None
     current_deploy_kwargs = None
     current_deploy_data = None
-    current_deploy_op_order = None
 
     def __init__(self, name, facts, data):
         self.name = name


### PR DESCRIPTION
Whilst looking into some recent issues with the `State.preserve_loop_order` function I realised a DAG would potentially remove the need for this, and other such hacks, entirely.

Operation order is now based on call order per host, combined into a DAG to generate the final order. The line numbers are still used in tie-break situations so operations continue to execute as expected.

Tested on and will close: #814 + #815 + #816