### PR TITLE
first version of facts and operations for files.flags

### DIFF
--- a/pyinfra/facts/files.py
+++ b/pyinfra/facts/files.py
@@ -38,8 +38,6 @@ SYMBOL_TO_OCTAL_PERMISSIONS = {
     "--x": "1",
 }
 
-FLAGS_PATTERN = re.compile(r"^[d-][rwx-]{9}.\s+\d+\s+\w+\s+\w+\s+([a-z,]+).*$")
-
 
 def _parse_mode(mode):
     """

--- a/pyinfra/facts/files.py
+++ b/pyinfra/facts/files.py
@@ -367,7 +367,7 @@ class Flags(FactBase):
 
     def command(self, path):
         return make_formatted_string_command(
-            "stat -f %Sf {0} || true",
+            "! test -e {0} || stat -f %Sf {0}",
             QuoteString(path),
         )
 

--- a/pyinfra/facts/files.py
+++ b/pyinfra/facts/files.py
@@ -367,7 +367,8 @@ class Flags(FactBase):
 
     def command(self, path):
         return make_formatted_string_command(
-            "test -e {0} && ( test -d {0} && ls -Old {0} || ls -Ol {0} ) || true", QuoteString(path),
+            "test -e {0} && ( test -d {0} && ls -Old {0} || ls -Ol {0} ) || true",
+            QuoteString(path),
         )
 
     def process(self, output):

--- a/pyinfra/facts/files.py
+++ b/pyinfra/facts/files.py
@@ -367,7 +367,7 @@ class Flags(FactBase):
 
     def command(self, path):
         return make_formatted_string_command(
-            "test -e {0} && ( test -d {0} && ls -Old {0} || ls -Ol {0} ) || true", QuoteString(path)
+            "test -e {0} && ( test -d {0} && ls -Old {0} || ls -Ol {0} ) || true", QuoteString(path),
         )
 
     def process(self, output):

--- a/pyinfra/facts/files.py
+++ b/pyinfra/facts/files.py
@@ -373,4 +373,4 @@ class Flags(FactBase):
 
     def process(self, output):
 
-        return [flag for flag in output[0].split(",") if len(flag)>0]  if len(output) == 1 else []
+        return [flag for flag in output[0].split(",") if len(flag) > 0] if len(output) == 1 else []

--- a/pyinfra/facts/files.py
+++ b/pyinfra/facts/files.py
@@ -367,15 +367,10 @@ class Flags(FactBase):
 
     def command(self, path):
         return make_formatted_string_command(
-            "test -e {0} && ( test -d {0} && ls -Old {0} || ls -Ol {0} ) || true",
+            "stat -f %Sf {0} || true",
             QuoteString(path),
         )
 
     def process(self, output):
-        if len(output) != 1:
-            return []
-        match = FLAGS_PATTERN.match(output[0])
-        if not match:
-            return []
 
-        return match.group(1).split(",") if match.group(1) != "-" else []
+        return [flag for flag in output[0].split(",") if len(flag)>0]  if len(output) == 1 else []

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -1580,6 +1580,5 @@ def flags(path, flags=None, present=True):
             )
         else:
             host.noop(
-                f'file \'{path}\' already has \'{",".join(flags)}\' \
-                    {"set" if present else "clear"}',
+                f'\'{path}\' already has \'{",".join(flags)}\' {"set" if present else "clear"}',
             )

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -1580,5 +1580,5 @@ def flags(path, flags=None, present=True):
             )
         else:
             host.noop(
-                f'file \'{path}\' already has \'{",".join(flags)}\' {"set" if present else "clear"}'
+                f'file \'{path}\' already has \'{",".join(flags)}\' {"set" if present else "clear"}',
             )

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -1580,5 +1580,6 @@ def flags(path, flags=None, present=True):
             )
         else:
             host.noop(
-                f'file \'{path}\' already has \'{",".join(flags)}\' {"set" if present else "clear"}',
+                f'file \'{path}\' already has \'{",".join(flags)}\' \
+                    {"set" if present else "clear"}',
             )

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -38,6 +38,7 @@ from pyinfra.facts.files import (
     File,
     FindFiles,
     FindInFile,
+    Flags,
     Link,
     Md5File,
     Sha1File,
@@ -1526,3 +1527,58 @@ def directory(
 
         if not changed:
             host.noop("directory {0} already exists".format(path))
+
+
+@operation(pipeline_facts={"flags": "path"})
+def flags(path, flags=None, present=True):
+    """
+    Set/clear file flags.
+
+    + path: path of the remote folder
+    + flags: a list of the file flags to be set or cleared
+    + present: whether the flags should be set or cleared
+
+    **Examples:**
+
+    .. code:: python
+
+        files.flags(
+            name="Ensure ~/Library is visible in the GUI",
+            path="~/Library",
+            flags="hidden",
+            present=False
+        )
+
+        files.directory(
+            name="Ensure no one can change these files",
+            path="/something/very/important",
+            flags=["uchg", "schg"],
+            present=True,
+            _sudo=True
+        )
+    """
+    flags = flags or []
+    if not isinstance(flags, list):
+        flags = [flags]
+
+    if len(flags) == 0:
+        host.noop(f"no changes requested to flags for '{path}'")
+    else:
+        current_set = set(host.get_fact(Flags, path=path))
+        to_change = list(set(flags) - current_set) if present else list(current_set & set(flags))
+
+        if len(to_change) > 0:
+            prefix = "" if present else "no"
+            new_flags = ",".join([prefix + flag for flag in sorted(to_change)])
+            yield StringCommand("chflags", new_flags, QuoteString(path))
+            host.create_fact(
+                Flags,
+                kwargs={"path": path},
+                data=list(current_set | set(to_change))
+                if present
+                else list(current_set - set(to_change)),
+            )
+        else:
+            host.noop(
+                f'file \'{path}\' already has \'{",".join(flags)}\' {"set" if present else "clear"}'
+            )

--- a/pyinfra/operations/files.pyi
+++ b/pyinfra/operations/files.pyi
@@ -470,3 +470,42 @@ def directory(
     _run_once: typing.Optional[bool] = None,
     _serial: typing.Optional[bool] = None,
 ): ...
+def flags(
+    path,
+    flags=None,
+    present=True,
+    _no_check_owner_mode=False,
+    _no_fail_on_link=False,
+    _sudo: typing.Optional[bool] = None,
+    _sudo_user: typing.Optional[bool] = None,
+    _use_sudo_login: typing.Optional[bool] = None,
+    _use_sudo_password: typing.Optional[bool] = None,
+    _preserve_sudo_env: typing.Optional[bool] = None,
+    _su_user: typing.Optional[str] = None,
+    _use_su_login: typing.Optional[bool] = None,
+    _preserve_su_env: typing.Optional[bool] = None,
+    _su_shell: typing.Optional[str] = None,
+    _doas: typing.Optional[bool] = None,
+    _doas_user: typing.Optional[str] = None,
+    _shell_executable: typing.Optional[str] = None,
+    _chdir: typing.Optional[str] = None,
+    _env: typing.Optional[typing.Mapping[str, str]] = None,
+    _success_exit_codes: typing.Optional[typing.Iterable[int]] = None,
+    _timeout: typing.Optional[int] = None,
+    _get_pty: typing.Optional[bool] = None,
+    _stdin: typing.Optional[typing.Union[str, list, tuple]] = None,
+    name: typing.Optional[str] = None,
+    _ignore_errors: typing.Optional[bool] = None,
+    _continue_on_error: typing.Optional[bool] = None,
+    _precondition: typing.Optional[str] = None,
+    _postcondition: typing.Optional[str] = None,
+    _on_success: typing.Optional[
+        typing.Callable[[pyinfra.api.state.State, pyinfra.api.host.Host, str], None]
+    ] = None,
+    _on_error: typing.Optional[
+        typing.Callable[[pyinfra.api.state.State, pyinfra.api.host.Host, str], None]
+    ] = None,
+    _parallel: typing.Optional[int] = None,
+    _run_once: typing.Optional[bool] = None,
+    _serial: typing.Optional[bool] = None,
+): ...

--- a/pyinfra/operations/files.pyi
+++ b/pyinfra/operations/files.pyi
@@ -474,8 +474,6 @@ def flags(
     path,
     flags=None,
     present=True,
-    _no_check_owner_mode=False,
-    _no_fail_on_link=False,
     _sudo: typing.Optional[bool] = None,
     _sudo_user: typing.Optional[bool] = None,
     _use_sudo_login: typing.Optional[bool] = None,

--- a/tests/facts/files.Flags/bad_output.json
+++ b/tests/facts/files.Flags/bad_output.json
@@ -1,7 +1,7 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "stat -f %Sf /foo/bar/baz || true",
+    "command": "! test -e /foo/bar/baz || stat -f %Sf /foo/bar/baz",
     "output": [
 	",,,"
     ],

--- a/tests/facts/files.Flags/bad_output.json
+++ b/tests/facts/files.Flags/bad_output.json
@@ -1,0 +1,10 @@
+{
+    "arg": ["/foo/bar/baz"],
+    "requires_command": "chflags",
+    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "output": [
+        "drwxr-xr-x  25  pyinfra  - 800 Feb  2 13:51 ./"
+    ],
+    "fact": [
+    ]
+}

--- a/tests/facts/files.Flags/bad_output.json
+++ b/tests/facts/files.Flags/bad_output.json
@@ -1,9 +1,9 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "command": "stat -f %Sf /foo/bar/baz || true",
     "output": [
-        "drwxr-xr-x  25  pyinfra  - 800 Feb  2 13:51 ./"
+	",,,"
     ],
     "fact": [
     ]

--- a/tests/facts/files.Flags/no_flags_set.json
+++ b/tests/facts/files.Flags/no_flags_set.json
@@ -1,9 +1,9 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "command": "stat -f %Sf /foo/bar/baz || true",
     "output": [
-        "drwxr-xr-x  25 pyinfra  pyinfra  - 800 Feb  2 13:51 ./"
+        ""
     ],
     "fact": [
     ]

--- a/tests/facts/files.Flags/no_flags_set.json
+++ b/tests/facts/files.Flags/no_flags_set.json
@@ -1,7 +1,7 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "stat -f %Sf /foo/bar/baz || true",
+    "command": "! test -e /foo/bar/baz || stat -f %Sf /foo/bar/baz",
     "output": [
         ""
     ],

--- a/tests/facts/files.Flags/no_flags_set.json
+++ b/tests/facts/files.Flags/no_flags_set.json
@@ -1,0 +1,10 @@
+{
+    "arg": ["/foo/bar/baz"],
+    "requires_command": "chflags",
+    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "output": [
+        "drwxr-xr-x  25 pyinfra  pyinfra  - 800 Feb  2 13:51 ./"
+    ],
+    "fact": [
+    ]
+}

--- a/tests/facts/files.Flags/no_output.json
+++ b/tests/facts/files.Flags/no_output.json
@@ -1,7 +1,7 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "command": "stat -f %Sf /foo/bar/baz || true",
     "output": [
     ],
     "fact": [

--- a/tests/facts/files.Flags/no_output.json
+++ b/tests/facts/files.Flags/no_output.json
@@ -1,7 +1,7 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "stat -f %Sf /foo/bar/baz || true",
+    "command": "! test -e /foo/bar/baz || stat -f %Sf /foo/bar/baz",
     "output": [
     ],
     "fact": [

--- a/tests/facts/files.Flags/no_output.json
+++ b/tests/facts/files.Flags/no_output.json
@@ -1,0 +1,9 @@
+{
+    "arg": ["/foo/bar/baz"],
+    "requires_command": "chflags",
+    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "output": [
+    ],
+    "fact": [
+    ]
+}

--- a/tests/facts/files.Flags/one_flag_set.json
+++ b/tests/facts/files.Flags/one_flag_set.json
@@ -1,0 +1,11 @@
+{
+    "arg": ["/foo/bar/baz"],
+    "requires_command": "chflags",
+    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "output": [
+        "drwxr-xr-x  25 pyinfra  pyinfra  oneflag 800 Feb  2 13:51 ./"
+    ],
+    "fact": [
+        "oneflag"
+    ]
+}

--- a/tests/facts/files.Flags/one_flag_set.json
+++ b/tests/facts/files.Flags/one_flag_set.json
@@ -1,9 +1,9 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "command": "stat -f %Sf /foo/bar/baz || true",
     "output": [
-        "drwxr-xr-x  25 pyinfra  pyinfra  oneflag 800 Feb  2 13:51 ./"
+        "oneflag"
     ],
     "fact": [
         "oneflag"

--- a/tests/facts/files.Flags/one_flag_set.json
+++ b/tests/facts/files.Flags/one_flag_set.json
@@ -1,7 +1,7 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "stat -f %Sf /foo/bar/baz || true",
+    "command": "! test -e /foo/bar/baz || stat -f %Sf /foo/bar/baz",
     "output": [
         "oneflag"
     ],

--- a/tests/facts/files.Flags/too_much_output.json
+++ b/tests/facts/files.Flags/too_much_output.json
@@ -1,7 +1,7 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "stat -f %Sf /foo/bar/baz || true",
+    "command": "! test -e /foo/bar/baz || stat -f %Sf /foo/bar/baz",
     "output": [
         "line one",
         "line two"

--- a/tests/facts/files.Flags/too_much_output.json
+++ b/tests/facts/files.Flags/too_much_output.json
@@ -1,7 +1,7 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "command": "stat -f %Sf /foo/bar/baz || true",
     "output": [
         "line one",
         "line two"

--- a/tests/facts/files.Flags/too_much_output.json
+++ b/tests/facts/files.Flags/too_much_output.json
@@ -1,0 +1,11 @@
+{
+    "arg": ["/foo/bar/baz"],
+    "requires_command": "chflags",
+    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "output": [
+        "line one",
+        "line two"
+    ],
+    "fact": [
+    ]
+}

--- a/tests/facts/files.Flags/two_flags_set.json
+++ b/tests/facts/files.Flags/two_flags_set.json
@@ -1,9 +1,9 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "command": "stat -f %Sf /foo/bar/baz || true",
     "output": [
-        "drwxr-xr-x  25 pyinfra  pyinfra  oneflag,twoflag 800 Feb  2 13:51 ./"
+        "oneflag,twoflag"
     ],
     "fact": [
         "oneflag",

--- a/tests/facts/files.Flags/two_flags_set.json
+++ b/tests/facts/files.Flags/two_flags_set.json
@@ -1,0 +1,12 @@
+{
+    "arg": ["/foo/bar/baz"],
+    "requires_command": "chflags",
+    "command": "test -e /foo/bar/baz && ( test -d /foo/bar/baz && ls -Old /foo/bar/baz || ls -Ol /foo/bar/baz ) || true",
+    "output": [
+        "drwxr-xr-x  25 pyinfra  pyinfra  oneflag,twoflag 800 Feb  2 13:51 ./"
+    ],
+    "fact": [
+        "oneflag",
+        "twoflag"
+    ]
+}

--- a/tests/facts/files.Flags/two_flags_set.json
+++ b/tests/facts/files.Flags/two_flags_set.json
@@ -1,7 +1,7 @@
 {
     "arg": ["/foo/bar/baz"],
     "requires_command": "chflags",
-    "command": "stat -f %Sf /foo/bar/baz || true",
+    "command": "! test -e /foo/bar/baz || stat -f %Sf /foo/bar/baz",
     "output": [
         "oneflag,twoflag"
     ],

--- a/tests/operations/files.flags/clear_no_flags.json
+++ b/tests/operations/files.flags/clear_no_flags.json
@@ -1,0 +1,12 @@
+{
+    "args": ["/path/to/something"],
+    "kwargs": {
+        "flags": null,
+        "present": false
+    },
+    "facts": {
+    },
+    "commands": [
+    ],
+    "noop_description": "no changes requested to flags for '/path/to/something'"
+}

--- a/tests/operations/files.flags/clear_one_flag_already_clear.json
+++ b/tests/operations/files.flags/clear_one_flag_already_clear.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": "dump",
+        "present": false
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": []
+        }
+    },
+    "commands": [
+    ],
+    "noop_description": "file 'testdir' already has 'dump' clear"
+}

--- a/tests/operations/files.flags/clear_one_flag_already_clear.json
+++ b/tests/operations/files.flags/clear_one_flag_already_clear.json
@@ -11,5 +11,5 @@
     },
     "commands": [
     ],
-    "noop_description": "file 'testdir' already has 'dump' clear"
+    "noop_description": "'testdir' already has 'dump' clear"
 }

--- a/tests/operations/files.flags/clear_one_flag_was_set.json
+++ b/tests/operations/files.flags/clear_one_flag_was_set.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": "dump",
+        "present": false
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["dump"]
+        }
+    },
+    "commands": [
+        "chflags nodump testdir"
+    ]
+}

--- a/tests/operations/files.flags/clear_two_flags.json
+++ b/tests/operations/files.flags/clear_two_flags.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": ["dump", "hidden"],
+        "present": false
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["dump", "hidden", "archive"]
+        }
+    },
+    "commands": [
+        "chflags nodump,nohidden testdir"
+    ]
+}

--- a/tests/operations/files.flags/clear_two_flags_already_clear.json
+++ b/tests/operations/files.flags/clear_two_flags_already_clear.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": ["dump", "hidden"],
+        "present": false
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["archive"]
+        }
+    },
+    "commands": [
+    ],
+    "noop_description": "file 'testdir' already has 'dump,hidden' clear"
+}

--- a/tests/operations/files.flags/clear_two_flags_already_clear.json
+++ b/tests/operations/files.flags/clear_two_flags_already_clear.json
@@ -11,5 +11,5 @@
     },
     "commands": [
     ],
-    "noop_description": "file 'testdir' already has 'dump,hidden' clear"
+    "noop_description": "'testdir' already has 'dump,hidden' clear"
 }

--- a/tests/operations/files.flags/clear_two_flags_first_already_clear.json
+++ b/tests/operations/files.flags/clear_two_flags_first_already_clear.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": ["dump", "hidden"],
+        "present": false
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["hidden", "archive"]
+        }
+    },
+    "commands": [
+        "chflags nohidden testdir"
+    ]
+}

--- a/tests/operations/files.flags/clear_two_flags_second_already_clear.json
+++ b/tests/operations/files.flags/clear_two_flags_second_already_clear.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": ["dump", "hidden"],
+        "present": false
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["dump", "archive"]
+        }
+    },
+    "commands": [
+        "chflags nodump testdir"
+    ]
+}

--- a/tests/operations/files.flags/set_no_flags.json
+++ b/tests/operations/files.flags/set_no_flags.json
@@ -1,0 +1,12 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": null,
+        "present": true
+    },
+    "facts": {
+    },
+    "commands": [
+    ],
+    "noop_description": "no changes requested to flags for 'testdir'"
+}

--- a/tests/operations/files.flags/set_one_flag_already_set.json
+++ b/tests/operations/files.flags/set_one_flag_already_set.json
@@ -11,5 +11,5 @@
     },
     "commands": [
     ],
-    "noop_description": "file 'testdir' already has 'dump' set"
+    "noop_description": "'testdir' already has 'dump' set"
 }

--- a/tests/operations/files.flags/set_one_flag_already_set.json
+++ b/tests/operations/files.flags/set_one_flag_already_set.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": "dump",
+        "present": true
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["dump", "hidden", "archive"]
+        }
+    },
+    "commands": [
+    ],
+    "noop_description": "file 'testdir' already has 'dump' set"
+}

--- a/tests/operations/files.flags/set_one_flag_not_yet_set.json
+++ b/tests/operations/files.flags/set_one_flag_not_yet_set.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": "dump",
+        "present": true
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["hidden", "archive"]
+        }
+    },
+    "commands": [
+        "chflags dump testdir"
+    ]
+}

--- a/tests/operations/files.flags/set_two_flags.json
+++ b/tests/operations/files.flags/set_two_flags.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": ["dump", "hidden"],
+        "present": true
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["archive"]
+        }
+    },
+    "commands": [
+         "chflags dump,hidden testdir"
+   ]
+}

--- a/tests/operations/files.flags/set_two_flags_already_set.json
+++ b/tests/operations/files.flags/set_two_flags_already_set.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": ["dump", "hidden"],
+        "present": true
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["dump", "hidden", "archive"]
+        }
+    },
+    "commands": [
+    ],
+    "noop_description": "file 'testdir' already has 'dump,hidden' set"
+}

--- a/tests/operations/files.flags/set_two_flags_already_set.json
+++ b/tests/operations/files.flags/set_two_flags_already_set.json
@@ -11,5 +11,5 @@
     },
     "commands": [
     ],
-    "noop_description": "file 'testdir' already has 'dump,hidden' set"
+    "noop_description": "'testdir' already has 'dump,hidden' set"
 }

--- a/tests/operations/files.flags/set_two_flags_first_already_set.json
+++ b/tests/operations/files.flags/set_two_flags_first_already_set.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": ["dump", "hidden"],
+        "present": true
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["dump", "archive"]
+        }
+    },
+    "commands": [
+         "chflags hidden testdir"
+   ]
+}

--- a/tests/operations/files.flags/set_two_flags_second_already_set.json
+++ b/tests/operations/files.flags/set_two_flags_second_already_set.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testdir"],
+    "kwargs": {
+        "flags": ["dump", "hidden"],
+        "present": true
+    },
+    "facts": {
+        "files.Flags": {
+            "path=testdir": ["hidden", "archive"]
+        }
+    },
+    "commands": [
+        "chflags dump testdir"
+   ]
+}


### PR DESCRIPTION
This is a fact and an operation to support file "flags" as found in[ BSD-derived](https://github.com/morrison12/pyinfra/pull/new/flags) OSs (including macOS).
The first example for macOS would be automating the usual `chflags nohidden ~/Library` in many setup scripts.