### PR TITLE
Include systemd inactive units when checking for status

### DIFF
--- a/pyinfra/facts/systemd.py
+++ b/pyinfra/facts/systemd.py
@@ -65,7 +65,7 @@ class SystemdStatus(FactBase):
             user_name=user_name,
         )
 
-        return f"{fact_cmd} show --property Id --property {self.state_key} '*'"
+        return f"{fact_cmd} show --all --property Id --property {self.state_key} '*'"
 
     def process(self, output):
         services = {}

--- a/tests/facts/systemd.SystemdEnabled/machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [false, "testmachine", "testuser"],
-    "command": "systemctl --machine=testuser@testmachine show --property Id --property UnitFileState '*'",
+    "command": "systemctl --machine=testuser@testmachine show --all --property Id --property UnitFileState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=vboxadd.service",

--- a/tests/facts/systemd.SystemdEnabled/root_machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/root_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [false, "testmachine"],
-    "command": "systemctl --machine=testmachine show --property Id --property UnitFileState '*'",
+    "command": "systemctl --machine=testmachine show --all --property Id --property UnitFileState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=vboxadd.service",

--- a/tests/facts/systemd.SystemdEnabled/services.json
+++ b/tests/facts/systemd.SystemdEnabled/services.json
@@ -1,6 +1,6 @@
 {
     "requires_command": "systemctl",
-    "command": "systemctl show --property Id --property UnitFileState '*'",
+    "command": "systemctl show --all --property Id --property UnitFileState '*'",
     "output": [
         "Id=vboxadd.service",
         "UnitFileState=enabled",

--- a/tests/facts/systemd.SystemdEnabled/user_machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/user_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [true, "testmachine", "testuser"],
-    "command": "systemctl --user --machine=testuser@testmachine show --property Id --property UnitFileState '*'",
+    "command": "systemctl --user --machine=testuser@testmachine show --all --property Id --property UnitFileState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=vboxadd.service",

--- a/tests/facts/systemd.SystemdEnabled/user_services.json
+++ b/tests/facts/systemd.SystemdEnabled/user_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [true],
-    "command": "systemctl --user show --property Id --property UnitFileState '*'",
+    "command": "systemctl --user show --all --property Id --property UnitFileState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=vboxadd.service",

--- a/tests/facts/systemd.SystemdStatus/machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [false, "testmachine", "testuser"],
-    "command": "systemctl --machine=testuser@testmachine show --property Id --property SubState '*'",
+    "command": "systemctl --machine=testuser@testmachine show --all --property Id --property SubState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/root_machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/root_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [false, "testmachine"],
-    "command": "systemctl --machine=testmachine show --property Id --property SubState '*'",
+    "command": "systemctl --machine=testmachine show --all --property Id --property SubState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/services.json
+++ b/tests/facts/systemd.SystemdStatus/services.json
@@ -1,5 +1,5 @@
 {
-    "command": "systemctl show --property Id --property SubState '*'",
+    "command": "systemctl show --all --property Id --property SubState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/services_invalid_output.json
+++ b/tests/facts/systemd.SystemdStatus/services_invalid_output.json
@@ -1,5 +1,5 @@
 {
-    "command": "systemctl show --property Id --property SubState '*'",
+    "command": "systemctl show --all --property Id --property SubState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/user_machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/user_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": ["True", "testmachine", "testuser"],
-    "command": "systemctl --user --machine=testuser@testmachine show --property Id --property SubState '*'",
+    "command": "systemctl --user --machine=testuser@testmachine show --all --property Id --property SubState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/user_services.json
+++ b/tests/facts/systemd.SystemdStatus/user_services.json
@@ -1,6 +1,6 @@
 {
     "arg": ["True"],
-    "command": "systemctl --user show --property Id --property SubState '*'",
+    "command": "systemctl --user show --all --property Id --property SubState '*'",
     "requires_command": "systemctl",
     "output": [
         "Id=lvm2-activation.service",


### PR DESCRIPTION
Added `--all` flag to `SystemdStatus` to include the inactive units. From the manual page of `systemctl`:

```
-a, --all
           When listing units, show all loaded units, regardless of their state, including inactive units.
```