### PR TITLE
Fix misspelling in docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,7 +46,7 @@ By default `pyinfra` only prints high level information (this host connected, th
 
 ## Inventory
 
-When using ``pyinfra`` inventory can be provided direct via the command line or [defined in a file](./deploys.html#inventory). Both support the full range of [connectors](./connectors) and multiple hosts. Some CLI examples:
+When using ``pyinfra`` inventory can be provided directly via the command line or [defined in a file](./deploys.html#inventory). Both support the full range of [connectors](./connectors) and multiple hosts. Some CLI examples:
 
 ```sh
 # Load inventory hosts from a file


### PR DESCRIPTION
Minor change: "direct" to "directly"