### PR TITLE
feat: use ssh connector parameters with files.rsync

### DIFF
--- a/pyinfra/connectors/ssh.py
+++ b/pyinfra/connectors/ssh.py
@@ -611,15 +611,19 @@ def rsync(
 
     known_hosts_file = host.data.get(DATA_KEYS.known_hosts_file, "")
     if known_hosts_file:
-        ssh_flags.append('-o \\"UserKnownHostsFile={0}\\"'.format(shlex.quote(known_hosts_file)))  # never trust users
+        ssh_flags.append(
+            '-o \\"UserKnownHostsFile={0}\\"'.format(shlex.quote(known_hosts_file))
+        )  # never trust users
 
     strict_host_key_checking = host.data.get(DATA_KEYS.strict_host_key_checking, "")
     if strict_host_key_checking:
-        ssh_flags.append('-o \\"StrictHostKeyChecking={0}\\"'.format(shlex.quote(strict_host_key_checking)))
+        ssh_flags.append(
+            '-o \\"StrictHostKeyChecking={0}\\"'.format(shlex.quote(strict_host_key_checking))
+        )
 
     ssh_config_file = host.data.get(DATA_KEYS.config_file, "")
     if ssh_config_file:
-        ssh_flags.append('-F {0}'.format(shlex.quote(ssh_config_file)))
+        ssh_flags.append("-F {0}".format(shlex.quote(ssh_config_file)))
 
     port = host.data.get(DATA_KEYS.port)
     if port:
@@ -637,7 +641,7 @@ def rsync(
 
     rsync_command = (
         "rsync {rsync_flags} "
-        "--rsh \"ssh {ssh_flags}\" "
+        '--rsh "ssh {ssh_flags}" '
         "--rsync-path '{remote_rsync_command}' "
         "{src} {user}{hostname}:{dest}"
     ).format(

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -712,7 +712,8 @@ def rsync(src, dest, flags=["-ax", "--delete"]):
 
     .. important::
         The ``files.rsync`` operation is in alpha, and only supported using SSH
-        or ``@local`` connectors.
+        or ``@local`` connectors. When using the SSH connector, rsync will automatically use the
+        StrictHostKeyChecking setting, config and known_hosts file (when specified).
 
     .. caution::
         When using SSH, the ``files.rsync`` operation only supports the ``sudo`` and ``sudo_user``

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -318,7 +318,7 @@ class TestOperationsApi(PatchSSHTestCase):
         fake_run_local_process.assert_called_with(
             (
                 "rsync -ax --delete --rsh "
-                "\"ssh -o BatchMode=yes\""
+                '"ssh -o BatchMode=yes"'
                 " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,
@@ -342,7 +342,7 @@ class TestOperationsApi(PatchSSHTestCase):
         fake_run_local_process.assert_called_with(
             (
                 "rsync -ax --delete --rsh "
-                "\"ssh -o BatchMode=yes -o \\\"StrictHostKeyChecking=no\\\"\""
+                '"ssh -o BatchMode=yes -o \\"StrictHostKeyChecking=no\\""'
                 " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,
@@ -350,12 +350,17 @@ class TestOperationsApi(PatchSSHTestCase):
         )
 
     def test_rsync_op_with_strict_host_key_checking_disabled_and_custom_config_file(self):
-        inventory = make_inventory(hosts=(
-            ("somehost", {
-                "ssh_strict_host_key_checking": "no",
-                "ssh_config_file": "/home/me/ssh_test_config"
-            }),
-        ))
+        inventory = make_inventory(
+            hosts=(
+                (
+                    "somehost",
+                    {
+                        "ssh_strict_host_key_checking": "no",
+                        "ssh_config_file": "/home/me/ssh_test_config",
+                    },
+                ),
+            )
+        )
         state = State(inventory, Config())
         connect_all(state)
 
@@ -371,7 +376,8 @@ class TestOperationsApi(PatchSSHTestCase):
         fake_run_local_process.assert_called_with(
             (
                 "rsync -ax --delete --rsh "
-                "\"ssh -o BatchMode=yes -o \\\"StrictHostKeyChecking=no\\\" -F /home/me/ssh_test_config\""
+                '"ssh -o BatchMode=yes '
+                '-o \\"StrictHostKeyChecking=no\\" -F /home/me/ssh_test_config"'
                 " --rsync-path 'sudo -u root rsync' src vagrant@somehost:dest"
             ),
             print_output=False,
@@ -379,11 +385,9 @@ class TestOperationsApi(PatchSSHTestCase):
         )
 
     def test_rsync_op_with_sanitized_custom_config_file(self):
-        inventory = make_inventory(hosts=(
-            ("somehost", {
-                "ssh_config_file": "/home/me/ssh_test_config && echo hi"
-            }),
-        ))
+        inventory = make_inventory(
+            hosts=(("somehost", {"ssh_config_file": "/home/me/ssh_test_config && echo hi"}),)
+        )
         state = State(inventory, Config())
         connect_all(state)
 


### PR DESCRIPTION
This pull requests aims to be a solution for and close #918. 

Rsync will use the `strict_host_key_checking`, `known_hosts_file` and `config_file` if provided by the user which can be helpful when having a lot of configuration regarding one single host that should not be part of the host configuration of the ssh connector itself. There are test cases covering the new options.