### PR TITLE
Spelling fixes, spotted using codespell

### DIFF
--- a/docs/deploy-process.rst
+++ b/docs/deploy-process.rst
@@ -136,7 +136,7 @@ This results in the following DAG order for each host - note that ``pyinfra`` do
     # @local: A -> B -> A-1 -> B-1
     # Other:       B -> A   -> B-1
 
-The probelm is that combining these two means A needs B and B needs A, causing a loop and raising an error. We can use the ``host.loop`` function to prevent this occurring by providing the loop position to ``pyinfra``:
+The problem is that combining these two means A needs B and B needs A, causing a loop and raising an error. We can use the ``host.loop`` function to prevent this occurring by providing the loop position to ``pyinfra``:
 
 .. code:: python
 

--- a/docs/examples/secret_storage.md
+++ b/docs/examples/secret_storage.md
@@ -1,6 +1,6 @@
 # Using Secrets in pyinfra
 
-Encrpyting sensitive information can be achieved using Python packages such as [privy](https://pypi.org/project/privy/).
+Encrypting sensitive information can be achieved using Python packages such as [privy](https://pypi.org/project/privy/).
 
 ```py
 # group_data/all.py

--- a/pyinfra/api/arguments.py
+++ b/pyinfra/api/arguments.py
@@ -58,7 +58,7 @@ auth_kwargs = {
     },
     "_doas": {
         "description": "Execute/apply any changes with ``doas``.",
-        "defailt": lambda config: config.DOAS,
+        "default": lambda config: config.DOAS,
         "type": bool,
     },
     "_doas_user": {

--- a/pyinfra/connectors/ssh.py
+++ b/pyinfra/connectors/ssh.py
@@ -216,7 +216,7 @@ def _make_paramiko_kwargs(state, host):
 
 def connect(state, host):
     """
-    Connect to a single host. Returns the SSH client if succesful. Stateless by
+    Connect to a single host. Returns the SSH client if successful. Stateless by
     design so can be run in parallel.
     """
 

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -284,12 +284,12 @@ def line(
         # prepare to do some maintenance
         maintenance_line = "SYSTEM IS DOWN FOR MAINTENANCE"
         files.line(
-            name="Add the down-for-maintence line in /etc/motd",
+            name="Add the down-for-maintenance line in /etc/motd",
             path="/etc/motd",
             line=maintenance_line,
         )
 
-        # Then, after the mantenance is done, remove the maintenance line
+        # Then, after the maintenance is done, remove the maintenance line
         files.line(
             name="Remove the down-for-maintenance line in /etc/motd",
             path="/etc/motd",

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -129,7 +129,7 @@ def make_operation_tests(arg):
                                     allowed_exception_names = [allowed_exception["name"]]
 
                                 if e.__class__.__name__ not in allowed_exception_names:
-                                    print("Wrong execption raised!")
+                                    print("Wrong exception raised!")
                                     raise
 
                                 assert e.args[0] == allowed_exception["message"]


### PR DESCRIPTION
I ran `pip install codespell` and then `codespell .` in the `pyinfra` directory. These are the fixes that it spotted which looked like they mattered (it had a bunch of noise too).