### PR TITLE
Add `ensure_newline` keyword argument to `files.line`

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -899,7 +899,7 @@ def user_authorized_keys(
 
         # And every public key is present
         for key in public_keys:
-            yield from files.line(path=authorized_key_file, line=key)
+            yield from files.line(path=authorized_key_file, line=key, ensure_newline=True)
 
 
 @operation

--- a/tests/end-to-end/test_e2e_local.py
+++ b/tests/end-to-end/test_e2e_local.py
@@ -136,3 +136,47 @@ def test_int_local_failed_postcondition(helpers):
         expected_lines=["@local] Error: postcondition failed: exit 1"],
         expected_exit_code=1,
     )
+
+
+@pytest.mark.end_to_end
+@pytest.mark.end_to_end_local
+def test_int_local_line_ensure_newline_true(helpers, tmp_path):
+    path = tmp_path / "_testfile"
+
+    path.write_bytes(b"hello world")
+    helpers.run_check_output(
+        "pyinfra -v @local files.line _testfile someline ensure_newline=true",
+        expected_lines=["@local] Success"],
+        cwd=tmp_path,
+    )
+    assert path.read_bytes() == b"hello world\nsomeline\n"
+
+    path.write_bytes(b"hello world\n")
+    helpers.run_check_output(
+        "pyinfra -v @local files.line _testfile someline ensure_newline=true",
+        expected_lines=["@local] Success"],
+        cwd=tmp_path,
+    )
+    assert path.read_bytes() == b"hello world\nsomeline\n"
+
+
+@pytest.mark.end_to_end
+@pytest.mark.end_to_end_local
+def test_int_local_line_ensure_newline_false(helpers, tmp_path):
+    path = tmp_path / "_testfile"
+
+    path.write_bytes(b"hello world")
+    helpers.run_check_output(
+        "pyinfra -v @local files.line _testfile someline ensure_newline=false",
+        expected_lines=["@local] Success"],
+        cwd=tmp_path,
+    )
+    assert path.read_bytes() == b"hello worldsomeline\n"
+
+    path.write_bytes(b"hello world\n")
+    helpers.run_check_output(
+        "pyinfra -v @local files.line _testfile someline ensure_newline=false",
+        expected_lines=["@local] Success"],
+        cwd=tmp_path,
+    )
+    assert path.read_bytes() == b"hello world\nsomeline\n"

--- a/tests/operations/server.user/key_files.json
+++ b/tests/operations/server.user/key_files.json
@@ -46,7 +46,7 @@
     },
     "commands": [
         "chmod 600 homedir/.ssh/authorized_keys",
-        "echo abc >> homedir/.ssh/authorized_keys",
-        "echo someotherkeydata >> homedir/.ssh/authorized_keys"
+        "( [ $(tail -c1 homedir/.ssh/authorized_keys | wc -l) -eq 0 ] && echo ; echo abc ) >> homedir/.ssh/authorized_keys",
+        "( [ $(tail -c1 homedir/.ssh/authorized_keys | wc -l) -eq 0 ] && echo ; echo someotherkeydata ) >> homedir/.ssh/authorized_keys"
     ]
 }

--- a/tests/operations/server.user/keys.json
+++ b/tests/operations/server.user/keys.json
@@ -37,6 +37,6 @@
     },
     "commands": [
         "chmod 600 homedir/.ssh/authorized_keys",
-        "echo abc >> homedir/.ssh/authorized_keys"
+        "( [ $(tail -c1 homedir/.ssh/authorized_keys | wc -l) -eq 0 ] && echo ; echo abc ) >> homedir/.ssh/authorized_keys"
     ]
 }

--- a/tests/operations/server.user/keys_nohome.json
+++ b/tests/operations/server.user/keys_nohome.json
@@ -36,6 +36,6 @@
     },
     "commands": [
         "chmod 600 /root/.ssh/authorized_keys",
-        "echo abc >> /root/.ssh/authorized_keys"
+        "( [ $(tail -c1 /root/.ssh/authorized_keys | wc -l) -eq 0 ] && echo ; echo abc ) >> /root/.ssh/authorized_keys"
     ]
 }

--- a/tests/operations/server.user/keys_single.json
+++ b/tests/operations/server.user/keys_single.json
@@ -37,6 +37,6 @@
     },
     "commands": [
         "chmod 600 homedir/.ssh/authorized_keys",
-        "echo abc >> homedir/.ssh/authorized_keys"
+        "( [ $(tail -c1 homedir/.ssh/authorized_keys | wc -l) -eq 0 ] && echo ; echo abc ) >> homedir/.ssh/authorized_keys"
     ]
 }


### PR DESCRIPTION
Fixes #823

 * When `ensure_newline=True` it will ensure that the appended line is always on a separate line.
 * `server.user_authorized_keys()` now uses `files.line(..., ensure_newline=True)`