### PR TITLE
Fix OpenRC status and Apk package fact detection

### DIFF
--- a/pyinfra/facts/apk.py
+++ b/pyinfra/facts/apk.py
@@ -2,7 +2,7 @@ from pyinfra.api import FactBase
 
 from .util.packaging import parse_packages
 
-APK_REGEX = r"^([a-zA-Z\-]+)-([0-9\.]+\-?[a-z0-9]*)\s"
+APK_REGEX = r"^([a-zA-Z0-9\-_]+)-([0-9\.]+\-?[a-z0-9]*)\s"
 
 
 class ApkPackages(FactBase):

--- a/pyinfra/facts/openrc.py
+++ b/pyinfra/facts/openrc.py
@@ -10,7 +10,7 @@ class OpenrcStatus(FactBase):
 
     default = dict
     requires_command = "rc-status"
-    regex = r"\s+([a-zA-Z0-9\-_]+)\s+\[\s+([a-z]+)\s+\]"
+    regex = r"\s+([a-zA-Z0-9\-_]+)\s+\[\s+([a-z]+)(?:\s(?:[0-9]+\sday\(s\)\s)?[0-9]+\:[0-9]+\:[0-9]+\s\([0-9]+\))?\s+\]"
 
     def command(self, runlevel="default"):
         return "rc-status {0}".format(runlevel)

--- a/pyinfra/facts/openrc.py
+++ b/pyinfra/facts/openrc.py
@@ -10,7 +10,14 @@ class OpenrcStatus(FactBase):
 
     default = dict
     requires_command = "rc-status"
-    regex = r"\s+([a-zA-Z0-9\-_]+)\s+\[\s+([a-z]+)(?:\s(?:[0-9]+\sday\(s\)\s)?[0-9]+\:[0-9]+\:[0-9]+\s\([0-9]+\))?\s+\]"
+    regex = (
+        r"\s+([a-zA-Z0-9\-_]+)"
+        r"\s+\[\s+"
+        r"([a-z]+)"
+        r"(?:\s(?:[0-9]+\sday\(s\)\s)?"
+        r"[0-9]+\:[0-9]+\:[0-9]+\s\([0-9]+\))?"
+        r"\s+\]"
+    )
 
     def command(self, runlevel="default"):
         return "rc-status {0}".format(runlevel)

--- a/tests/facts/apk.ApkPackages/packages.json
+++ b/tests/facts/apk.ApkPackages/packages.json
@@ -7,7 +7,9 @@
         "musl-1.1.22-r3 x86_64 {musl} (MIT) [installed]",
         "zlib-1.2.11-r1 x86_64 {zlib} (zlib) [installed]",
         "apk-tools-2.10.4-r2 x86_64 {apk-tools} (GPL2) [installed]",
-        "musl-utils-1.1.22-r3 x86_64 {musl} (MIT BSD GPL2+) [installed]"
+        "musl-utils-1.1.22-r3 x86_64 {musl} (MIT BSD GPL2+) [installed]",
+        "iproute2-5.17.0-r0 x86_64 {iproute2} (GPL-2.0-or-later) [installed]",
+        "linux-firmware-rtl_nic-20220509-r1 x86_64 {linux-firmware} (custom:multiple) [installed]"
     ],
     "fact": {
         "musl": [
@@ -21,6 +23,12 @@
         ],
         "musl-utils": [
             "1.1.22-r3"
+        ],
+        "iproute2": [
+            "5.17.0-r0"
+        ],
+        "linux-firmware-rtl_nic": [
+            "20220509-r1"
         ]
     }
 }

--- a/tests/facts/openrc.OpenrcStatus/services.json
+++ b/tests/facts/openrc.OpenrcStatus/services.json
@@ -7,12 +7,16 @@
         "  net-online                                    [  started  ]",
         "  sshd                                    [  started  ]",
         "  virtualbox-guest-additions              [  crashed  ]",
-        "  crond                                    [  started  ]"
+        "  crond                                    [  started  ]",
+        "  podman                                   [  started 00:34:14 (10) ]",
+        "  podman-long-running                      [  started 15 day(s) 00:34:14 (10) ]"
     ],
     "fact":  {
         "net-online": true,
         "sshd": true,
         "virtualbox-guest-additions": false,
-        "crond": true
+        "crond": true,
+        "podman": true,
+        "podman-long-running": true
     }
 }

--- a/tests/facts/openrc.OpenrcStatus/services_runlevel.json
+++ b/tests/facts/openrc.OpenrcStatus/services_runlevel.json
@@ -7,12 +7,16 @@
         "  net-online                                    [  started  ]",
         "  sshd                                    [  started  ]",
         "  virtualbox-guest-additions              [  crashed  ]",
-        "  crond                                    [  started  ]"
+        "  crond                                    [  started  ]",
+        "  podman                                   [  started 00:34:14 (10) ]",
+        "  podman-long-running                      [  started 15 day(s) 00:34:14 (10) ]"
     ],
     "fact":  {
         "net-online": true,
         "sshd": true,
         "virtualbox-guest-additions": false,
-        "crond": true
+        "crond": true,
+        "podman": true,
+        "podman-long-running": true
     }
 }


### PR DESCRIPTION
This PR fix some detection problem with openrc and apk facts :

* Apk package fact
   include numbers and underscores in package's name search regex
   package like `iproute2` or `linux-firmware-rtl_nic` are now detected 

* OpenRC fact
   include extended status format (started_until date and restart_count) in rc-status output parser
   supervised service with following status are now detected :

   ```
   podman                                   [  started 00:34:14 (10) ]
   podman                                   [  started 15 day(s) 00:34:14 (10) ]
   ```