### PR TITLE
Remove `Windows` prefix from all Windows facts.

### DIFF
--- a/examples/choco.py
+++ b/examples/choco.py
@@ -1,8 +1,8 @@
 from pyinfra import host
-from pyinfra.facts.windows import WindowsComputerInfo
+from pyinfra.facts.windows import ComputerInfo
 from pyinfra.operations import choco
 
-computer_info = host.get_fact(WindowsComputerInfo)
+computer_info = host.get_fact(ComputerInfo)
 if computer_info:
     product_name = computer_info["WindowsProductName"]
     if product_name:

--- a/examples/windows_ip.py
+++ b/examples/windows_ip.py
@@ -1,8 +1,8 @@
 from pyinfra import host
-from pyinfra.facts.windows import WindowsNetworkConfiguration
+from pyinfra.facts.windows import NetworkConfiguration
 
 # print ip address for all network entries
-windows_network_config = host.get_fact(WindowsNetworkConfiguration)
+windows_network_config = host.get_fact(NetworkConfiguration)
 
 for index, data in windows_network_config["Index"]:
     print(data["IPAddress"])

--- a/pyinfra/connectors/winrm.py
+++ b/pyinfra/connectors/winrm.py
@@ -290,11 +290,11 @@ def put_file(
     """
 
     # TODO: fix this? Workaround for circular import
-    from pyinfra.facts.windows_files import WindowsTempDir
+    from pyinfra.facts.windows_files import TempDir
 
     # Always use temp file here in case of failure
     temp_file = ntpath.join(
-        host.get_fact(WindowsTempDir),
+        host.get_fact(TempDir),
         "pyinfra-{0}".format(sha1_hash(remote_filename)),
     )
 


### PR DESCRIPTION
Fixes examples.

Relates to 3a274a04dad3f2a4ae85a02909638132dbdb437b.
