### PR TITLE
Install requirement failed as codecov package is no longer available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: pip install '.[test]'
       - run: pytest --cov --disable-warnings
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3
 
   # End-to-end tests
   #

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ TEST_REQUIRES = ANSIBLE_REQUIRES + (
     'pytest==7.2.0 ; python_version > "3.6"',
     'coverage==6.5 ; python_version > "3.6"',
     "pytest-cov==4.0.0",
-    "codecov==2.1.12",
     # Formatting & linting
     "black==22.3.0",
     "isort==5.10.1",


### PR DESCRIPTION
On April 12, 2023, codecov package was removed on Pypi repository. I have forked the project to add a new operation but I got an error during `pip install -e '.[dev]'`. This pull request remove the package from dependecies and update the workflow to use codecov v3 as v1 was deprecated.