### PR TITLE
Fix for RpmPackage fact to work with .rpm files as well as package names

### DIFF
--- a/pyinfra/facts/rpm.py
+++ b/pyinfra/facts/rpm.py
@@ -44,8 +44,9 @@ class RpmPackage(FactBase):
 
     def command(self, name):
         return (
+            'rpm --queryformat "{0}" -q {1} || '
             "! test -e {1} || "
-            '(rpm --queryformat "{0}" -qp {1} 2> /dev/null || rpm --queryformat "{0}" -q {1})'
+            'rpm --queryformat "{0}" -qp {1} 2> /dev/null'
         ).format(rpm_query_format, name)
 
     def process(self, output):

--- a/tests/facts/rpm.RpmPackage/package.json
+++ b/tests/facts/rpm.RpmPackage/package.json
@@ -1,6 +1,6 @@
 {
     "arg": "somepackage",
-    "command": "! test -e somepackage || (rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -qp somepackage 2> /dev/null || rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -q somepackage)",
+    "command": "rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -q somepackage || ! test -e somepackage || rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -qp somepackage 2> /dev/null",
     "requires_command": "rpm",
     "output": [
         "pydash 3.48.0"


### PR DESCRIPTION
Currently the `RpmPackage` fact only works for `.rpm` files and not also package names (because the command starts with `! test -e {1} || `). However the fact is used by the `dnf.rpm` opertation in both ways (from `packaging.ensure_rpm`):

```python
    # Check for file .rpm information
    info = host.get_fact(RpmPackage, name=source)
    exists = False

    # We have info!
    if info:
        current_package = host.get_fact(RpmPackage, name=info["name"])
        if current_package and current_package["version"] == info["version"]:
            exists = True
```

This PR allows the `RpmPackage` fact to work for both `.rpm` files and package names, fixing the `dnf.rpm` operation.