### PR TITLE
SUDO_ASKPASS_COMMAND: respect TMPDIR if it is set

### DIFF
--- a/pyinfra/connectors/util.py
+++ b/pyinfra/connectors/util.py
@@ -13,7 +13,7 @@ from pyinfra.api.util import memoize
 
 SUDO_ASKPASS_ENV_VAR = "PYINFRA_SUDO_PASSWORD"
 SUDO_ASKPASS_COMMAND = r"""
-temp=$(mktemp /tmp/pyinfra-sudo-askpass-XXXXXXXXXXXX)
+temp=$(mktemp "${{TMPDIR:=/tmp}}/pyinfra-sudo-askpass-XXXXXXXXXXXX")
 cat >"$temp"<<'__EOF__'
 #!/bin/sh
 printf '%s\n' "${0}"


### PR DESCRIPTION
Respect TMPDIR if it is set instead of forcing /tmp which on some hosts may not be writable. Note that we're not using `-t` since it does not behave in a portable way across platforms. e.g. macOS `-t` does NOT want trailing XXXXXXX, while the BSDs do want them, and on Linux `-t` is deprecated altogether.

Fixes #880.