### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyinfra/facts/selinux.py
+++ b/pyinfra/facts/selinux.py
@@ -10,7 +10,7 @@ class FileContext(FactBase):
         {
             "user": "system_u",
             "role": "object_r",
-            "type": "deafult_t",
+            "type": "default_t",
             "level": "s0",
         }
     """

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -336,7 +336,7 @@ def hostname(hostname, hostname_file=None):
         The hostname file only matters no systems that do not have ``hostnamectl``,
         which is part of ``systemd``.
 
-        By default pyinfra will auto detect this by targetting ``/etc/hostname``
+        By default pyinfra will auto detect this by targeting ``/etc/hostname``
         on Linux and ``/etc/myname`` on OpenBSD.
 
         To completely disable writing the hostname file, set ``hostname_file=False``.


### PR DESCRIPTION
There are small typos in:
- pyinfra/facts/selinux.py
- pyinfra/operations/server.py

Fixes:
- Should read `targeting` rather than `targetting`.
- Should read `default` rather than `deafult`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md