### PR TITLE
Git config add

### DIFF
--- a/pyinfra/facts/git.py
+++ b/pyinfra/facts/git.py
@@ -33,7 +33,7 @@ class GitConfig(FactBase):
 
         for line in output:
             key, value = line.split("=", 1)
-            items[key] = value
+            items.setdefault(key, []).append(value)
 
         return items
 

--- a/tests/facts/git.GitConfig/global.json
+++ b/tests/facts/git.GitConfig/global.json
@@ -5,6 +5,6 @@
         "user.email=nick@gmail.com"
     ],
     "fact": {
-        "user.email": "nick@gmail.com"
+        "user.email": ["nick@gmail.com"]
     }
 }

--- a/tests/facts/git.GitConfig/multi_value.json
+++ b/tests/facts/git.GitConfig/multi_value.json
@@ -1,0 +1,14 @@
+{
+    "command": "git config --global -l || true",
+    "requires_command": "git",
+    "output": [
+        "safe.directory=/a/safe/repo",
+        "safe.directory=/another/safe/repo"
+    ],
+    "fact": {
+        "safe.directory": [
+            "/a/safe/repo",
+            "/another/safe/repo"
+        ]
+    }
+}

--- a/tests/facts/git.GitConfig/repo.json
+++ b/tests/facts/git.GitConfig/repo.json
@@ -6,6 +6,6 @@
         "user.email=nick@gmail.com"
     ],
     "fact": {
-        "user.email": "nick@gmail.com"
+        "user.email": ["nick@gmail.com"]
     }
 }

--- a/tests/operations/git.config/add_existing_multi_value.json
+++ b/tests/operations/git.config/add_existing_multi_value.json
@@ -1,10 +1,12 @@
 {
     "args": ["key", "value"],
+    "kwargs": {
+        "multi_value": true
+    },
     "facts": {
         "git.GitConfig": {
             "key": ["value"]
         }
     },
-    "commands": [],
-    "noop_description": "git config key is set to value"
+    "commands": []
 }

--- a/tests/operations/git.config/add_first_multi_value.json
+++ b/tests/operations/git.config/add_first_multi_value.json
@@ -1,0 +1,12 @@
+{
+    "args": ["key", "value"],
+    "kwargs": {
+        "multi_value": true
+    },
+    "facts": {
+        "git.GitConfig": {}
+    },
+    "commands": [
+        "git config --global --add key \"value\""
+    ]
+}

--- a/tests/operations/git.config/add_second_multi_value.json
+++ b/tests/operations/git.config/add_second_multi_value.json
@@ -1,0 +1,14 @@
+{
+    "args": ["key", "another_value"],
+    "kwargs": {
+        "multi_value": true
+    },
+    "facts": {
+        "git.GitConfig": {
+            "key": ["value"]
+        }
+    },
+    "commands": [
+        "git config --global --add key \"another_value\""
+    ]
+}

--- a/tests/operations/git.config/edit_global.json
+++ b/tests/operations/git.config/edit_global.json
@@ -2,7 +2,7 @@
     "args": ["key", "value"],
     "facts": {
         "git.GitConfig": {
-            "key": "wrongvalue"
+            "key": ["wrongvalue"]
         }
     },
     "commands": [

--- a/tests/operations/git.config/set_repo.json
+++ b/tests/operations/git.config/set_repo.json
@@ -6,7 +6,7 @@
     "facts": {
         "git.GitConfig": {
             "repo=/my/repo": {
-                "another_key": "value"
+                "another_key": ["value"]
             }
         },
         "files.Directory": {


### PR DESCRIPTION
Built on top of https://github.com/Fizzadar/pyinfra/pull/966 for CI tests

Allow to add git config key/value pairs for options that support multiple lines such as `safe.directory`.

NOTE: This changes slightly the API of the `git.GitConfig` Fact, since it now always returns a list of values for each key present. I think this is more in line with the possible structure of the configuration file though.

The [git config file documentation](https://git-scm.com/docs/git-config#_configuration_file), shows that there's an undefined number of possible options, with no real way to know (programmatically) whether an option allows multiple values. So the design here (let the `pyinfra` user specify it's a multi_value option) stands.