### PR TITLE
feat: support auto_remove on apt.upgrade

### DIFF
--- a/pyinfra/operations/apt.py
+++ b/pyinfra/operations/apt.py
@@ -340,20 +340,34 @@ _update = update  # noqa: E305
 
 
 @operation(is_idempotent=False)
-def upgrade():
+def upgrade(auto_remove: bool = False):
     """
     Upgrades all apt packages.
+
+    + autoremove: removes transitive dependencies that are no longer needed.
 
     **Example:**
 
     .. code:: python
 
+        # Upgrade all packages
         apt.upgrade(
             name="Upgrade apt packages",
         )
+
+        # Upgrade all packages and remove unneeded transitive dependencies
+        apt.upgrade(
+            name="Upgrade apt packages and remove unneeded dependencies"
+            auto_remove=True
+        )
     """
 
-    yield noninteractive_apt("upgrade")
+    command = ["upgrade"]
+
+    if auto_remove:
+        command.append("--autoremove")
+
+    yield noninteractive_apt(" ".join(command))
 
 
 _upgrade = upgrade  # noqa: E305 (for use below where update is a kwarg)

--- a/tests/operations/apt.upgrade/upgrade_autoremove.json
+++ b/tests/operations/apt.upgrade/upgrade_autoremove.json
@@ -1,0 +1,7 @@
+{
+    "args": ["auto_remove"],
+    "commands": [
+        "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade --autoremove"
+    ],
+    "idempotent": false
+}

--- a/tests/operations/apt.upgrade/upgrade_autoremove.json
+++ b/tests/operations/apt.upgrade/upgrade_autoremove.json
@@ -1,5 +1,5 @@
 {
-    "args": ["auto_remove"],
+    "kwargs": {"auto_remove": true},
     "commands": [
         "DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::=\"--force-confdef\" -o Dpkg::Options::=\"--force-confold\" upgrade --autoremove"
     ],


### PR DESCRIPTION
# :books: Context

I used `pyinfra` to keep small home servers running and it's been of great help in making maintenance a breeze. Recently, I've been looking at converting the `apt` calls I have from using the `server` operations (i.e. just spelling out the full command via `server.shell`) to something more targeted using the `apt` operation set.

Whenever I upgrade dependencies, I generally throw in `--auto-remove` in to collect orphaned transitive dependencies and avoid accumulating cruft, but the absence of support for it in the `apt` operations, I can either use a forked `pyinfra` to allow it, or keep using `server.shell`, which I'm lukewarm about.

This changeset addresses this by adding an `auto_remove` optional argument to `apt.upgrade`. I think it'd be a great thing to have since folks who rely on `autoremove` would no longer have to resort to `server.shell` to use it.

I would welcome feedback if you have thoughts!

# :hammer_and_pick: QA

I've QA'd this firsthand with my own setup using the forked `pyinfra` to run my update and upgrade playbook. Tossed in a test to cover the new option as well.