### PR TITLE
fix lxd container hanging on launch

### DIFF
--- a/pyinfra/operations/lxd.py
+++ b/pyinfra/operations/lxd.py
@@ -62,7 +62,7 @@ def container(
     if present:
         if not container:
             # Command to create the container:
-            yield "lxc launch {image} {id}".format(id=id, image=image)
+            yield "lxc launch {image} {id} < /dev/null".format(id=id, image=image)
             current_containers.append(
                 {
                     "name": id,

--- a/tests/operations/lxd.container/add_container.json
+++ b/tests/operations/lxd.container/add_container.json
@@ -7,6 +7,6 @@
         "lxd.LxdContainers": []
     },
     "commands": [
-        "lxc launch ubuntu:16.04 container1"
+        "lxc launch ubuntu:16.04 container1 < /dev/null"
     ]
 }


### PR DESCRIPTION
See Fizzadar/pyinfra#860

Adds `< /dev/null` to the end of the command, per
[https://discuss.linuxcontainers.org/t/lxc-launch-over-ssh-need-pseudo-terminal-allocation/6238](https://discuss.linuxcontainers.org/t/lxc-launch-over-ssh-need-pseudo-terminal-allocation/6238)

fixes #860