### PR TITLE
Fix mysql load command

### DIFF
--- a/pyinfra/operations/mysql.py
+++ b/pyinfra/operations/mysql.py
@@ -14,7 +14,7 @@ See the example/mysql.py
 """
 
 from pyinfra import host
-from pyinfra.api import MaskString, OperationError, StringCommand, operation
+from pyinfra.api import MaskString, OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.mysql import (
     MysqlDatabases,
     MysqlUserGrants,
@@ -595,7 +595,7 @@ def load(
         )
     """
 
-    yield "{0} < {1}".format(
+    commands_bits = [
         make_mysql_command(
             database=database,
             user=mysql_user,
@@ -603,5 +603,7 @@ def load(
             host=mysql_host,
             port=mysql_port,
         ),
-        src,
-    )
+        "<",
+        QuoteString(src),
+    ]
+    yield StringCommand(*commands_bits)

--- a/tests/operations/mysql.load/load_space.json
+++ b/tests/operations/mysql.load/load_space.json
@@ -1,0 +1,11 @@
+{
+    "args": ["some file"],
+    "kwargs": {
+        "database": "somedb",
+        "mysql_user": "root"
+    },
+    "commands": [
+        "mysql somedb -u\"root\" < 'some file'"
+    ],
+    "idempotent": false
+}


### PR DESCRIPTION
* Test highlighting the problem: Missing quotes around the filename.
* Fix for that problem

The fix also includes the `< '<filename>'` as 2 additional bits in the `StringCommand`. This is not just for aesthetics, it actually fixed a problem I was having but couldn't get to the bottom of it as the command I see in the operation (`--debug-operation`) works if I exactly copy-paste it in a terminal.

I suspect it was that both bits in `< '<filename>'` used to be passed to the shell as a single argument, but without quoting it's impossible to see that.

Maybe `--debug-operations` should print out the bits rather than the formatted command.