### PR TITLE
get_facts: run get_fact with context set

### DIFF
--- a/pyinfra/api/facts.py
+++ b/pyinfra/api/facts.py
@@ -23,6 +23,7 @@ from pyinfra.api.util import (
     print_host_combined_output,
 )
 from pyinfra.connectors.util import split_combined_output
+from pyinfra.context import ctx_host, ctx_state
 from pyinfra.progress import progress_spinner
 
 from .arguments import get_executor_kwarg_keys
@@ -97,8 +98,13 @@ def _get_executor_kwargs(state, host, override_kwargs=None, override_kwarg_keys=
 
 
 def get_facts(state, *args, **kwargs):
+    def get_fact_with_context(state, host, *args, **kwargs):
+        with ctx_state.use(state):
+            with ctx_host.use(host):
+                return get_fact(state, host, *args, **kwargs)
+
     greenlet_to_host = {
-        state.pool.spawn(get_fact, state, host, *args, **kwargs): host
+        state.pool.spawn(get_fact_with_context, state, host, *args, **kwargs): host
         for host in state.inventory.iter_active_hosts()
     }
 


### PR DESCRIPTION
User-defined facts might expect to have a context in all situations,
not just when run as part of an operation. e.g, when called via
`pyinfra INVENTORY fact ...`.

Another use case is when setting `CONFIG.use_sudo_password` to a
function which wants to look-up the password as an attribute on a
host's group-data, the function might be surprised to find that host
isn't an instance of Host, but rather is the ctx_host.