### PR TITLE
Appimage builder

### DIFF
--- a/appimage.sh
+++ b/appimage.sh
@@ -1,0 +1,5 @@
+:#!/bin/bash
+pip install python-appimage
+python-appimage install appimagetool &&
+python-appimage install patchelf &&
+python-appimage build app -p 3.11 ./appimage

--- a/appimage.sh
+++ b/appimage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pip install python-appimage
+pipx install python-appimage
 python-appimage install appimagetool &&
 python-appimage install patchelf &&
 python-appimage build app -p 3.11 ./appimage

--- a/appimage.sh
+++ b/appimage.sh
@@ -1,4 +1,4 @@
-:#!/bin/bash
+#!/bin/bash
 pip install python-appimage
 python-appimage install appimagetool &&
 python-appimage install patchelf &&

--- a/appimage/entrypoint.sh
+++ b/appimage/entrypoint.sh
@@ -1,0 +1,2 @@
+#! /bin/bash -i
+{{ python-executable }} -u "${APPDIR}/opt/python{{ python-version }}/bin/pyinfra" "$@"

--- a/appimage/pyinfra.appdata.xml
+++ b/appimage/pyinfra.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
     <id>pyinfra</id>
     <metadata_license>MIT</metadata_license>
-    <project_license>BSD</project_license>
+    <project_license>MIT</project_license>
     <name>Pyinfra</name>
     <summary>Pyinfra on Python {{ python-fullversion }}</summary>
     <description>

--- a/appimage/pyinfra.appdata.xml
+++ b/appimage/pyinfra.appdata.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>pyinfra</id>
+    <metadata_license>MIT</metadata_license>
+    <project_license>BSD</project_license>
+    <name>Pyinfra</name>
+    <summary>Pyinfra on Python {{ python-fullversion }}</summary>
+    <description>
+        <p>  Python {{ python-fullversion }} + Pyinfra bundled in an AppImage.
+        </p>
+    </description>
+    <launchable type="desktop-id">pyinfra.desktop</launchable>
+    <url type="homepage">https://pyinfra.com</url>
+    <provides>
+        <binary>python{{ python-version }}</binary>
+    </provides>
+</component>

--- a/appimage/pyinfra.desktop
+++ b/appimage/pyinfra.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Name=pyinfra
+Exec=pyinfra
+Comment=pyinfraon Python {{ python-fullversion }}
+Icon=python
+Categories=System;
+Terminal=true

--- a/appimage/requirements.txt
+++ b/appimage/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/Fizzadar/pyinfra


### PR DESCRIPTION
- added appimage building support , it directly pulls from 2.x branch and then compiles into appimage binary.
- added a build-time dependency for python-appimage 
- run `appimage.sh` to build pyinfra as `AppImage` 