### PR TITLE
Suggestions: Typing, Operations Decomposition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ dist/
 venv/
 .venv/
 .cache/
+.mypy_cache/
+.pytest_cache/
 
 .vagrant*
 
@@ -26,5 +28,6 @@ docs/apidoc/
 docs/_deploy_globals.rst
 
 .idea/
+.vscode/
 
 pyinfra-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 dist/
 
 venv/
+.venv/
 .cache/
 
 .vagrant*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+install_dev:
+	pip install -e '.[extra]'
+
+install_docs:
+	pip install -e '.[docs]'
+
+test:
+	pytest --cov
+
+.PHONY: docs
+docs:
+	sphinx-build -a docs/ docs/build/
+
+docs_serve:
+	python3 -m http.server -d docs/build/
+

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ state.disconnect_all()
 - Clone the forked repository with `git clone https://github.com/<you_user_name>/pyinfra.git`
 - Into the repo `cd pyinfra`
 - Set the original repo as upstram with `git remote add upstream https://github.com/Fizzadar/pyinfra`
-- Insall the necessary packages `pip install -e '.[dev]'`
+- Install the necessary packages `pip install -e '.[dev]'`
 - Create your new branch `git checkout -b my_new_feature`
 - Test everything is working: `pytest --cov`
 - Generate docs: `sphinx-build -a docs/ docs/build/`

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ config = Config(
 
 # Initialize the State object & Connect
 state = State(inventory, config)
-connect_all(state)
+state.connect_all()
 
 # Add operations to state
 add_op(
@@ -149,13 +149,15 @@ run_ops(state)
 
 # Get facts for all hosts
 facts = get_facts(state, LinuxName)
+
+state.disconnect_all()
 ```
 
 ## Developing
 
-Create a new fork: you can do this straight from Github.
-Clone the forked repository with `git clone https://github.com/<you_user_name>/pyinfra.git`
-Set the original repo as upstram with `git remote add upstream https://github.com/Fizzadar/pyinfra`
-Insall the necessary packages `python3 setup.py install`
-Create your new branch `git checkout -b my_new_feature`
-Test everything is working: `pytest`
+- Create a new fork: you can do this straight from Github.
+- Clone the forked repository with `git clone https://github.com/<you_user_name>/pyinfra.git`
+- Set the original repo as upstram with `git remote add upstream https://github.com/Fizzadar/pyinfra`
+- Insall the necessary packages `python3 setup.py install`
+- Create your new branch `git checkout -b my_new_feature`
+- Test everything is working: `pytest`

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@
 
 pyinfra automates/provisions/manages/deploys infrastructure. It can be used for ad-hoc command execution, service deployment, configuration management and more. Design features include:
 
-+ 🚀 **Super fast** execution over thousands of hosts with predictable performance.
-+ 🚨 **Instant debugging** with stdout & stderr output on error or as required (`-v`|`-vv`|`-vvv`).
-+ 📦 **Extendable** with _any_ Python package as configured & written in standard Python.
-+ 💻 **Agentless execution** against SSH/Docker/subprocess/winrm hosts.
-+ ❗️ **Two stage process** that enables `--dry` runs before executing any changes.
-+ 🔌 **Integrated** with Docker, Vagrant/Mech & Ansible out of the box.
+- 🚀 **Super fast** execution over thousands of hosts with predictable performance.
+- 🚨 **Instant debugging** with stdout & stderr output on error or as required (`-v`|`-vv`|`-vvv`).
+- 📦 **Extendable** with _any_ Python package as configured & written in standard Python.
+- 💻 **Agentless execution** against SSH/Docker/subprocess/winrm hosts.
+- ❗️ **Two stage process** that enables `--dry` runs before executing any changes.
+- 🔌 **Integrated** with Docker, Vagrant/Mech & Ansible out of the box.
 
 When you run pyinfra you'll see something like ([non animated version](https://pyinfra.com/static/example_deploy.png)):
 
@@ -72,7 +72,6 @@ pyinfra @docker/ubuntu apt.packages iftop update=true _sudo=true
 
 Which can then be saved as a Python file like `deploy.py`:
 
-
 ```py
 from pyinfra.operations import apt
 
@@ -90,7 +89,6 @@ The hosts can also be saved in a file, for example `inventory.py`:
 targets = ["@docker/ubuntu", "my-test-server.net"]
 ```
 
-
 And executed together:
 
 ```sh
@@ -100,3 +98,64 @@ pyinfra inventory.py deploy.py
 Now you know the building blocks of pyinfra! By combining inventory, operations and Python code you can deploy anything.
 
 See the more detailed [getting started](https://docs.pyinfra.com/page/getting-started.html) or [using operations](https://docs.pyinfra.com/page/using-operations.html) guides. See how to use [inventory & data](https://docs.pyinfra.com/page/inventory-data.html), [global arguments](https://docs.pyinfra.com/page/arguments.html) and [the CLI](https://docs.pyinfra.com/page/cli.html) or check out the [documented examples](https://docs.pyinfra.com/page/examples.html).
+
+## Using Pyinfra Programtically
+
+Pyinfra can also be used directly from within a Python a application, without the need of the CLI.
+Quick example shown below:
+
+```python
+# Basic imports
+from pyinfra.api import Config, Inventory, State
+from pyinfra.api.operation import add_op
+from pyinfra.api.operations import run_ops
+from pyinfra.api.connect import connect_all
+from pyinfra.api.facts import get_facts
+
+
+# Build your inventory:
+inventory = Inventory(
+    (["myhostname"], {
+            "ssh_hostname": "localhost",
+            "ssh_user": "vagrant",
+            "ssh_port": "2222",
+            "ssh_key": "/path/to/ssh_key/file"
+        })
+)
+
+# Initialize the configuration
+config = Config(
+    FAIL_PERCENT=81,
+    CONNECT_TIMEOUT=5
+)
+
+
+# Initialize the State object & Connect
+state = State(inventory, config)
+connect_all(state)
+
+# Add operations to state
+add_op(
+    state,
+    server.user,
+    user='vagrant',
+    home='/home/vagrant',
+    shell='/bin/bash',
+    sudo=True
+)
+
+# Run all state operations
+run_ops(state)
+
+# Get facts for all hosts
+facts = get_facts(state, LinuxName)
+```
+
+## Developing
+
+Create a new fork: you can do this straight from Github.
+Clone the forked repository with `git clone https://github.com/<you_user_name>/pyinfra.git`
+Set the original repo as upstram with `git remote add upstream https://github.com/Fizzadar/pyinfra`
+Insall the necessary packages `python3 setup.py install`
+Create your new branch `git checkout -b my_new_feature`
+Test everything is working: `pytest`

--- a/README.md
+++ b/README.md
@@ -157,7 +157,10 @@ state.disconnect_all()
 
 - Create a new fork: you can do this straight from Github.
 - Clone the forked repository with `git clone https://github.com/<you_user_name>/pyinfra.git`
+- Into the repo `cd pyinfra`
 - Set the original repo as upstram with `git remote add upstream https://github.com/Fizzadar/pyinfra`
-- Insall the necessary packages `python3 setup.py install`
+- Insall the necessary packages `pip install -e '.[dev]'`
 - Create your new branch `git checkout -b my_new_feature`
-- Test everything is working: `pytest`
+- Test everything is working: `pytest --cov`
+- Generate docs: `sphinx-build -a docs/ docs/build/`
+- View docs locally: `python -m http.server -d docs/build/` (http://localhost:8000)

--- a/pyinfra/api/arguments.py
+++ b/pyinfra/api/arguments.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
+import typing as t
 from typing import Callable, Iterable, Mapping, Union
 
 import pyinfra
 from pyinfra import context, logger
+from pyinfra.api.config import Config
 from pyinfra.api.state import State
+
+if t.TYPE_CHECKING:
+    from pyinfra.api.inventory import Host
 
 from .util import get_call_location, memoize
 
@@ -69,7 +76,7 @@ auth_kwargs = {
 }
 
 
-def generate_env(config, value):
+def generate_env(config: "Config", value):
     env = config.ENV.copy()
 
     # TODO: this is to protect against host.data.env being a string or similar,
@@ -219,7 +226,7 @@ def show_legacy_argument_host_data_warning(key):
     )
 
 
-def pop_global_arguments(kwargs, state=None, host=None, keys_to_check=None):
+def pop_global_arguments(kwargs, state: t.Optional["State"] = None, host: t.Optional["Host"] = None, keys_to_check=None):
     """
     Pop and return operation global keyword arguments, in preferred order:
 

--- a/pyinfra/api/config.py
+++ b/pyinfra/api/config.py
@@ -98,6 +98,32 @@ class Config(object):
     state = None
 
     def __init__(self, **kwargs):
+        """
+        Initialise the config with the given kwargs.
+        Has pre defined attributes to help with autocomplete & type checking.
+        """        
+        self.FAIL_PERCENT = None
+        self.CONNECT_TIMEOUT: int = 10
+        self.TEMP_DIR = None
+        self.PARALLEL = None
+        self.REQUIRE_PYINFRA_VERSION = None
+        self.REQUIRE_PACKAGES = None
+        self.SU_USER = None
+        self.USE_SU_LOGIN: bool = False
+        self.SU_SHELL = None
+        self.PRESERVE_SU_ENV: bool = False
+        self.SUDO: bool = False
+        self.SUDO_USER = None
+        self.PRESERVE_SUDO_ENV: bool = False
+        self.USE_SUDO_LOGIN: bool = False
+        self.USE_SUDO_PASSWORD: bool = False
+        self.DOAS: bool = False
+        self.DOAS_USER = None
+        self.DOAS = None
+        self.DOAS_USER = None
+        self.IGNORE_ERRORS: bool = False
+        self.SHELL = None
+
         # Always apply some env
         env = kwargs.pop("ENV", {})
         self.ENV = env

--- a/pyinfra/api/connect.py
+++ b/pyinfra/api/connect.py
@@ -1,9 +1,14 @@
+import typing as t
+
 import gevent
+
+if t.TYPE_CHECKING:
+    from pyinfra.api.state import State
 
 from pyinfra.progress import progress_spinner
 
 
-def connect_all(state):
+def connect_all(state: "State"):
     """
     Connect to all the configured servers in parallel. Reads/writes state.inventory.
 

--- a/pyinfra/api/connectors.py
+++ b/pyinfra/api/connectors.py
@@ -35,11 +35,12 @@ def get_all_connectors():
 
 
 def get_execution_connectors():
-    return {
+    all_conectors = {
         connector: connector_mod
         for connector, connector_mod in get_all_connectors().items()
         if connector_mod.Meta.handles_execution
     }
+    return all_conectors
 
 
 def get_execution_connector(name):

--- a/pyinfra/api/connectors.py
+++ b/pyinfra/api/connectors.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pkg_resources
 
 
@@ -34,14 +36,14 @@ def get_all_connectors():
     }
 
 
-def get_execution_connectors():
-    all_conectors = {
+def get_execution_connectors() -> t.Dict[str, t.Any]:
+    all_connectors = {
         connector: connector_mod
         for connector, connector_mod in get_all_connectors().items()
         if connector_mod.Meta.handles_execution
     }
-    return all_conectors
+    return all_connectors
 
 
-def get_execution_connector(name):
+def get_execution_connector(name: str) -> t.Any:
     return get_execution_connectors()[name]

--- a/pyinfra/api/facts.py
+++ b/pyinfra/api/facts.py
@@ -5,6 +5,7 @@ for a deploy.
 """
 
 import re
+import typing as t
 from inspect import getcallargs
 from socket import error as socket_error, timeout as timeout_error
 from typing import Optional, Type
@@ -16,6 +17,11 @@ from paramiko import SSHException
 from pyinfra import logger
 from pyinfra.api import StringCommand
 from pyinfra.api.arguments import pop_global_arguments
+
+if t.TYPE_CHECKING:
+    from pyinfra.api.host import Host
+    from pyinfra.api.state import State
+
 from pyinfra.api.util import (
     get_kwargs_str,
     log_error_or_warning,
@@ -98,7 +104,29 @@ def _get_executor_kwargs(state, host, override_kwargs=None, override_kwarg_keys=
     }
 
 
-def get_facts(state, *args, **kwargs):
+def get_facts(state: "State", *args, **kwargs):
+    """Get a set of Facts for a specific state.
+    Accepts the state or the host as the first argument, and the Fact class as the second.
+    Example::
+
+        ..codeblock:: python
+
+            >>> facts = get_facts(state, HostFact)
+
+    Args:
+        state (State): The State Object
+        host (Host): The Host Object
+        cls (FactBase): A Fact class that inherits from FactBase
+        args (_type_, optional): _description_. Defaults to None.
+        kwargs (_type_, optional): _description_. Defaults to None.
+        ensure_hosts (_type_, optional): _description_. Defaults to None.
+        apply_failed_hosts (bool, optional): _description_. Defaults to True.
+        fact_hash (_type_, optional): _description_. Defaults to None.
+        use_cache (bool, optional): _description_. Defaults to True.
+
+    Returns:
+        _type_: _description_
+    """
     def get_fact_with_context(state, host, *args, **kwargs):
         with ctx_state.use(state):
             with ctx_host.use(host):
@@ -121,16 +149,33 @@ def get_facts(state, *args, **kwargs):
 
 
 def get_fact(
-    state,
-    host,
-    cls,
-    args=None,
-    kwargs=None,
-    ensure_hosts=None,
-    apply_failed_hosts=True,
-    fact_hash=None,
-    use_cache=True,
+    state: "State",
+    host: "Host",
+    cls: t.Type[FactBase],
+    args = None,
+    kwargs = None,
+    ensure_hosts = None,
+    apply_failed_hosts: bool = True,
+    fact_hash = None,
+    use_cache: bool = True,
 ):
+    """
+    Get Fact for a specific state / host.
+
+    Args:
+        state (State): The State Object
+        host (Host): The Host Object
+        cls (FactBase): A Fact class that inherits from FactBase
+        args (_type_, optional): _description_. Defaults to None.
+        kwargs (_type_, optional): _description_. Defaults to None.
+        ensure_hosts (_type_, optional): _description_. Defaults to None.
+        apply_failed_hosts (bool, optional): _description_. Defaults to True.
+        fact_hash (_type_, optional): _description_. Defaults to None.
+        use_cache (bool, optional): _description_. Defaults to True.
+
+    Returns:
+        _type_: _description_
+    """
     if issubclass(cls, ShortFactBase):
         return get_short_facts(
             state,

--- a/pyinfra/api/host.py
+++ b/pyinfra/api/host.py
@@ -1,9 +1,14 @@
+import typing as t
 from contextlib import contextmanager
 
 import click
 from gevent.lock import BoundedSemaphore
 
 from pyinfra import logger
+
+if t.TYPE_CHECKING:
+    from pyinfra.api.inventory import Inventory
+
 from pyinfra.connectors.util import remove_any_sudo_askpass_file
 
 from .connectors import get_execution_connector
@@ -97,8 +102,8 @@ class Host(object):
 
     def __init__(
         self,
-        name,
-        inventory,
+        name: str,
+        inventory: "Inventory",
         groups,
         executor=get_execution_connector("ssh"),
     ):

--- a/pyinfra/api/host.py
+++ b/pyinfra/api/host.py
@@ -105,7 +105,7 @@ class Host(object):
         name: str,
         inventory: "Inventory",
         groups,
-        executor: str | t.Any = "ssh",
+        executor: t.Union[str, t.Any] = "ssh",
     ):
         self.inventory = inventory
         self.groups = groups
@@ -172,7 +172,7 @@ class Host(object):
     @property
     def executor(self):
         if self._executor is None:
-            return self.set_executor("ssh")
+            return self.set_executor(self.default_executor)
         return self._executor
 
     def style_print_prefix(self, *args, **kwargs):
@@ -263,7 +263,7 @@ class Host(object):
         if not self.state:
             raise TypeError("Cannot call this function with no state!")
 
-    def connect(self, reason=None, show_errors=True, raise_exceptions=False):
+    def connect(self, reason=None, show_errors: bool = True, raise_exceptions: bool = False):
         self._check_state()
         if not self.connection:
             self.state.trigger_callbacks("host_before_connect", self)
@@ -342,7 +342,7 @@ class Host(object):
 
     # Executor options
 
-    def set_executor(self, executor: str | t.Any):
+    def set_executor(self, executor: t.Union[str, t.Any]):
         """
         Sets the Host executor.
         This runs when the Host is initialized.

--- a/pyinfra/api/inventory.py
+++ b/pyinfra/api/inventory.py
@@ -132,7 +132,7 @@ class Inventory(object):
                     )
 
         # Now we can actually make Host instances
-        hosts = {}
+        hosts: dict[str, "Host"] = {}
 
         for name, executor in names_executors:
             host_groups = name_to_group_names[name]
@@ -161,32 +161,36 @@ class Inventory(object):
 
         return iter(self.hosts.values())
 
-    def iter_active_hosts(self):
+    def iter_active_hosts(self) -> t.Iterator["Host"]:
         """
         Iterates over active inventory hosts.
         """
-
+        if self.state is None:
+            raise RuntimeError("No state set. Set the `State` to get the active hosts.")
         return iter(self.state.active_hosts)
 
-    def len_active_hosts(self):
+    def len_active_hosts(self) -> int:
         """
         Returns the number of active inventory hosts.
         """
-
+        if self.state is None:
+            raise RuntimeError("No state set. Set the state to get the number of active hosts.")
         return len(self.state.active_hosts)
 
-    def iter_activated_hosts(self):
+    def iter_activated_hosts(self) -> t.Iterator["Host"]:
         """
         Iterates over activated inventory hosts.
         """
-
+        if self.state is None:
+            raise RuntimeError("No state set. Set the `State` to get the activated hosts.")
         return iter(self.state.activated_hosts)
 
-    def len_activated_hosts(self):
+    def len_activated_hosts(self) -> int:
         """
         Returns the number of activated inventory hosts.
         """
-
+        if self.state is None:
+            raise RuntimeError("No state set. Set the state to get the number of actived hosts.")
         return len(self.state.activated_hosts)
 
     def get_host(self, name: str, default=NoHostError):

--- a/pyinfra/api/inventory.py
+++ b/pyinfra/api/inventory.py
@@ -1,3 +1,4 @@
+import typing as t
 from collections import defaultdict
 
 from .connectors import get_all_connectors, get_execution_connectors
@@ -146,14 +147,14 @@ class Inventory(object):
 
         return hosts
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Returns the number of inventory hosts.
         """
 
         return len(self.hosts)
 
-    def __iter__(self):
+    def __iter__(self) -> t.Iterator["Host"]:
         """
         Iterates over all inventory hosts.
         """
@@ -188,7 +189,7 @@ class Inventory(object):
 
         return len(self.state.activated_hosts)
 
-    def get_host(self, name, default=NoHostError):
+    def get_host(self, name: str, default=NoHostError):
         """
         Get a single host by name.
         """
@@ -201,7 +202,7 @@ class Inventory(object):
 
         return default
 
-    def get_group(self, name, default=NoGroupError):
+    def get_group(self, name: str, default=NoGroupError):
         """
         Get a list of hosts belonging to a group.
         """
@@ -228,7 +229,7 @@ class Inventory(object):
 
         return self.override_data
 
-    def get_host_data(self, hostname):
+    def get_host_data(self, hostname: str):
         """
         Get data for a single host in this inventory.
         """

--- a/pyinfra/api/inventory.py
+++ b/pyinfra/api/inventory.py
@@ -21,6 +21,19 @@ class Inventory(object):
     Represents a collection of target hosts. Stores and provides access to group data,
     host data and default data for these hosts.
 
+    Example::
+
+        ..code-block:: python
+
+            >>> host_details = {
+                    "ssh_hostname": "localhost",
+                    "ssh_user": "vagrant",
+                    "ssh_port": "2222",
+                    "ssh_key": "/path/to/my/ssh_key_file"
+                }
+            >>> single_host = (['myhostname'], host_details)
+            >>> inventory = Inventory(single host)
+
     Args:
         names_data: tuple of ``(names, data)``
         override_data: dictionary of data overrides

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -233,13 +233,13 @@ def operation(
         host.current_op_global_kwargs = None
 
         # We're doing some commands, meta/ops++
-        state.meta[host]["ops"] += 1
-        state.meta[host]["commands"] += len(commands)
+        state.host_meta[host]["ops"] += 1
+        state.host_meta[host]["commands"] += len(commands)
 
         if commands:
-            state.meta[host]["ops_change"] += 1
+            state.host_meta[host]["ops_change"] += 1
         else:
-            state.meta[host]["ops_no_change"] += 1
+            state.host_meta[host]["ops_no_change"] += 1
 
         operation_meta = OperationMeta(op_hash, commands)
 

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -206,7 +206,7 @@ def operation(
         # Run once and we've already added meta for this op? Stop here.
         if op_hash_map["run_once"]:
             has_run = False
-            for ops in state.ops.values():
+            for ops in state.ops_hosts.values():
                 if op_hash in ops:
                     has_run = True
                     break

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -27,7 +27,7 @@ from .util import (
     memoize,
 )
 
-op_meta_default = object()
+op_hash_map_default = object()
 
 
 class OperationMeta(object):
@@ -189,9 +189,9 @@ def operation(
 
         for key in get_execution_kwarg_keys():
             global_value = global_kwargs.pop(key)
-            op_meta_value = op_hash_map.get(key, op_meta_default)
+            op_hash_map_value = op_hash_map.get(key, op_hash_map_default)
 
-            if op_meta_value is not op_meta_default and global_value != op_meta_value:
+            if op_hash_map_value is not op_hash_map_default and global_value != op_hash_map_value:
                 raise OperationValueError("Cannot have different values for `{0}`.".format(key))
 
             op_hash_map[key] = global_value
@@ -220,7 +220,6 @@ def operation(
         host.in_op = True
         host.current_op_hash = op_hash
         host.current_op_global_kwargs = global_kwargs
-
 
         # Convert to list as the result may be a generator
         commands = func(*args, **kwargs)
@@ -266,7 +265,7 @@ def operation(
         # Return result meta for use in deploy scripts
         return operation_meta
 
-    decorated_func._pyinfra_op = func
+    decorated_func._pyinfra_op = func  # type: ignore
     return decorated_func
 
 
@@ -284,7 +283,7 @@ def _solve_legacy_operation_arguments(op_func, state: "State", host: "Host", kwa
     """
     Solve legacy operation arguments.
     """
-    
+
     # If this is a legacy operation function (ie - state & host arg kwargs), ensure that state
     # and host are included as kwargs.
 

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -77,7 +77,7 @@ class OperationMeta(object):
         return "\n".join(self.stderr_lines)
 
 
-def add_op(state, op_func, *args, **kwargs):
+def add_op(state: "State", op_func, *args, **kwargs):
     """
     Prepare & add an operation to ``pyinfra.state`` by executing it on all hosts.
 
@@ -115,9 +115,9 @@ def add_op(state, op_func, *args, **kwargs):
 def operation(
     func=None,
     pipeline_facts=None,
-    is_idempotent=True,
+    is_idempotent: bool = True,
     idempotent_notice=None,
-    frame_offset=1,
+    frame_offset: int = 1,
 ):
     """
     Decorator that takes a simple module function and turn it into the internal
@@ -301,7 +301,7 @@ def _solve_legacy_operation_arguments(op_func, state: "State", host: "Host", kwa
     return None
 
 
-def _generate_operation_name(func, host, kwargs, global_kwargs):
+def _generate_operation_name(func, host: "Host", kwargs, global_kwargs):
     # Generate an operation name if needed (Module/Operation format)
     name = global_kwargs.get("name")
     add_args = False
@@ -325,7 +325,7 @@ def _generate_operation_name(func, host, kwargs, global_kwargs):
     return names, add_args
 
 
-def _solve_operation_consistency(names, state, host):
+def _solve_operation_consistency(names, state: "State", host: "Host"):
     # Operation order is used to tie-break available nodes in the operation DAG, in CLI mode
     # we use stack call order so this matches as defined by the user deploy code.
     if pyinfra.is_cli:

--- a/pyinfra/api/operations.py
+++ b/pyinfra/api/operations.py
@@ -1,6 +1,11 @@
 import traceback
+import typing as t
 from itertools import product
 from socket import error as socket_error, timeout as timeout_error
+
+if t.TYPE_CHECKING:
+    from .state import State
+    from .inventory import Host
 
 import click
 import gevent
@@ -28,8 +33,8 @@ def show_pre_or_post_condition_warning(condition_name):
 
 
 def _run_shell_command(
-    state,
-    host,
+    state: "State",
+    host: "Host",
     command,
     global_kwargs,
     executor_kwargs,
@@ -56,7 +61,7 @@ def _run_shell_command(
     return status
 
 
-def run_host_op(state, host, op_hash):
+def run_host_op(state: "State", host: "Host", op_hash):
     state.trigger_callbacks("operation_host_start", host, op_hash)
 
     if op_hash not in state.ops_hosts[host]:
@@ -284,7 +289,7 @@ def log_operation_start(op_hash_map, op_types=None, prefix="--> "):
     )
 
 
-def _run_host_ops(state, host, progress=None):
+def _run_host_ops(state: "State", host: "Host", progress=None):
     """
     Run all ops for a single server.
     """
@@ -313,7 +318,7 @@ def _run_host_ops(state, host, progress=None):
             click.echo(err=True)
 
 
-def _run_serial_ops(state):
+def _run_serial_ops(state: "State"):
     """
     Run all ops for all servers, one server at a time.
     """
@@ -331,7 +336,7 @@ def _run_serial_ops(state):
                 state.fail_hosts({host})
 
 
-def _run_no_wait_ops(state):
+def _run_no_wait_ops(state: "State"):
     """
     Run all ops for all servers at once.
     """
@@ -351,7 +356,7 @@ def _run_no_wait_ops(state):
         gevent.joinall(greenlets)
 
 
-def _run_single_op(state, op_hash):
+def _run_single_op(state: "State", op_hash):
     """
     Run a single operation for all servers. Can be configured to run in serial.
     """
@@ -410,7 +415,7 @@ def _run_single_op(state, op_hash):
     state.trigger_callbacks("operation_end", op_hash)
 
 
-def run_ops(state, serial=False, no_wait=False):
+def run_ops(state: "State", serial: bool = False, no_wait: bool = False):
     """
     Runs all operations across all servers in a configurable manner.
 

--- a/pyinfra/api/operations.py
+++ b/pyinfra/api/operations.py
@@ -344,6 +344,8 @@ def _run_no_wait_ops(state: "State"):
     hosts_operations = product(state.inventory.iter_active_hosts(), state.get_op_order())
     with progress_spinner(hosts_operations) as progress:
         # Spawn greenlet for each host to run *all* ops
+        if state.pool is None:
+            raise PyinfraError("No pool found on state.")
         greenlets = [
             state.pool.spawn(
                 _run_host_ops,
@@ -392,6 +394,8 @@ def _run_single_op(state: "State", op_hash):
         for batch in batches:
             with progress_spinner(batch) as progress:
                 # Spawn greenlet for each host
+                if state.pool is None:
+                    raise PyinfraError("No pool found on state.")                
                 greenlet_to_host = {
                     state.pool.spawn(run_host_op, state, host, op_hash): host for host in batch
                 }

--- a/pyinfra/api/operations.py
+++ b/pyinfra/api/operations.py
@@ -59,7 +59,7 @@ def _run_shell_command(
 def run_host_op(state, host, op_hash):
     state.trigger_callbacks("operation_host_start", host, op_hash)
 
-    if op_hash not in state.ops[host]:
+    if op_hash not in state.ops_hosts[host]:
         logger.info("{0}{1}".format(host.print_prefix, click.style("Skipped", "blue")))
         return True
 

--- a/pyinfra/api/operations.py
+++ b/pyinfra/api/operations.py
@@ -66,7 +66,7 @@ def run_host_op(state, host, op_hash):
     op_data = state.get_op_data(host, op_hash)
     global_kwargs = op_data["global_kwargs"]
 
-    op_hash_map = state.get_op_meta(op_hash)
+    op_hash_map = state.get_op_hash_map(op_hash)
 
     ignore_errors = global_kwargs["ignore_errors"]
     continue_on_error = global_kwargs["continue_on_error"]
@@ -292,7 +292,7 @@ def _run_host_ops(state, host, progress=None):
     logger.debug("Running all ops on {0}".format(host))
 
     for op_hash in state.get_op_order():
-        op_hash_map = state.get_op_meta(op_hash)
+        op_hash_map = state.get_op_hash_map(op_hash)
         log_operation_start(op_hash_map)
 
         result = run_host_op(state, host, op_hash)
@@ -358,7 +358,7 @@ def _run_single_op(state, op_hash):
 
     state.trigger_callbacks("operation_start", op_hash)
 
-    op_hash_map = state.get_op_meta(op_hash)
+    op_hash_map = state.get_op_hash_map(op_hash)
     log_operation_start(op_hash_map)
 
     failed_hosts = set()

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -156,7 +156,7 @@ class State(object):
         # Actually initialise the state object
         #
 
-        self.callback_handlers = []
+        self.callback_handlers: list[BaseStateCallback] = []
 
         # Setup greenlet pools
         self.pool = Pool(config.PARALLEL)
@@ -167,18 +167,18 @@ class State(object):
         self.sftp_connections = {}
 
         # Private keys
-        self.private_keys = {}
+        self.private_keys: dict[str, t.Any] = {}
 
         # Assign inventory/config
         self.inventory = inventory
         self.config = config
 
         # Hosts we've activated at any time
-        self.activated_hosts = set()
+        self.activated_hosts: t.Set["Host"] = set()
         # Active hosts that *haven't* failed yet
-        self.active_hosts = set()
+        self.active_hosts: t.Set["Host"] = set()
         # Hosts that have failed
-        self.failed_hosts = set()
+        self.failed_hosts: t.Set["Host"] = set()
 
         # Limit hosts changes dynamically to limit operations to a subset of hosts
         self.limit_hosts = initial_limit
@@ -188,13 +188,13 @@ class State(object):
         self.ops_run = set()  # list of ops which have been started/run
 
         # Op dict for each host
-        self.ops_hosts = {host: {} for host in inventory}
+        self.ops_hosts: dict["Host", t.Any] = {host: {} for host in inventory}
 
         # Facts dict for each host
-        self.facts = {host: {} for host in inventory}
+        self.facts: dict["Host", t.Any] = {host: {} for host in inventory}
 
         # Meta dict for each host
-        self.host_meta = {
+        self.host_meta: dict["Host", t.Any] = {
             host: {
                 "ops": 0,  # one function call in a deploy file
                 "ops_change": 0,
@@ -303,7 +303,7 @@ class State(object):
         self.activated_hosts.add(host)
         self.active_hosts.add(host)
 
-    def fail_hosts(self, hosts_to_fail, activated_count=None):
+    def fail_hosts(self, hosts_to_fail: list["Host"], activated_count: t.Optional[int] = None):
         """
         Flag a ``set`` of hosts as failed, error for ``config.FAIL_PERCENT``.
         """
@@ -404,5 +404,8 @@ class State(object):
         self.fail_hosts(failed_hosts, activated_count=len(hosts))
 
     def disconnect_all(self):
-        for host in self.activated_hosts:  # only hosts we connected to please!
-            host.disconnect()  # normally a noop
+        """
+        Disconnect from all activated hosts on a given state.
+        """        
+        for host in self.activated_hosts:
+            host.disconnect()

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -281,7 +281,7 @@ class State(object):
 
         return final_op_order
 
-    def get_op_meta(self, op_hash):
+    def get_op_hash_map(self, op_hash):
         return self.op_hash_map[op_hash]
 
     def get_op_data(self, host, op_hash):

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -193,7 +193,7 @@ class State(object):
         self.facts = {host: {} for host in inventory}
 
         # Meta dict for each host
-        self.meta = {
+        self.host_meta = {
             host: {
                 "ops": 0,  # one function call in a deploy file
                 "ops_change": 0,
@@ -229,7 +229,7 @@ class State(object):
             "op_order": self.get_op_order(),
             "ops": self.ops,
             "facts": self.facts,
-            "meta": self.meta,
+            "meta": self.host_meta,
             "results": self.results,
         }
 

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -113,13 +113,15 @@ class State(object):
     current_exec_filename = None
     current_op_file_number = 0
 
-    def __init__(self, inventory: Optional["Inventory"] =None, config: Optional["Config"] = None, **kwargs):
+    def __init__(
+        self, inventory: Optional["Inventory"] = None, config: Optional["Config"] = None, **kwargs
+    ):
         """Initializes the state, the main Pyinfra
 
         Args:
             inventory (Optional[Inventory], optional): The inventory. Defaults to None.
             config (Optional[Config], optional): The config object. Defaults to None.
-        """        
+        """
         if inventory:
             self.init(inventory, config, **kwargs)
 
@@ -376,10 +378,8 @@ class State(object):
         """
 
         hosts = [
-            host
-            for host in self.inventory
-            if self.is_host_in_limit(host)  # these are the hosts to activate ("initially connect to")
-        ]
+            host for host in self.inventory if self.is_host_in_limit(host)
+        ]  # these are the hosts to activate ("initially connect to")
 
         greenlet_to_host = {self.pool.spawn(host.connect): host for host in hosts}
 
@@ -406,6 +406,6 @@ class State(object):
     def disconnect_all(self):
         """
         Disconnect from all activated hosts on a given state.
-        """        
+        """
         for host in self.activated_hosts:
             host.disconnect()

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -187,7 +187,7 @@ class State(object):
         self.ops_run = set()  # list of ops which have been started/run
 
         # Op dict for each host
-        self.ops = {host: {} for host in inventory}
+        self.ops_hosts = {host: {} for host in inventory}
 
         # Facts dict for each host
         self.facts = {host: {} for host in inventory}
@@ -227,7 +227,7 @@ class State(object):
     def to_dict(self):
         return {
             "op_order": self.get_op_order(),
-            "ops": self.ops,
+            "ops": self.ops_hosts,
             "facts": self.facts,
             "meta": self.host_meta,
             "results": self.results,
@@ -285,10 +285,10 @@ class State(object):
         return self.op_hash_map[op_hash]
 
     def get_op_data(self, host, op_hash):
-        return self.ops[host][op_hash]
+        return self.ops_hosts[host][op_hash]
 
     def set_op_data(self, host, op_hash, op_data):
-        self.ops[host][op_hash] = op_data
+        self.ops_hosts[host][op_hash] = op_data
 
     def activate_host(self, host):
         """

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -13,6 +13,7 @@ from gevent.pool import Pool
 from pyinfra.progress import progress_spinner
 
 if t.TYPE_CHECKING:
+    from pyinfra.api.host import Host
     from pyinfra.api.inventory import Inventory
 
 from pyinfra import logger
@@ -122,7 +123,7 @@ class State(object):
         if inventory:
             self.init(inventory, config, **kwargs)
 
-    def init(self, inventory, config, initial_limit=None):
+    def init(self, inventory: "Inventory", config: Optional["Config"], initial_limit=None):
         # Config validation
         #
 
@@ -240,7 +241,7 @@ class State(object):
             )
         self.callback_handlers.append(handler)
 
-    def trigger_callbacks(self, method_name, *args, **kwargs):
+    def trigger_callbacks(self, method_name: str, *args, **kwargs):
         for handler in self.callback_handlers:
             func = getattr(handler, method_name)
             func(self, *args, **kwargs)
@@ -284,13 +285,13 @@ class State(object):
     def get_op_hash_map(self, op_hash):
         return self.op_hash_map[op_hash]
 
-    def get_op_data(self, host, op_hash):
+    def get_op_data(self, host: "Host", op_hash):
         return self.ops_hosts[host][op_hash]
 
-    def set_op_data(self, host, op_hash, op_data):
+    def set_op_data(self, host: "Host", op_hash, op_data):
         self.ops_hosts[host][op_hash] = op_data
 
-    def activate_host(self, host):
+    def activate_host(self, host: "Host"):
         """
         Flag a host as active.
         """
@@ -342,7 +343,7 @@ class State(object):
                     ),
                 )
 
-    def is_host_in_limit(self, host):
+    def is_host_in_limit(self, host: "Host"):
         """
         Returns a boolean indicating if the host is within the current state limit.
         """

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -183,7 +183,7 @@ class State(object):
         self.limit_hosts = initial_limit
 
         # Op basics
-        self.op_meta = {}  # maps operation hash -> names/etc
+        self.op_hash_map = {}  # maps operation hash -> names/etc
         self.ops_run = set()  # list of ops which have been started/run
 
         # Op dict for each host
@@ -274,7 +274,7 @@ class State(object):
             # dependency order we order them by line numbers.
             node_group = sorted(
                 ts.get_ready(),
-                key=lambda op_hash: self.op_meta[op_hash]["op_order"],
+                key=lambda op_hash: self.op_hash_map[op_hash]["op_order"],
             )
             ts.done(*node_group)
             final_op_order.extend(node_group)
@@ -282,7 +282,7 @@ class State(object):
         return final_op_order
 
     def get_op_meta(self, op_hash):
-        return self.op_meta[op_hash]
+        return self.op_hash_map[op_hash]
 
     def get_op_data(self, host, op_hash):
         return self.ops[host][op_hash]

--- a/pyinfra/api/state.py
+++ b/pyinfra/api/state.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
+import typing as t
 from contextlib import contextmanager
 from graphlib import TopologicalSorter
 from multiprocessing import cpu_count
+from typing import Optional
 from uuid import uuid4
 
 from gevent.pool import Pool
+
+if t.TYPE_CHECKING:
+    from pyinfra.api.inventory import Inventory
 
 from pyinfra import logger
 
@@ -78,10 +85,10 @@ class State(object):
     initialised = False
 
     # A pyinfra.api.Inventory which stores all our pyinfra.api.Host's
-    inventory = None
+    inventory: "Inventory" = None
 
     # A pyinfra.api.Config
-    config = None
+    config: "Config" = None
 
     # Main gevent pool
     pool = None
@@ -102,7 +109,13 @@ class State(object):
     current_exec_filename = None
     current_op_file_number = 0
 
-    def __init__(self, inventory=None, config=None, **kwargs):
+    def __init__(self, inventory: Optional["Inventory"] =None, config: Optional["Config"] = None, **kwargs):
+        """Initializes the state, the main Pyinfra
+
+        Args:
+            inventory (Optional[Inventory], optional): The inventory. Defaults to None.
+            config (Optional[Config], optional): The config object. Defaults to None.
+        """        
         if inventory:
             self.init(inventory, config, **kwargs)
 

--- a/pyinfra/api/util.py
+++ b/pyinfra/api/util.py
@@ -1,3 +1,4 @@
+import typing as t
 from functools import wraps
 from hashlib import sha1
 from inspect import getframeinfo, getfullargspec, stack
@@ -11,6 +12,10 @@ from paramiko import SSHException
 import pyinfra
 from pyinfra import logger
 
+if t.TYPE_CHECKING:
+    from pyinfra.api.host import Host
+    from pyinfra.api.state import State
+
 # 64kb chunks
 BLOCKSIZE = 65536
 
@@ -21,7 +26,7 @@ FILE_SHAS = {}
 PYINFRA_API_DIR = path.dirname(__file__)
 
 
-def get_file_path(state, filename):
+def get_file_path(state: "State", filename: str):
     if path.isabs(filename):
         return filename
 
@@ -33,7 +38,7 @@ def get_file_path(state, filename):
     return path.join(relative_to, filename)
 
 
-def get_args_kwargs_spec(func):
+def get_args_kwargs_spec(func: t.Callable):
     args = []
     kwargs = {}
 
@@ -74,7 +79,7 @@ def try_int(value):
         return value
 
 
-def memoize(func):
+def memoize(func: t.Callable):
     @wraps(func)
     def wrapper(*args, **kwargs):
         key = "{0}{1}".format(args, kwargs)
@@ -89,7 +94,7 @@ def memoize(func):
     return wrapper
 
 
-def get_call_location(frame_offset=1):
+def get_call_location(frame_offset: int=1):
     frame = get_caller_frameinfo(frame_offset=frame_offset)  # escape *this* function
     relpath = frame.filename
 
@@ -103,7 +108,7 @@ def get_call_location(frame_offset=1):
     return "line {0} in {1}".format(frame.lineno, relpath)
 
 
-def get_caller_frameinfo(frame_offset=0):
+def get_caller_frameinfo(frame_offset: int=0):
     # Default frames to look at is 2; one for this function call itself
     # in util.py and one for the caller of this function within pyinfra
     # giving the external call frame (ie end user deploy code).
@@ -119,7 +124,7 @@ def get_caller_frameinfo(frame_offset=0):
     return info
 
 
-def get_operation_order_from_stack(state):
+def get_operation_order_from_stack(state: "State"):
     stack_items = list(reversed(stack()))
 
     # Find the *first* occurrence of our deploy file in the reversed stack
@@ -150,7 +155,7 @@ def get_operation_order_from_stack(state):
     return line_numbers
 
 
-def get_template(filename_or_io):
+def get_template(filename_or_io: str):
     """
     Gets a jinja2 ``Template`` object for the input filename or string, with caching
     based on the filename of the template, or the SHA1 of the input string.
@@ -177,7 +182,7 @@ def get_template(filename_or_io):
     return template
 
 
-def sha1_hash(string):
+def sha1_hash(string: str):
     """
     Return the SHA1 of the input string.
     """
@@ -191,7 +196,7 @@ def format_exception(e):
     return "{0}{1}".format(e.__class__.__name__, e.args)
 
 
-def print_host_combined_output(host, combined_output_lines):
+def print_host_combined_output(host: "Host", combined_output_lines):
     for type_, line in combined_output_lines:
         if type_ == "stderr":
             logger.error(
@@ -209,7 +214,7 @@ def print_host_combined_output(host, combined_output_lines):
             )
 
 
-def log_error_or_warning(host, ignore_errors, description="", continue_on_error=False):
+def log_error_or_warning(host: "Host", ignore_errors, description="", continue_on_error=False):
     log_func = logger.error
     log_color = "red"
     log_text = "Error: " if description else "Error"
@@ -232,7 +237,7 @@ def log_error_or_warning(host, ignore_errors, description="", continue_on_error=
     )
 
 
-def log_host_command_error(host, e, timeout=0):
+def log_host_command_error(host: "Host", e, timeout=0):
     if isinstance(e, timeout_error):
         logger.error(
             "{0}{1}".format(
@@ -393,7 +398,7 @@ def get_file_sha1(filename_or_io):
     return digest
 
 
-def get_path_permissions_mode(pathname):
+def get_path_permissions_mode(pathname: str):
     """
     Get the permissions (bits) of a path as an integer.
     """

--- a/pyinfra/api/util.py
+++ b/pyinfra/api/util.py
@@ -214,16 +214,16 @@ def print_host_combined_output(host: "Host", combined_output_lines):
             )
 
 
-def log_operation_start(op_meta, op_types=None, prefix="--> "):
+def log_operation_start(op_hash_map, op_types=None, prefix="--> "):
     op_types = op_types or []
-    if op_meta["serial"]:
+    if op_hash_map["serial"]:
         op_types.append("serial")
-    if op_meta["run_once"]:
+    if op_hash_map["run_once"]:
         op_types.append("run once")
 
     args = ""
-    if op_meta["args"]:
-        args = "({0})".format(", ".join(str(arg) for arg in op_meta["args"]))
+    if op_hash_map["args"]:
+        args = "({0})".format(", ".join(str(arg) for arg in op_hash_map["args"]))
 
     logger.info(
         "{0} {1} {2}".format(
@@ -234,13 +234,15 @@ def log_operation_start(op_meta, op_types=None, prefix="--> "):
                 ),
                 "blue",
             ),
-            click.style(", ".join(op_meta["names"]), bold=True),
+            click.style(", ".join(op_hash_map["names"]), bold=True),
             args,
         ),
     )
 
 
-def log_error_or_warning(host: "Host", ignore_errors, description: str = "", continue_on_error: bool = False):
+def log_error_or_warning(
+    host: "Host", ignore_errors, description: str = "", continue_on_error: bool = False
+):
     log_func = logger.error
     log_color = "red"
     log_text = "Error: " if description else "Error"

--- a/pyinfra/connectors/util.py
+++ b/pyinfra/connectors/util.py
@@ -55,7 +55,9 @@ def read_buffer(type_, io, output_queue, print_output: bool = False, print_func=
             _print(line)
 
 
-def execute_command_with_sudo_retry(host: "Host", command_kwargs, execute_command: t.Callable[..., tuple[t.Any, ...]]):
+def execute_command_with_sudo_retry(
+    host: "Host", command_kwargs, execute_command: t.Callable[..., tuple[t.Any, ...]]
+):
     return_code, combined_output = execute_command()
 
     if return_code != 0 and combined_output:
@@ -224,7 +226,7 @@ def make_unix_command(
     command,
     env=None,
     chdir=None,
-    shell_executable: str ="sh",
+    shell_executable: str = "sh",
     # Su config
     su_user=None,
     use_su_login: bool = False,
@@ -238,7 +240,7 @@ def make_unix_command(
     sudo_askpass_path=None,
     preserve_sudo_env: bool = False,
     # Doas config
-    doas: bool = False, 
+    doas: bool = False,
     doas_user=None,
 ):
     """
@@ -258,7 +260,7 @@ def make_unix_command(
     if chdir:
         command = StringCommand("cd", chdir, "&&", command)
 
-    command_bits: list["PyinfraCommand" | "QuoteString" | str] = []
+    command_bits: list[t.Union["PyinfraCommand", "QuoteString", str]] = []
 
     if doas:
         command_bits.extend(["doas", "-n"])

--- a/pyinfra_cli/exceptions.py
+++ b/pyinfra_cli/exceptions.py
@@ -22,7 +22,7 @@ class CliError(PyinfraError, click.ClickException):
             # Get any operation meta + name
             op_name = None
             current_op_hash = host.current_op_hash
-            current_op_meta = state.op_meta.get(current_op_hash)
+            current_op_meta = state.op_hash_map.get(current_op_hash)
             if current_op_meta:
                 op_name = ", ".join(current_op_meta["names"])
 

--- a/pyinfra_cli/exceptions.py
+++ b/pyinfra_cli/exceptions.py
@@ -22,9 +22,9 @@ class CliError(PyinfraError, click.ClickException):
             # Get any operation meta + name
             op_name = None
             current_op_hash = host.current_op_hash
-            current_op_meta = state.op_hash_map.get(current_op_hash)
-            if current_op_meta:
-                op_name = ", ".join(current_op_meta["names"])
+            current_op_hash_map = state.op_hash_map.get(current_op_hash)
+            if current_op_hash_map:
+                op_name = ", ".join(current_op_hash_map["names"])
 
             sys.stderr.write(
                 "--> {0}{1}{2}: ".format(

--- a/pyinfra_cli/prints.py
+++ b/pyinfra_cli/prints.py
@@ -59,13 +59,13 @@ def print_state_operations(state):
     click.echo(jsonify(state_ops, indent=4, default=json_encode), err=True)
     click.echo(err=True)
     click.echo("--> Operation meta:", err=True)
-    click.echo(jsonify(state.op_meta, indent=4, default=json_encode), err=True)
+    click.echo(jsonify(state.op_hash_map, indent=4, default=json_encode), err=True)
 
     click.echo(err=True)
     click.echo("--> Operation order:", err=True)
     click.echo(err=True)
     for op_hash in state.get_op_order():
-        meta = state.op_meta[op_hash]
+        meta = state.op_hash_map[op_hash]
         hosts = set(host for host, operations in state.ops.items() if op_hash in operations)
 
         click.echo(

--- a/pyinfra_cli/prints.py
+++ b/pyinfra_cli/prints.py
@@ -52,7 +52,7 @@ def print_state_facts(state):
 
 
 def print_state_operations(state):
-    state_ops = {host: ops for host, ops in state.ops.items() if state.is_host_in_limit(host)}
+    state_ops = {host: ops for host, ops in state.ops_hosts.items() if state.is_host_in_limit(host)}
 
     click.echo(err=True)
     click.echo("--> Operations:", err=True)
@@ -66,7 +66,7 @@ def print_state_operations(state):
     click.echo(err=True)
     for op_hash in state.get_op_order():
         meta = state.op_hash_map[op_hash]
-        hosts = set(host for host, operations in state.ops.items() if op_hash in operations)
+        hosts = set(host for host, operations in state.ops_hosts.items() if op_hash in operations)
 
         click.echo(
             "    {0} (names={1}, hosts={2})".format(

--- a/pyinfra_cli/prints.py
+++ b/pyinfra_cli/prints.py
@@ -218,7 +218,7 @@ def print_meta(state):
             rows.append((logger.info, "Ungrouped:"))
 
         for host in hosts:
-            meta = state.meta[host]
+            meta = state.host_meta[host]
 
             # Didn't connect to this host?
             if host not in state.activated_hosts:
@@ -287,7 +287,7 @@ def print_results(state):
 
             results = state.results[host]
 
-            meta = state.meta[host]
+            meta = state.host_meta[host]
             success_ops = results["success_ops"]
             partial_ops = results["partial_ops"]
             changed_ops = success_ops - meta["ops_no_change"]

--- a/tests/test_api/test_api_deploys.py
+++ b/tests/test_api/test_api_deploys.py
@@ -37,7 +37,7 @@ class TestDeploysApi(PatchSSHTestCase):
         assert len(op_order) == 2
 
         first_op_hash = op_order[0]
-        assert state.op_meta[first_op_hash]["names"] == {"test_deploy | Server/Shell"}
+        assert state.op_hash_map[first_op_hash]["names"] == {"test_deploy | Server/Shell"}
         assert state.ops[somehost][first_op_hash]["commands"] == [
             StringCommand("echo first command"),
         ]
@@ -46,7 +46,7 @@ class TestDeploysApi(PatchSSHTestCase):
         ]
 
         second_op_hash = op_order[1]
-        assert state.op_meta[second_op_hash]["names"] == {"test_deploy | Server/Shell"}
+        assert state.op_hash_map[second_op_hash]["names"] == {"test_deploy | Server/Shell"}
         assert state.ops[somehost][second_op_hash]["commands"] == [
             StringCommand("echo second command"),
         ]
@@ -105,13 +105,13 @@ class TestDeploysApi(PatchSSHTestCase):
         assert len(op_order) == 3
 
         first_op_hash = op_order[0]
-        assert state.op_meta[first_op_hash]["names"] == {"test_deploy | Server/Shell"}
+        assert state.op_hash_map[first_op_hash]["names"] == {"test_deploy | Server/Shell"}
         assert state.ops[somehost][first_op_hash]["commands"] == [
             StringCommand("echo first command"),
         ]
 
         second_op_hash = op_order[1]
-        assert state.op_meta[second_op_hash]["names"] == {
+        assert state.op_hash_map[second_op_hash]["names"] == {
             "test_deploy | test_nested_deploy | Server/Shell",
         }
         assert state.ops[somehost][second_op_hash]["commands"] == [
@@ -119,7 +119,7 @@ class TestDeploysApi(PatchSSHTestCase):
         ]
 
         third_op_hash = op_order[2]
-        assert state.op_meta[third_op_hash]["names"] == {"test_deploy | Server/Shell"}
+        assert state.op_hash_map[third_op_hash]["names"] == {"test_deploy | Server/Shell"}
         assert state.ops[somehost][third_op_hash]["commands"] == [
             StringCommand("echo second command"),
         ]

--- a/tests/test_api/test_api_deploys.py
+++ b/tests/test_api/test_api_deploys.py
@@ -38,19 +38,19 @@ class TestDeploysApi(PatchSSHTestCase):
 
         first_op_hash = op_order[0]
         assert state.op_hash_map[first_op_hash]["names"] == {"test_deploy | Server/Shell"}
-        assert state.ops[somehost][first_op_hash]["commands"] == [
+        assert state.ops_hosts[somehost][first_op_hash]["commands"] == [
             StringCommand("echo first command"),
         ]
-        assert state.ops[anotherhost][first_op_hash]["commands"] == [
+        assert state.ops_hosts[anotherhost][first_op_hash]["commands"] == [
             StringCommand("echo first command"),
         ]
 
         second_op_hash = op_order[1]
         assert state.op_hash_map[second_op_hash]["names"] == {"test_deploy | Server/Shell"}
-        assert state.ops[somehost][second_op_hash]["commands"] == [
+        assert state.ops_hosts[somehost][second_op_hash]["commands"] == [
             StringCommand("echo second command"),
         ]
-        assert state.ops[anotherhost][second_op_hash]["commands"] == [
+        assert state.ops_hosts[anotherhost][second_op_hash]["commands"] == [
             StringCommand("echo second command"),
         ]
 
@@ -106,7 +106,7 @@ class TestDeploysApi(PatchSSHTestCase):
 
         first_op_hash = op_order[0]
         assert state.op_hash_map[first_op_hash]["names"] == {"test_deploy | Server/Shell"}
-        assert state.ops[somehost][first_op_hash]["commands"] == [
+        assert state.ops_hosts[somehost][first_op_hash]["commands"] == [
             StringCommand("echo first command"),
         ]
 
@@ -114,12 +114,12 @@ class TestDeploysApi(PatchSSHTestCase):
         assert state.op_hash_map[second_op_hash]["names"] == {
             "test_deploy | test_nested_deploy | Server/Shell",
         }
-        assert state.ops[somehost][second_op_hash]["commands"] == [
+        assert state.ops_hosts[somehost][second_op_hash]["commands"] == [
             StringCommand("echo nested command"),
         ]
 
         third_op_hash = op_order[2]
         assert state.op_hash_map[third_op_hash]["names"] == {"test_deploy | Server/Shell"}
-        assert state.ops[somehost][third_op_hash]["commands"] == [
+        assert state.ops_hosts[somehost][third_op_hash]["commands"] == [
             StringCommand("echo second command"),
         ]

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -27,12 +27,12 @@ from ..util import make_inventory
 
 class TestOperationMeta(TestCase):
     def test_operation_meta_repr_no_change(self):
-        op_meta = OperationMeta("hash", [])
-        assert repr(op_meta) == "OperationMeta(commands=0, changed=False, hash=hash)"
+        op_hash_map = OperationMeta("hash", [])
+        assert repr(op_hash_map) == "OperationMeta(commands=0, changed=False, hash=hash)"
 
     def test_operation_meta_repr_changes(self):
-        op_meta = OperationMeta("hash", ["a-command"])
-        assert repr(op_meta) == "OperationMeta(commands=1, changed=True, hash=hash)"
+        op_hash_map = OperationMeta("hash", ["a-command"])
+        assert repr(op_hash_map) == "OperationMeta(commands=1, changed=True, hash=hash)"
 
 
 class TestOperationsApi(PatchSSHTestCase):
@@ -77,7 +77,7 @@ class TestOperationsApi(PatchSSHTestCase):
         first_op_hash = op_order[0]
 
         # Ensure the op name
-        assert state.op_meta[first_op_hash]["names"] == {"Files/File"}
+        assert state.op_hash_map[first_op_hash]["names"] == {"Files/File"}
 
         # Ensure the commands
         assert state.ops[somehost][first_op_hash]["commands"] == [
@@ -185,7 +185,7 @@ class TestOperationsApi(PatchSSHTestCase):
         second_op_hash = op_order[1]
 
         # Ensure first op is the right one
-        assert state.op_meta[first_op_hash]["names"] == {"First op name"}
+        assert state.op_hash_map[first_op_hash]["names"] == {"First op name"}
 
         somehost = inventory.get_host("somehost")
         anotherhost = inventory.get_host("anotherhost")
@@ -236,7 +236,7 @@ class TestOperationsApi(PatchSSHTestCase):
         assert len(op_order) == 1
 
         first_op_hash = op_order[0]
-        assert state.op_meta[first_op_hash]["names"] == {"First op name"}
+        assert state.op_hash_map[first_op_hash]["names"] == {"First op name"}
 
         somehost = inventory.get_host("somehost")
         anotherhost = inventory.get_host("anotherhost")
@@ -345,7 +345,7 @@ class TestOperationsApi(PatchSSHTestCase):
             def setdefault(self, key, _):
                 return self[key]
 
-        state.op_meta = NoSetDefaultDict(lambda: {"serial": True})
+        state.op_hash_map = NoSetDefaultDict(lambda: {"serial": True})
 
         connect_all(state)
 

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -80,20 +80,20 @@ class TestOperationsApi(PatchSSHTestCase):
         assert state.op_hash_map[first_op_hash]["names"] == {"Files/File"}
 
         # Ensure the commands
-        assert state.ops[somehost][first_op_hash]["commands"] == [
+        assert state.ops_hosts[somehost][first_op_hash]["commands"] == [
             StringCommand("touch /var/log/pyinfra.log"),
             StringCommand("chmod 644 /var/log/pyinfra.log"),
             StringCommand("chown pyinfra:pyinfra /var/log/pyinfra.log"),
         ]
 
         # Ensure the global kwargs (same for both hosts)
-        somehost_global_kwargs = state.ops[somehost][first_op_hash]["global_kwargs"]
+        somehost_global_kwargs = state.ops_hosts[somehost][first_op_hash]["global_kwargs"]
         assert somehost_global_kwargs["sudo"] is True
         assert somehost_global_kwargs["sudo_user"] == "test_sudo"
         assert somehost_global_kwargs["su_user"] == "test_su"
         assert somehost_global_kwargs["ignore_errors"] is True
 
-        anotherhost_global_kwargs = state.ops[anotherhost][first_op_hash]["global_kwargs"]
+        anotherhost_global_kwargs = state.ops_hosts[anotherhost][first_op_hash]["global_kwargs"]
         assert anotherhost_global_kwargs["sudo"] is True
         assert anotherhost_global_kwargs["sudo_user"] == "test_sudo"
         assert anotherhost_global_kwargs["su_user"] == "test_su"
@@ -191,17 +191,17 @@ class TestOperationsApi(PatchSSHTestCase):
         anotherhost = inventory.get_host("anotherhost")
 
         # Ensure first op has the right (upload) command
-        assert state.ops[somehost][first_op_hash]["commands"] == [
+        assert state.ops_hosts[somehost][first_op_hash]["commands"] == [
             StringCommand("mkdir -p /home/vagrant"),
             FileUploadCommand("files/file.txt", "/home/vagrant/file.txt"),
         ]
 
         # Ensure second op has sudo/sudo_user
-        assert state.ops[somehost][second_op_hash]["global_kwargs"]["sudo"] is True
-        assert state.ops[somehost][second_op_hash]["global_kwargs"]["sudo_user"] == "pyinfra"
+        assert state.ops_hosts[somehost][second_op_hash]["global_kwargs"]["sudo"] is True
+        assert state.ops_hosts[somehost][second_op_hash]["global_kwargs"]["sudo_user"] == "pyinfra"
 
         # Ensure third has su_user
-        assert state.ops[somehost][op_order[2]]["global_kwargs"]["su_user"] == "pyinfra"
+        assert state.ops_hosts[somehost][op_order[2]]["global_kwargs"]["su_user"] == "pyinfra"
 
         # Check run ops works
         run_ops(state)
@@ -242,7 +242,7 @@ class TestOperationsApi(PatchSSHTestCase):
         anotherhost = inventory.get_host("anotherhost")
 
         # Ensure first op has the right (upload) command
-        assert state.ops[somehost][first_op_hash]["commands"] == [
+        assert state.ops_hosts[somehost][first_op_hash]["commands"] == [
             FileDownloadCommand("/home/vagrant/file.txt", "files/file.txt"),
         ]
 
@@ -292,7 +292,7 @@ class TestOperationsApi(PatchSSHTestCase):
         anotherhost = inventory.get_host("anotherhost")
 
         # Ensure between the two hosts we only run the one op
-        assert len(state.ops[somehost]) + len(state.ops[anotherhost]) == 1
+        assert len(state.ops_hosts[somehost]) + len(state.ops_hosts[anotherhost]) == 1
 
         # Check run works
         run_ops(state)
@@ -503,8 +503,8 @@ class TestOperationOrdering(PatchSSHTestCase):
         assert op_order[2] == second_context_hash
 
         # Ensure somehost has two ops and anotherhost only has the one
-        assert len(state.ops[inventory.get_host("somehost")]) == 2
-        assert len(state.ops[inventory.get_host("anotherhost")]) == 2
+        assert len(state.ops_hosts[inventory.get_host("somehost")]) == 2
+        assert len(state.ops_hosts[inventory.get_host("anotherhost")]) == 2
 
     # In API mode, pyinfra *overrides* the line numbers such that whenever an
     # operation or deploy is added it is simply appended. This makes sense as

--- a/tests/test_cli/test_cli_deploy.py
+++ b/tests/test_cli/test_cli_deploy.py
@@ -38,9 +38,9 @@ class TestCliDeployState(PatchSSHTestCase):
             correct_op_name_and_host_names,
         ):
             op_hash = op_order[i]
-            op_meta = state.op_meta[op_hash]
+            op_hash_map = state.op_hash_map[op_hash]
 
-            assert list(op_meta["names"])[0] == correct_op_name
+            assert list(op_hash_map["names"])[0] == correct_op_name
 
             for host in state.inventory:
                 if correct_host_names is True or host.name in correct_host_names:

--- a/tests/test_cli/test_cli_deploy.py
+++ b/tests/test_cli/test_cli_deploy.py
@@ -21,7 +21,7 @@ class TestCliDeploy(PatchSSHTestCase):
 
         # Check every operation had commands/changes - this ensures that each
         # combo (add/remove/add) always had changes.
-        for host, ops in state.ops.items():
+        for host, ops in state.ops_hosts.items():
             for _, op in ops.items():
                 assert len(op["commands"]) > 0
 


### PR DESCRIPTION
Made a few suggestions, hope you guys like. Coverage dropped 0,1%, all tests passing (tested before every single commit so we should be fairly easy to pick relevant ones, or drop irrelevant ones).

Suggestions:
- Added typing to a few places. Only the obvious so far. Used the `if TYPE_CHECKING` to avoid circular imports. MyPy is working great now
- Decomposed a bit of the `operations` function which was quite long. No changes in logic were made, just splitting the function itself.
- Suggestion to change the name from `op_meta` to `op_hash_map` to be more descriptive
- Suggestion to change the name `meta` to `host_meta` to be more descriptive
- Suggestion to change the name `ops` from the `state` to `ops_hosts` to be more descriptive
- Suggestion to add the keys to the Config to be able to know which keys are available, have auto complete and check for default configurations easily
- Suggestion to add the programatic access to the readme
- Suggestion to add a few more instructions to the readme
- Suggestion to remove a default mutable argument from the host and set the driver during initialization
- Suggestion to add a Makefile
- Suggestion to add the `connect_all` and `disconnect_all` functions as methods to the `state` to be more explicit

This are all just suggestions that I think would help to make the code base a bit easier to reason about, I made a comment to every (almost) commit to explain the rationale behind each change, trying to make it explicit and easy to understand. Let me know what you guys think, happy to further work on it. Also invited @Fizzadar to the fork just in case. Let me know if I should add anyone else. 

Already merged to 2.4 to fix conflicts.