### PR TITLE
Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs/_deploy_globals.rst
 .idea/
 
 pyinfra-debug.log
+Makefile

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -179,76 +179,9 @@ def operation(
                 )
             return func(*args, **kwargs) or []
 
-        # If this is a legacy operation function (ie - state & host arg kwargs), ensure that state
-        # and host are included as kwargs.
-        if func.is_legacy:
-            if "state" not in kwargs:
-                kwargs["state"] = state
-            if "host" not in kwargs:
-                kwargs["host"] = host
-        # If not legacy, pop off any state/host kwargs that may come from legacy @deploy functions
-        else:
-            kwargs.pop("state", None)
-            kwargs.pop("host", None)
-
-        # Name the operation
-        name = global_kwargs.get("name")
-        add_args = False
-
-        if name:
-            names = {name}
-
-        # Generate an operation name if needed (Module/Operation format)
-        else:
-            add_args = True
-
-            if func.__module__:
-                module_bits = func.__module__.split(".")
-                module_name = module_bits[-1]
-                name = "{0}/{1}".format(module_name.title(), func.__name__.title())
-            else:
-                name = func.__name__
-
-            names = {name}
-
-        if host.current_deploy_name:
-            names = {"{0} | {1}".format(host.current_deploy_name, name) for name in names}
-
-        # Operation order is used to tie-break available nodes in the operation DAG, in CLI mode
-        # we use stack call order so this matches as defined by the user deploy code.
-        if pyinfra.is_cli:
-            op_order = get_operation_order_from_stack(state)
-        # In API mode we just increase the order for each host
-        else:
-            op_order = [len(host.op_hash_order)]
-
-        # Make a hash from the call stack lines
-        op_hash = make_hash(op_order)
-
-        # Avoid adding duplicates! This happens if an operation is called within
-        # a loop - such that the filename/lineno/code _are_ the same, but the
-        # arguments might be different. We just append an increasing number to
-        # the op hash and also handle below with the op order.
-        duplicate_op_count = 0
-        while op_hash in host.op_hash_order:
-            logger.debug("Duplicate hash (%s) detected!", op_hash)
-            op_hash = "{0}-{1}".format(op_hash, duplicate_op_count)
-            duplicate_op_count += 1
-
-        host.op_hash_order.append(op_hash)
-
-        if duplicate_op_count:
-            op_order.append(duplicate_op_count)
-
-        op_order = tuple(op_order)
-
-        logger.debug(
-            "Adding operation names=%r, host=%s, opOrder=%r, opHash=%s",
-            names,
-            host,
-            op_order,
-            op_hash,
-        )
+        kwargs = _solve_legacy_operation_arguments(func, state, host, kwargs)
+        names, add_args = _generate_operation_name(func, host, kwargs, global_kwargs)
+        op_order, op_hash = _solve_operation_consistency(names, state, host)
 
         # Ensure shared (between servers) operation meta
         op_meta = state.op_meta.setdefault(
@@ -274,21 +207,7 @@ def operation(
 
         # Attach normal args, if we're auto-naming this operation
         if add_args:
-            for arg in args:
-                if isinstance(arg, FunctionType):
-                    arg = arg.__name__
-
-                if arg not in op_meta["args"]:
-                    op_meta["args"].append(arg)
-
-            # Attach keyword args
-            for key, value in kwargs.items():
-                if isinstance(value, FunctionType):
-                    value = value.__name__
-
-                arg = "=".join((str(key), str(value)))
-                if arg not in op_meta["args"]:
-                    op_meta["args"].append(arg)
+            op_meta = _attach_args(op_meta, args, kwargs)
 
         # Check if we're actually running the operation on this host
         #
@@ -347,17 +266,118 @@ def operation(
 
         # If we're already in the execution phase, execute this operation immediately
         if state.is_executing:
-            logger.warning(
-                f"Note: nested operations are currently in beta ({get_call_location()})\n"
-                "    More information: "
-                "https://docs.pyinfra.com/en/2.x/using-operations.html#nested-operations",
-            )
-            op_data["parent_op_hash"] = host.executing_op_hash
-            log_operation_start(op_meta, op_types=["nested"], prefix="")
-            run_host_op(state, host, op_hash)
+            _execute_immediately(state, host, op_data, op_meta, op_hash)
 
         # Return result meta for use in deploy scripts
         return operation_meta
 
     decorated_func._pyinfra_op = func
     return decorated_func
+
+
+def _solve_legacy_operation_arguments(op_func, state, host, kwargs):
+    """
+    Solve legacy operation arguments.
+    """
+
+    # If this is a legacy operation function (ie - state & host arg kwargs), ensure that state
+    # and host are included as kwargs.
+
+    # Legacy operation arguments
+    if op_func.is_legacy:
+        if "state" not in kwargs:
+            kwargs["state"] = state
+        if "host" not in kwargs:
+            kwargs["host"] = host
+    # If not legacy, pop off any state/host kwargs that may come from legacy @deploy functions
+    else:
+        kwargs.pop("state", None)
+        kwargs.pop("host", None)
+
+    return kwargs
+
+
+def _generate_operation_name(func, host, kwargs, global_kwargs):
+    # Generate an operation name if needed (Module/Operation format)
+    name = global_kwargs.get("name")
+    add_args = False
+    if name:
+        names = {name}
+    else:
+        add_args = True
+
+        if func.__module__:
+            module_bits = func.__module__.split(".")
+            module_name = module_bits[-1]
+            name = "{0}/{1}".format(module_name.title(), func.__name__.title())
+        else:
+            name = func.__name__
+
+        names = {name}
+
+    if host.current_deploy_name:
+        names = {"{0} | {1}".format(host.current_deploy_name, name) for name in names}
+
+    return names, add_args
+
+
+def _solve_operation_consistency(names, state, host):
+    # Operation order is used to tie-break available nodes in the operation DAG, in CLI mode
+    # we use stack call order so this matches as defined by the user deploy code.
+    if pyinfra.is_cli:
+        op_order = get_operation_order_from_stack(state)
+    # In API mode we just increase the order for each host
+    else:
+        op_order = [len(host.op_hash_order)]
+
+    # Make a hash from the call stack lines
+    op_hash = make_hash(op_order)
+
+    # Avoid adding duplicates! This happens if an operation is called within
+    # a loop - such that the filename/lineno/code _are_ the same, but the
+    # arguments might be different. We just append an increasing number to
+    # the op hash and also handle below with the op order.
+    duplicate_op_count = 0
+    while op_hash in host.op_hash_order:
+        logger.debug("Duplicate hash ({0}) detected!".format(op_hash))
+        op_hash = "{0}-{1}".format(op_hash, duplicate_op_count)
+        duplicate_op_count += 1
+
+    host.op_hash_order.append(op_hash)
+    if duplicate_op_count:
+        op_order.append(duplicate_op_count)
+
+    op_order = tuple(op_order)
+    logger.debug(f"Adding operation, {names}, opOrder={op_order}, opHash={op_hash}")
+    return op_order, op_hash
+
+
+def _execute_immediately(state, host, op_data, op_meta, op_hash):
+    logger.warning(
+        f"Note: nested operations are currently in beta ({get_call_location()})\n"
+        "    More information: "
+        "https://docs.pyinfra.com/en/2.x/using-operations.html#nested-operations",
+    )
+    op_data["parent_op_hash"] = host.executing_op_hash
+    log_operation_start(op_meta, op_types=["nested"], prefix="")
+    run_host_op(state, host, op_hash)
+
+
+def _attach_args(op_meta, args, kwargs):
+    for arg in args:
+        if isinstance(arg, FunctionType):
+            arg = arg.__name__
+
+        if arg not in op_meta["args"]:
+            op_meta["args"].append(arg)
+
+    # Attach keyword args
+    for key, value in kwargs.items():
+        if isinstance(value, FunctionType):
+            value = value.__name__
+
+        arg = "=".join((str(key), str(value)))
+        if arg not in op_meta["args"]:
+            op_meta["args"].append(arg)
+
+    return op_meta

--- a/pyinfra_cli/main.py
+++ b/pyinfra_cli/main.py
@@ -281,7 +281,6 @@ def _main(
 ):
     # Setup working directory
     #
-
     if chdir:
         os_chdir(chdir)
 
@@ -349,20 +348,13 @@ def _main(
 
     # Connect to the hosts & start handling the user commands
     #
-
-    if not quiet:
-        click.echo(err=True)
-        click.echo("--> Connecting to hosts...", err=True)
-
+    echo_msg("--> Connecting to hosts...", quiet)
     connect_all(state)
     state, config = _handle_commands(state, config, command, original_operations, operations, quiet)
 
     # Print proposed changes, execute unless --dry, and exit
     #
-
-    if not quiet:
-        click.echo(err=True)
-        click.echo("--> Proposed changes:", err=True)
+    echo_msg("--> Proposed changes:", quiet)
     print_meta(state)
 
     # If --debug-facts or --debug-operations, print and exit
@@ -378,15 +370,12 @@ def _main(
     if dry:
         _exit()
 
-    if not quiet:
-        click.echo(err=True)
+    echo_msg(quiet=quiet)
+    echo_msg("--> Beginning operation run...", quiet)
 
-    if not quiet:
-        click.echo("--> Beginning operation run...", err=True)
     run_ops(state, serial=serial, no_wait=no_wait)
 
-    if not quiet:
-        click.echo("--> Results:", err=True)
+    echo_msg("--> Results:", quiet)
     print_results(state)
 
     _exit()
@@ -568,8 +557,7 @@ def _set_config(
     if fail_percent is not None:
         config.FAIL_PERCENT = fail_percent
 
-    if not quiet:
-        click.echo("--> Loading inventory...", err=True)
+    echo_msg("--> Loading inventory...", quiet)
 
     return config
 
@@ -585,8 +573,7 @@ def _set_verbosity(state, verbosity, quiet):
     if verbosity > 2:
         state.print_output = state.print_fact_output = True
 
-    if not quiet:
-        click.echo("--> Loading config...", err=True)
+    echo_msg("--> Loading config...", quiet)
 
     return state
 
@@ -633,9 +620,7 @@ def _handle_commands(state, config, command, original_operations, operations, qu
 
 
 def _run_fact_operations(state, config, operations, quiet):
-    if not quiet:
-        click.echo(err=True)
-        click.echo("--> Gathering facts...", err=True)
+    echo_msg("--> Gathering Facts...", quiet)
 
     state.print_fact_info = True
     fact_data = {}
@@ -675,9 +660,7 @@ def _run_exec_operations(state, config, operations, quiet):
 
 
 def _run_deploy_operations(state, config, operations, quiet):
-    if not quiet:
-        click.echo(err=True)
-        click.echo("--> Preparing operations...", err=True)
+    echo_msg("--> Preparing Operations...", quiet)
 
     # Number of "steps" to make = number of files * number of hosts
     for i, filename in enumerate(operations):
@@ -694,9 +677,7 @@ def _run_deploy_operations(state, config, operations, quiet):
 
 
 def _run_op_operations(state, config, operations, original_operations, quiet):
-    if not quiet:
-        click.echo(err=True)
-        click.echo("--> Preparing operation...", err=True)
+    echo_msg("--> Preparing operation...", quiet)
 
     op, args = operations
     args, kwargs = args
@@ -712,3 +693,12 @@ def _run_op_operations(state, config, operations, original_operations, quiet):
     add_op(state, op, *args, **kwargs)
 
     return state, kwargs
+
+
+# Utils
+#
+def echo_msg(msg=None, quiet=None):
+    if not quiet:
+        click.echo(err=True)
+    if msg:
+        click.echo(msg, err=True)

--- a/pyinfra_cli/main.py
+++ b/pyinfra_cli/main.py
@@ -328,6 +328,7 @@ def _main(
     )
 
     # Load up the inventory from the filesystem
+    echo_msg("--> Loading inventory...", quiet)
     inventory, inventory_group = make_inventory(
         inventory,
         cwd=state.cwd,
@@ -527,6 +528,8 @@ def _set_config(
     fail_percent,
     quiet,
 ):
+    echo_msg("--> Loading config...", quiet)
+
     # Load up any config.py from the filesystem
     config_filename = path.join(state.cwd, config_filename)
     if path.exists(config_filename):
@@ -557,8 +560,6 @@ def _set_config(
     if fail_percent is not None:
         config.FAIL_PERCENT = fail_percent
 
-    echo_msg("--> Loading inventory...", quiet)
-
     return config
 
 
@@ -572,8 +573,6 @@ def _set_verbosity(state, verbosity, quiet):
 
     if verbosity > 2:
         state.print_output = state.print_fact_output = True
-
-    echo_msg("--> Loading config...", quiet)
 
     return state
 


### PR DESCRIPTION
The idea here is to make functions smaller, and easier to comprehend (and maintain).
I tried to split the big functions (mainly the `main` cli, `operations` and `operation`) into smaller chunks that made sense (not sure I was able to). I tried to follow the logic already present using the comment blocks.

Example for the `main`:

```python
_setup_log_level()
_validate_operations()
_setup_state()
_set_override_data()
_set_config()
_set_verbosity()
_apply_inventory_limit()
```
Unfortunately this made the diff quite a pain specially for the `cli` part, I'm sorry about that. Hopefully looking at the code directly will make more sense. The good part is that it made the function a lot smaller (from ~350 to less than 100 lines), and easier to understand (in my opinion, of course).

Also tried to slightly reduce the indented and nested parts of the code (this usually happens with log messages) - as a first suggestion, I chose to go to the "more variables, less indentation path" but this is purely a personal choice (I personally feel is easier to read & follow). A lot of these are local/private, and won't be used anywhere else, hence the `_` prefix.

In general I chose to play safe, sometimes returning more information that what's necessary, mainly because there are a few places that change global vars, so I though it would be better to return more than what's necessary.

I made an effort not to change any piece of logic, just purely organizing functions. Tests are passing normally. I hope you guys like it, but I understand there's a lot of personal preferences here, let me now what you think and I'll be happy to adjust accordingly. If none of this makes sense, I'll also understand, no worries at all.