### PR TITLE
Fix handling of mysql privileges

### DIFF
--- a/pyinfra/facts/mysql.py
+++ b/pyinfra/facts/mysql.py
@@ -222,8 +222,7 @@ class MysqlUserGrants(MysqlFactBase):
 
             for privilege in privileges.split(","):
                 privilege = privilege.strip()
-                if privilege != "USAGE":  # USAGE means no privilege
-                    database_table_privileges[database_table].add(privilege)
+                database_table_privileges[database_table].add(privilege)
 
             if "WITH GRANT OPTION" in extras:
                 database_table_privileges[database_table].add("GRANT OPTION")

--- a/pyinfra/facts/mysql.py
+++ b/pyinfra/facts/mysql.py
@@ -163,8 +163,8 @@ class MysqlUsers(MysqlFactBase):
 
 
 MYSQL_GRANT_REGEX = (
-    r"^GRANT ([A-Z,\s]+) ON ((?:\*|`[a-z_\\]+`)(?:\.\*|'[a-z_]+')) "
-    r"TO `[A-Z0-9a-z_\-]+`@`[A-Z0-9a-z_\.\-]+`(.*)"
+    r"^GRANT ([A-Z,\s]+) ON ((?:\*|`[a-z_\\]+`)\.(?:\*|`[a-z_]+`)) "
+    r"TO `[A-Z0-9a-z_\-]+`@`(?:%|[A-Z0-9a-z_\.\-]+)`(.*)"
 )
 
 
@@ -222,7 +222,8 @@ class MysqlUserGrants(MysqlFactBase):
 
             for privilege in privileges.split(","):
                 privilege = privilege.strip()
-                database_table_privileges[database_table].add(privilege)
+                if privilege != "USAGE":  # USAGE means no privilege
+                    database_table_privileges[database_table].add(privilege)
 
             if "WITH GRANT OPTION" in extras:
                 database_table_privileges[database_table].add("GRANT OPTION")

--- a/pyinfra/operations/mysql.py
+++ b/pyinfra/operations/mysql.py
@@ -504,17 +504,9 @@ def privileges(
     # Find / grant any privileges that we want but do not exist
     privileges_to_grant = privileges - existing_privileges
 
-    if privileges_to_grant:
-        if {"ALL", "GRANT OPTION"} == privileges_to_grant:
-            # ALL must be named by itself and cannot be specified along with other privileges
-            # The only exception for us is GRANT OPTION but as a WITH clause
-            # So handle this case and let the other ones fail
-            yield from handle_privileges("GRANT", "TO", {"ALL PRIVILEGES"}, "GRANT OPTION")
-        else:
-            yield from handle_privileges("GRANT", "TO", privileges_to_grant)
-        user_grants[database_table].update(privileges_to_grant)
 
-        # We have granted something on this table, no need to revoke "USAGE" as it was overridden
+    if privileges_to_grant:
+        # We will grant something on this table, no need to revoke "USAGE" as it will be overridden
         privileges_to_revoke.discard("USAGE")
 
     if privileges_to_revoke:
@@ -526,6 +518,16 @@ def privileges(
         else:
             yield from handle_privileges("REVOKE", "FROM", privileges_to_revoke)
         user_grants[database_table] -= privileges_to_revoke
+
+    if privileges_to_grant:
+        if {"ALL", "GRANT OPTION"} == privileges_to_grant:
+            # ALL must be named by itself and cannot be specified along with other privileges
+            # The only exception for us is GRANT OPTION but as a WITH clause
+            # So handle this case and let the other ones fail
+            yield from handle_privileges("GRANT", "TO", {"ALL PRIVILEGES"}, "GRANT OPTION")
+        else:
+            yield from handle_privileges("GRANT", "TO", privileges_to_grant)
+        user_grants[database_table].update(privileges_to_grant)
 
     if privileges_to_grant or privileges_to_revoke:
         if flush:

--- a/pyinfra/operations/mysql.py
+++ b/pyinfra/operations/mysql.py
@@ -514,6 +514,9 @@ def privileges(
             yield from handle_privileges("GRANT", "TO", privileges_to_grant)
         user_grants[database_table].update(privileges_to_grant)
 
+        # We have granted something on this table, no need to revoke "USAGE" as it was overridden
+        privileges_to_revoke.discard("USAGE")
+
     if privileges_to_revoke:
         if {"ALL", "GRANT OPTION"} == privileges_to_revoke:
             # This specific case is identified as the alternative syntax for revoke (without ON).

--- a/pyinfra/operations/mysql.py
+++ b/pyinfra/operations/mysql.py
@@ -504,7 +504,6 @@ def privileges(
     # Find / grant any privileges that we want but do not exist
     privileges_to_grant = privileges - existing_privileges
 
-
     if privileges_to_grant:
         # We will grant something on this table, no need to revoke "USAGE" as it will be overridden
         privileges_to_revoke.discard("USAGE")

--- a/pyinfra/operations/mysql.py
+++ b/pyinfra/operations/mysql.py
@@ -504,6 +504,9 @@ def privileges(
     # Find / grant any privileges that we want but do not exist
     privileges_to_grant = privileges - existing_privileges
 
+    user_grants[database_table] -= privileges_to_revoke
+    user_grants[database_table].update(privileges_to_grant)
+
     if privileges_to_grant:
         # We will grant something on this table, no need to revoke "USAGE" as it will be overridden
         privileges_to_revoke.discard("USAGE")
@@ -516,7 +519,6 @@ def privileges(
             yield from handle_privileges("REVOKE", "FROM", {"ALL PRIVILEGES"})
         else:
             yield from handle_privileges("REVOKE", "FROM", privileges_to_revoke)
-        user_grants[database_table] -= privileges_to_revoke
 
     if privileges_to_grant:
         if {"ALL", "GRANT OPTION"} == privileges_to_grant:
@@ -526,7 +528,6 @@ def privileges(
             yield from handle_privileges("GRANT", "TO", {"ALL PRIVILEGES"}, "GRANT OPTION")
         else:
             yield from handle_privileges("GRANT", "TO", privileges_to_grant)
-        user_grants[database_table].update(privileges_to_grant)
 
     if privileges_to_grant or privileges_to_revoke:
         if flush:

--- a/tests/operations/mysql.privileges/add_all_with_grant_option.json
+++ b/tests/operations/mysql.privileges/add_all_with_grant_option.json
@@ -1,0 +1,17 @@
+{
+    "args": ["someuser", ["ALL"]],
+    "kwargs": {
+        "with_grant_option": true
+    },
+    "facts": {
+        "mysql.MysqlUserGrants": {
+            "mysql_host=None, mysql_password=None, mysql_port=None, mysql_user=None, user=someuser, hostname=localhost": {
+                "*.*": ["set:"]
+            }
+        }
+    },
+    "commands": [
+        "mysql -Be 'GRANT ALL PRIVILEGES ON *.* TO \"someuser\"@\"localhost\" WITH GRANT OPTION'",
+        "mysql -Be 'FLUSH PRIVILEGES'"
+    ]
+}

--- a/tests/operations/mysql.privileges/add_delete_usage.json
+++ b/tests/operations/mysql.privileges/add_delete_usage.json
@@ -1,0 +1,14 @@
+{
+    "args": ["someuser", ["SELECT"]],
+    "facts": {
+        "mysql.MysqlUserGrants": {
+            "mysql_host=None, mysql_password=None, mysql_port=None, mysql_user=None, user=someuser, hostname=localhost": {
+                "*.*": ["set:", "USAGE"]
+            }
+        }
+    },
+    "commands": [
+        "mysql -Be 'GRANT SELECT ON *.* TO \"someuser\"@\"localhost\"'",
+        "mysql -Be 'FLUSH PRIVILEGES'"
+    ]
+}

--- a/tests/operations/mysql.privileges/delete_all.json
+++ b/tests/operations/mysql.privileges/delete_all.json
@@ -1,15 +1,15 @@
 {
-    "args": ["someuser", ["SELECT", "INSERT", "DELETE"]],
+    "args": ["someuser", ["DELETE"]],
     "facts": {
         "mysql.MysqlUserGrants": {
             "mysql_host=None, mysql_password=None, mysql_port=None, mysql_user=None, user=someuser, hostname=localhost": {
-                "*.*": ["set:", "DELETE", "UPDATE"]
+                "*.*": ["set:", "ALL"]
             }
         }
     },
     "commands": [
-        "mysql -Be 'REVOKE UPDATE ON *.* FROM \"someuser\"@\"localhost\"'",
-        "mysql -Be 'GRANT INSERT, SELECT ON *.* TO \"someuser\"@\"localhost\"'",
+        "mysql -Be 'REVOKE ALL ON *.* FROM \"someuser\"@\"localhost\"'",
+        "mysql -Be 'GRANT DELETE ON *.* TO \"someuser\"@\"localhost\"'",
         "mysql -Be 'FLUSH PRIVILEGES'"
     ]
 }

--- a/tests/operations/mysql.privileges/delete_all_with_grant_option.json
+++ b/tests/operations/mysql.privileges/delete_all_with_grant_option.json
@@ -1,0 +1,15 @@
+{
+    "args": ["someuser", []],
+    "facts": {
+        "mysql.MysqlUserGrants": {
+            "mysql_host=None, mysql_password=None, mysql_port=None, mysql_user=None, user=someuser, hostname=localhost": {
+                "*.*": ["set:", "ALL", "GRANT OPTION"]
+            }
+        }
+    },
+    "commands": [
+        "mysql -Be 'REVOKE GRANT OPTION ON *.* FROM \"someuser\"@\"localhost\"'",
+        "mysql -Be 'REVOKE ALL PRIVILEGES ON *.* FROM \"someuser\"@\"localhost\"'",
+        "mysql -Be 'FLUSH PRIVILEGES'"
+    ]
+}

--- a/tests/operations/mysql.privileges/remove_usage.json
+++ b/tests/operations/mysql.privileges/remove_usage.json
@@ -1,0 +1,14 @@
+{
+    "args": ["someuser", []],
+    "facts": {
+        "mysql.MysqlUserGrants": {
+            "mysql_host=None, mysql_password=None, mysql_port=None, mysql_user=None, user=someuser, hostname=localhost": {
+                "*.*": ["set:", "USAGE"]
+            }
+        }
+    },
+    "commands": [
+        "mysql -Be 'REVOKE USAGE ON *.* FROM \"someuser\"@\"localhost\"'",
+        "mysql -Be 'FLUSH PRIVILEGES'"
+    ]
+}


### PR DESCRIPTION
I hope the code change is self-explanatory.

Happy to rewrite the commit history if it's not gonna be a squash merge.

* Fixed the regex that caused the Fact to always return an empty list, whatever the output
* Ignore "USAGE" privilege in the Fact since this is a placeholder that means "no privilege"
* Fix special cases of the "ALL" (aka "ALL PRIVILEGE") case where it conflicts with "GRANT OPTION"