### PR TITLE
cli.md: fix shell autocompletion instructions

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,6 +160,6 @@ Add the following to your `~/.bash_profile` or `~/.profile` files:
 These files were generated using these commands:
 
 ```
-env _PYINFRA_COMPLETE=source_bash pyinfra > pyinfra-complete.sh
-env _PYINFRA_COMPLETE=source_zsh pyinfra > pyinfra-complete.zsh
+env _PYINFRA_COMPLETE=bash_source pyinfra > pyinfra-complete.sh
+env _PYINFRA_COMPLETE=zsh_source pyinfra > pyinfra-complete.zsh
 ```


### PR DESCRIPTION
Per [Shell Completion](https://click.palletsprojects.com/en/8.1.x/shell-completion/) the correct form is:

```
{PROG_NAME}_COMPLETE set to {shell}_source
```

Note that it is `{shell}_source` and NOT `source_{shell}`.