### PR TITLE
Add Ubuntu latest (22.04) to CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,16 @@ jobs:
       - type-check
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-latest]
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
         include:
           - os: macos-12
             python-version: "3.11"
           - os: windows-2022
             python-version: "3.11"
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.6"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -67,7 +70,7 @@ jobs:
       - unit-test
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-latest]
         test-name: [local, ssh, docker]
         include:
           - os: macos-latest


### PR DESCRIPTION
Built on top of https://github.com/Fizzadar/pyinfra/pull/966 for tests to pass