### PR TITLE
Enable calling any function directly from the CLI

### DIFF
--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -92,10 +92,7 @@ def add_op(state: "State", op_func, *args, **kwargs):
         args/kwargs: passed to the operation function
     """
 
-    allow_cli_mode = kwargs.pop("_allow_cli_mode", False)
-    after_host_callback = kwargs.pop("_after_host_callback", lambda host: None)
-
-    if pyinfra.is_cli and not allow_cli_mode:
+    if pyinfra.is_cli:
         raise PyinfraError(
             ("`add_op` should not be called when pyinfra is executing in CLI mode! ({0})").format(
                 get_call_location(),
@@ -111,7 +108,6 @@ def add_op(state: "State", op_func, *args, **kwargs):
         for op_host in hosts:
             with ctx_host.use(op_host):
                 results[op_host] = op_func(*args, **kwargs)
-            after_host_callback(op_host)
 
     return results
 

--- a/tests/test_cli/test_cli_util.py
+++ b/tests/test_cli/test_cli_util.py
@@ -8,12 +8,12 @@ import pytest
 
 from pyinfra.operations import server
 from pyinfra_cli.exceptions import CliError
-from pyinfra_cli.util import get_operation_and_args, json_encode
+from pyinfra_cli.util import get_func_and_args, json_encode
 
 
 class TestCliUtil(TestCase):
     def test_json_encode_function(self):
-        assert json_encode(get_operation_and_args) == "Function: get_operation_and_args"
+        assert json_encode(get_func_and_args) == "Function: get_func_and_args"
 
     def test_json_encode_datetime(self):
         now = datetime.utcnow()
@@ -28,19 +28,19 @@ class TestCliUtil(TestCase):
 
     def test_setup_no_module(self):
         with self.assertRaises(CliError) as context:
-            get_operation_and_args(("no.op",))
+            get_func_and_args(("no.op",))
         assert context.exception.message == "No such module: no"
 
     def test_setup_no_op(self):
         with self.assertRaises(CliError) as context:
-            get_operation_and_args(("server.no",))
+            get_func_and_args(("server.no",))
 
         assert context.exception.message == "No such operation: server.no"
 
     def test_setup_op_and_args(self):
-        commands = ("server.user", "one", "two", "hello=world")
+        commands = ("pyinfra.operations.server.user", "one", "two", "hello=world")
 
-        assert get_operation_and_args(commands) == (
+        assert get_func_and_args(commands) == (
             server.user,
             (["one", "two"], {"hello": "world"}),
         )
@@ -48,7 +48,7 @@ class TestCliUtil(TestCase):
     def test_setup_op_and_json_args(self):
         commands = ("server.user", '[["one", "two"], {"hello": "world"}]')
 
-        assert get_operation_and_args(commands) == (
+        assert get_func_and_args(commands) == (
             server.user,
             (["one", "two"], {"hello": "world"}),
         )
@@ -72,12 +72,12 @@ def user_sys_path():
 # def test_no_user_op():
 #     commands = ('test_ops.dummy_op', 'arg1', 'arg2')
 #     with pytest.raises(CliError, match='^No such module: test_ops$'):
-#         get_operation_and_args(commands)
+#         get_func_and_args(commands)
 
 
 def test_user_op(user_sys_path):
     commands = ("test_ops.dummy_op", "arg1", "arg2")
-    res = get_operation_and_args(commands)
+    res = get_func_and_args(commands)
 
     import test_ops
 


### PR DESCRIPTION
This removes the limitation on calling `<module>.<function>` with the CLI and enables loading up any module/function, whether they are a wrapped operation, deploy or just plain Python function.

Additionally this properly parallelises the generation of commands on target hosts, previously for direct op calls this would be done in serial unlike deploy files.

Also noting here that long term this may be a cleaner approach to using pyinfra in general - always wrapping deploy code underneath a function and calling it as a module rather than pointing at a .py file.