### PR TITLE
Refactor `files.HashFile` facts

### DIFF
--- a/pyinfra/api/facts.py
+++ b/pyinfra/api/facts.py
@@ -45,7 +45,8 @@ SU_REGEXES = (
 
 
 class FactNameMeta(type):
-    def __init__(cls, name: str, bases, attrs):
+    def __init__(cls, name: str, bases, attrs, **kwargs):
+        super().__init__(name, bases, attrs, **kwargs)
         module_name = cls.__module__.replace("pyinfra.facts.", "")
         cls.name = f"{module_name}.{cls.__name__}"
 

--- a/tests/facts/files.Md5File/file.json
+++ b/tests/facts/files.Md5File/file.json
@@ -1,6 +1,6 @@
 {
     "arg": "myfile",
-    "command": "test -e myfile && ( md5sum myfile 2> /dev/null || md5 myfile ) || true",
+    "command": "test -e myfile && ( md5sum myfile 2> /dev/null || md5 myfile 2> /dev/null ) || true",
     "output": [
         "c10ba97d7c9078a006d26b5db01d8ee7 myfile"
     ],

--- a/tests/facts/files.Md5File/file_bsd_style.json
+++ b/tests/facts/files.Md5File/file_bsd_style.json
@@ -1,6 +1,6 @@
 {
     "arg": "myfile",
-    "command": "test -e myfile && ( md5sum myfile 2> /dev/null || md5 myfile ) || true",
+    "command": "test -e myfile && ( md5sum myfile 2> /dev/null || md5 myfile 2> /dev/null ) || true",
     "output": [
         "MD5 (myfile) = c10ba97d7c9078a006d26b5db01d8ee7"
     ],

--- a/tests/facts/files.Md5File/file_needs_quotes.json
+++ b/tests/facts/files.Md5File/file_needs_quotes.json
@@ -1,6 +1,6 @@
 {
     "arg": "my () file && special_chars.txt",
-    "command": "test -e 'my () file && special_chars.txt' && ( md5sum 'my () file && special_chars.txt' 2> /dev/null || md5 'my () file && special_chars.txt' ) || true",
+    "command": "test -e 'my () file && special_chars.txt' && ( md5sum 'my () file && special_chars.txt' 2> /dev/null || md5 'my () file && special_chars.txt' 2> /dev/null ) || true",
     "output": [
         "c10ba97d7c9078a006d26b5db01d8ee7 my () file && special_chars.txt"
     ],

--- a/tests/facts/files.Sha1File/file.json
+++ b/tests/facts/files.Sha1File/file.json
@@ -1,6 +1,6 @@
 {
     "arg": "myfile",
-    "command": "test -e myfile && ( sha1sum myfile 2> /dev/null || shasum myfile 2> /dev/null || sha1 myfile ) || true",
+    "command": "test -e myfile && ( sha1sum myfile 2> /dev/null || shasum myfile 2> /dev/null || sha1 myfile 2> /dev/null ) || true",
     "output": [
         "85746ef87ddabd9fdf4836c5835e34a030d2a141 myfile"
     ],

--- a/tests/facts/files.Sha1File/file_bsd_style.json
+++ b/tests/facts/files.Sha1File/file_bsd_style.json
@@ -1,6 +1,6 @@
 {
     "arg": "myfile",
-    "command": "test -e myfile && ( sha1sum myfile 2> /dev/null || shasum myfile 2> /dev/null || sha1 myfile ) || true",
+    "command": "test -e myfile && ( sha1sum myfile 2> /dev/null || shasum myfile 2> /dev/null || sha1 myfile 2> /dev/null ) || true",
     "output": [
         "SHA1 (myfile) = 85746ef87ddabd9fdf4836c5835e34a030d2a141"
     ],

--- a/tests/facts/files.Sha1File/file_needs_quotes.json
+++ b/tests/facts/files.Sha1File/file_needs_quotes.json
@@ -1,6 +1,6 @@
 {
     "arg": "my () file && special_chars.txt",
-    "command": "test -e 'my () file && special_chars.txt' && ( sha1sum 'my () file && special_chars.txt' 2> /dev/null || shasum 'my () file && special_chars.txt' 2> /dev/null || sha1 'my () file && special_chars.txt' ) || true",
+    "command": "test -e 'my () file && special_chars.txt' && ( sha1sum 'my () file && special_chars.txt' 2> /dev/null || shasum 'my () file && special_chars.txt' 2> /dev/null || sha1 'my () file && special_chars.txt' 2> /dev/null ) || true",
     "output": [
         "85746ef87ddabd9fdf4836c5835e34a030d2a141 my () file && special_chars.txt"
     ],

--- a/tests/facts/files.Sha256File/file.json
+++ b/tests/facts/files.Sha256File/file.json
@@ -1,6 +1,6 @@
 {
     "arg": "myfile",
-    "command": "test -e myfile && ( sha256sum myfile 2> /dev/null || shasum -a 256 myfile 2> /dev/null || sha256 myfile ) || true",
+    "command": "test -e myfile && ( sha256sum myfile 2> /dev/null || shasum -a 256 myfile 2> /dev/null || sha256 myfile 2> /dev/null ) || true",
     "output": [
         "3867882e8ccc16bd6a1e3e214a46608f9cf5d21687bbb8c25751da3c47b48033 myfile"
     ],

--- a/tests/facts/files.Sha256File/file_bsd_style.json
+++ b/tests/facts/files.Sha256File/file_bsd_style.json
@@ -1,6 +1,6 @@
 {
     "arg": "myfile",
-    "command": "test -e myfile && ( sha256sum myfile 2> /dev/null || shasum -a 256 myfile 2> /dev/null || sha256 myfile ) || true",
+    "command": "test -e myfile && ( sha256sum myfile 2> /dev/null || shasum -a 256 myfile 2> /dev/null || sha256 myfile 2> /dev/null ) || true",
     "output": [
         "SHA256 (myfile) = 3867882e8ccc16bd6a1e3e214a46608f9cf5d21687bbb8c25751da3c47b48033"
     ],

--- a/tests/facts/files.Sha256File/file_needs_quotes.json
+++ b/tests/facts/files.Sha256File/file_needs_quotes.json
@@ -1,6 +1,6 @@
 {
     "arg": "my () file && special_chars.txt",
-    "command": "test -e 'my () file && special_chars.txt' && ( sha256sum 'my () file && special_chars.txt' 2> /dev/null || shasum -a 256 'my () file && special_chars.txt' 2> /dev/null || sha256 'my () file && special_chars.txt' ) || true",
+    "command": "test -e 'my () file && special_chars.txt' && ( sha256sum 'my () file && special_chars.txt' 2> /dev/null || shasum -a 256 'my () file && special_chars.txt' 2> /dev/null || sha256 'my () file && special_chars.txt' 2> /dev/null ) || true",
     "output": [
         "3867882e8ccc16bd6a1e3e214a46608f9cf5d21687bbb8c25751da3c47b48033 my () file && special_chars.txt"
     ],

--- a/tests/words.txt
+++ b/tests/words.txt
@@ -74,11 +74,13 @@ chocolately
 chown
 chroot
 cim
+cmds
 commitish
 comparator
 compat
 computersystem
 configparser
+coreutils
 cp
 cpus
 createdb


### PR DESCRIPTION
This just refactors `Sha1File`, `Sha256File`, and `Md5File` to derive from a common `HashFileFactBase` to remove the previous duplicated code.

`HashFileFactBase` uses `__init_subclass__()` so that the class variables are only initialised once for each class (rather than for every instance), but this did require tweaking `FactNameMeta` to ignore extra `kwarg` parameters. Python docs are pretty bad about those function signatures.

It also extracts the hash name from the subclass name (stripping the `File` suffix) as a bit of sneaky magic, but the tests will catch any breakage if the subclassses are renamed later.

Two slight changes to the behaviour that should not pose a problem:
- the regexes are tightened to match just hex digits rather than alphanumeric
- the `sha1`, `sha256`, and `md5` commands now also silence `stderr` with `2> /dev/null` the same as the other commands

Did this separately to the previous `Md5File` fix in case you didn't like this one. ;)