### PR TITLE
Fix docs-related typos

### DIFF
--- a/docs/api/facts.rst
+++ b/docs/api/facts.rst
@@ -52,7 +52,7 @@ This fact could then be used like so:
 Example: getting the list of files in a directory
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This fact returns a list of files found in a given directory. For this fact the ``command`` is delcated as a class method, indicating the fact takes arguments.
+This fact returns a list of files found in a given directory. For this fact the ``command`` is declared as a class method, indicating the fact takes arguments.
 
 .. code:: python
 
@@ -80,7 +80,7 @@ This fact could then be used like so:
 Example: getting any output from a command
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This fact returns the raw output of any command. For this fact the ``command`` is delcated as a class method, indicating the fact takes arguments.
+This fact returns the raw output of any command. For this fact the ``command`` is declared as a class method, indicating the fact takes arguments.
 
 .. code:: python
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,7 +73,7 @@ It is possible to limit the inventory at execution time using the `--limit` argu
 # Only execute against @local
 pyinfra inventory.py deploy.py --limit @local
 
-# Only execute against hosts in the `app_servers` grouo
+# Only execute against hosts in the `app_servers` group
 pyinfra inventory.py deploy.py --limit app_servers
 
 # Only execute against hosts with names matching db*

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,7 +38,7 @@ GitHub will run all the test suites as part of any pull requests, here's how you
 
 Use `pytest` to run the unit tests, or `pytest --cov` to run with coverage. Pull requests are expected to be tested and not drop overall project coverage by >1%.
 
-### End to End Testst
+### End to End Tests
 
 The end to end tests are also executed via `pytest` but not selected by default, options/usage:
 

--- a/docs/inventory-data.rst
+++ b/docs/inventory-data.rst
@@ -42,7 +42,7 @@ It is possible to limit the inventory at execution time using the ``--limit`` ar
     # Only execute against @local
     pyinfra inventory.py deploy.py --limit @local
 
-    # Only execute against hosts in the `app_servers` grouo
+    # Only execute against hosts in the `app_servers` group
     pyinfra inventory.py deploy.py --limit app_servers
 
     # Only execute against hosts with names matching db*

--- a/examples/choco.py
+++ b/examples/choco.py
@@ -8,7 +8,7 @@ if computer_info:
     if product_name:
         if product_name.split()[0] == "Windows":
 
-            # install Chocolately
+            # install Chocolatey
             choco.install()
 
             choco.packages(

--- a/pyinfra/api/arguments.py
+++ b/pyinfra/api/arguments.py
@@ -269,7 +269,7 @@ def pop_global_arguments(
     This is a bit strange because internally pyinfra uses non-_-prefixed arguments,
     and this function is responsible for the translation between the two.
 
-    TODO: is this wird-ness acceptable? Is it worth updating internal use to _prefix?
+    TODO: is this weird-ness acceptable? Is it worth updating internal use to _prefix?
     """
 
     state = state or context.state

--- a/pyinfra/local.py
+++ b/pyinfra/local.py
@@ -55,7 +55,7 @@ def shell(
 
     Args:
         commands (string, list): command or list of commands to execute
-        spltlines (bool): optionally have the output split by lines
+        splitlines (bool): optionally have the output split by lines
         ignore_errors (bool): ignore errors when executing these commands
     """
 

--- a/pyinfra/operations/python.py
+++ b/pyinfra/operations/python.py
@@ -69,7 +69,7 @@ def raise_exception(exception, *args, **kwargs):
     .. code:: python
 
         python.raise_exception(
-            name="Raise NotImplementedError exceptipn",
+            name="Raise NotImplementedError exception",
             exception=NotImplementedError,
             message="This is not implemented",
         )

--- a/pyinfra/operations/windows_files.py
+++ b/pyinfra/operations/windows_files.py
@@ -48,7 +48,7 @@ def download(
 
     .. code:: python
 
-        winows_files.download(
+        windows_files.download(
             name="Download the Docker repo file",
             src="https://download.docker.com/linux/centos/docker-ce.repo",
             dest="C:\\docker",

--- a/scripts/cleanup_words.py
+++ b/scripts/cleanup_words.py
@@ -12,7 +12,7 @@ def cleanup_words():
 
     lines = sorted(set(lines))
 
-    lines.insert(0, "# it is automatically cleaned/sorted by scripts/cleaup_words.py")
+    lines.insert(0, "# it is automatically cleaned/sorted by scripts/cleanup_words.py")
     lines.insert(0, "# This is a list of additional words for flake8-spellcheck")
 
     with open(path.join("tests", "words.txt"), "w", encoding="utf-8") as f:

--- a/tests/words.txt
+++ b/tests/words.txt
@@ -1,5 +1,5 @@
 # This is a list of additional words for flake8-spellcheck
-# it is automatically cleaned/sorted by scripts/cleaup_words.py
+# it is automatically cleaned/sorted by scripts/cleanup_words.py
 0
 1
 2
@@ -70,7 +70,6 @@ cfg
 changelog
 chdir
 choco
-chocolately
 chown
 chroot
 cim
@@ -368,7 +367,6 @@ uefi
 ufw
 uname
 unignored
-unitialised
 unmount
 up
 up2


### PR DESCRIPTION
I admit I did have a fire-extinguisher-on-fire-meme chuckle on seeing `cleanup_words.py` misspell its own name, as well as other typos that made it into `words.txt`, and so I felt obliged to fix some more.

(These changes are only docs-related, ie. they do not change any lib/api/cli behaviour.)