### PR TITLE
Fix URL to point to the new default branch.

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,7 +1,7 @@
 Example Deploys
 ===============
 
-If you are getting started with ``pyinfra`` checkout `the examples on Github <https://github.com/Fizzadar/pyinfra/tree/master/examples>`_ which should properly introduce the file/folder structure as well as operation basics.
+If you are getting started with ``pyinfra`` checkout `the examples on Github <https://github.com/Fizzadar/pyinfra/tree/2.x/examples>`_ which should properly introduce the file/folder structure as well as operation basics.
 
 Included here is a set of documented example deploys highlighting common patterns and best practices:
 


### PR DESCRIPTION
Fixes the typo mentioned in https://discord.com/channels/758274384828825621/1011699113898807367/1011704591471095859