### PR TITLE
Fix short facts whose base fact requires arguments

### DIFF
--- a/pyinfra/api/facts.py
+++ b/pyinfra/api/facts.py
@@ -131,7 +131,14 @@ def get_fact(
     use_cache=True,
 ):
     if issubclass(cls, ShortFactBase):
-        return get_short_facts(state, host, cls, args=args, ensure_hosts=ensure_hosts)
+        return get_short_facts(
+            state,
+            host,
+            cls,
+            args=args,
+            kwargs=kwargs,
+            ensure_hosts=ensure_hosts,
+        )
 
     with host.facts_lock:
         if use_cache and fact_hash and fact_hash in host.facts:


### PR DESCRIPTION
kwargs must be passed to get_short_facts, otherwise it doesn't come back to get_fact
when its called on the underlying fact. If the underlying fact requires any arguments 
a TypeError would be thrown.