### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/pyinfra/api/facts.py
+++ b/pyinfra/api/facts.py
@@ -219,6 +219,7 @@ def _get_fact(
 
     status = False
     stdout = []
+    combined_output_lines = []
 
     try:
         status, combined_output_lines = host.run_shell_command(


### PR DESCRIPTION
If `host.run_shell_command` throws an exception on line 225, then 
combined_output_lines ends up undefined, causing an UnboundLocalError
on line 239.

Resolves #846.