### PR TITLE
Ssh 2 fa support

### DIFF
--- a/pyinfra/connectors/sshuserclient/client.py
+++ b/pyinfra/connectors/sshuserclient/client.py
@@ -239,7 +239,9 @@ class SSHClient(ParamikoClient):
 
             for i, hop in enumerate(hops):
                 hop_hostname, hop_config = self.derive_shorthand(ssh_config, hop)
-                logger.debug("SSH ProxyJump through %s:%s", hop_hostname, hop_config["port"])
+                if "pkey" in initial_cfg:
+                    hop_config["pkey"] = initial_cfg["pkey"]
+                logger.debug("SSH ProxyJump through %s:%s", hop_hostname, hop_config)
 
                 c = SSHClient()
                 c.connect(

--- a/pyinfra/connectors/sshuserclient/client.py
+++ b/pyinfra/connectors/sshuserclient/client.py
@@ -12,7 +12,9 @@ from paramiko import (
     ProxyCommand,
     SSHClient as ParamikoClient,
     SSHException,
+    Transport,
 )
+from paramiko.ssh_exception import BadAuthenticationType
 from paramiko.agent import AgentRequestHandler
 
 from pyinfra import logger
@@ -160,7 +162,15 @@ class SSHClient(ParamikoClient):
             config.update(_pyinfra_ssh_paramiko_connect_kwargs)
 
         self._ssh_config = config
-        super().connect(hostname, **config)
+        try:
+            super().connect(hostname, **config)
+        except BadAuthenticationType:
+            super()
+            transport = Transport(hostname)
+            transport.start_client()
+            transport.auth_interactive_dumb(config["username"])
+            transport.auth_publickey(username=config["username"], key=config["pkey"])
+            self._transport = transport
 
         if _pyinfra_ssh_forward_agent is not None:
             forward_agent = _pyinfra_ssh_forward_agent


### PR DESCRIPTION
The server i'm working with has a bastion that need a yubikey old "One Time Password" with a ssh interactive session. It does not work out of box with pyinfra, so I propose this pull requests.

It's a fallback on connect, when there is a BadAuthenticationType, in my case when the authenfication is interactive. In this case, the solution I found is working with Transport, doing first an "auth_interactive_dumb", that just link the session and stdin stdout, and then a auth_publikey.  I've tested it and it work perfectly in my case, without breaking anything. I'm not sure though how generic is my use case.

Thanks again for you good work on pyinfra, that's amazing stuff.