### PR TITLE
Fix handling of short facts whose fact has args or kwargs

### DIFF
--- a/pyinfra/api/facts.py
+++ b/pyinfra/api/facts.py
@@ -343,7 +343,10 @@ def get_host_fact(
     args: Optional[List] = None,
     kwargs: Optional[Dict] = None,
 ):
-    fact_hash = _get_fact_hash(state, host, cls, args, kwargs)
+    if issubclass(cls, ShortFactBase):
+        fact_hash = None
+    else:
+        fact_hash = _get_fact_hash(state, host, cls, args, kwargs)
     return get_fact(state, host, cls, args=args, kwargs=kwargs, fact_hash=fact_hash)
 
 


### PR DESCRIPTION
Fix an AttributeError that occurs with ShortFactBase subclasses whose fact class has args or kwargs:

    File "pyinfra_cli/util.py", line 60, in exec_file
      exec(PYTHON_CODES[filename], data)
    [...]
    File "pyinfra/api/host.py", line 255, in get_fact
      return get_host_fact(self.state, self, name_or_cls, args=args, kwargs=kwargs)
    File "pyinfra/api/facts.py", line 346, in get_host_fact
      fact_hash = _get_fact_hash(state, host, cls, args, kwargs)
    File "pyinfra/api/facts.py", line 335, in _get_fact_hash
      fact_kwargs, executor_kwargs = _handle_fact_kwargs(state, host, cls, args, kwargs)
    File "pyinfra/api/facts.py", line 148, in _handle_fact_kwargs
      assert not isinstance(cls.command, str)
    AttributeError: type object 'MyShortFact' has no attribute 'command'

This is apparently due to the refactoring that occurred in 0a27fff181 (Fix handling of facts with no args and global args, 2022-11-09).

I don't know the purpose of the fact hash, so this may be papering over the problem instead of a correct solution.