### PR TITLE
Do not reuse temporary file in server.script()

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -172,7 +172,7 @@ def script(src):
         )
     """
 
-    temp_file = state.get_temp_filename(src)
+    temp_file = state.get_temp_filename()
     yield from files.put(src, temp_file)
 
     yield chmod(temp_file, "+x")


### PR DESCRIPTION
Even if `src` is the same, other parameters
such as `_su_user` may be different. In this
case pyinfra unconditionally tries to run `chmod +x`
on the file and fails, because the file is
already uploaded as a different user.