### PR TITLE
Fix `files.Md5File` fact for BSD-style output

### DIFF
--- a/pyinfra/facts/files.py
+++ b/pyinfra/facts/files.py
@@ -272,7 +272,7 @@ class Md5File(FactBase):
 
     _regexes = [
         r"^([a-zA-Z0-9]{32})\s+%s$",
-        r"^SHA256\s+\(%s\)\s+=\s+([a-zA-Z0-9]{32})$",
+        r"^MD5\s+\(%s\)\s+=\s+([a-zA-Z0-9]{32})$",
     ]
 
     def command(self, path):

--- a/tests/facts/files.Md5File/file_bsd_style.json
+++ b/tests/facts/files.Md5File/file_bsd_style.json
@@ -1,0 +1,8 @@
+{
+    "arg": "myfile",
+    "command": "test -e myfile && ( md5sum myfile 2> /dev/null || md5 myfile ) || true",
+    "output": [
+        "MD5 (myfile) = c10ba97d7c9078a006d26b5db01d8ee7"
+    ],
+    "fact": "c10ba97d7c9078a006d26b5db01d8ee7"
+}


### PR DESCRIPTION
First noticed that `files.Md5File` had a copy/paste error in its BSD-style output regex while browsing the code.

Then confirmed `Md5File` was indeed missing the test case even though `Sha1File` and `Sha256File` covered it.

This PR adds the test case, and then fixes the bug.