### PR TITLE
Prevent Paramiko size mismatch errors in utf-8 strings

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -885,7 +885,7 @@ def put(
 
         files.put(
             name="Upload a BytesIO object",
-            src=BytesIO("file contents"),
+            src=BytesIO("file contents".encode("utf-8")),
             dest="/etc/motd",
         )
     """
@@ -1052,7 +1052,7 @@ def template(src, dest, user=None, group=None, mode=None, create_remote_dir=True
         {% for entry in foo_list %}
             - "{{ entry }}"
         {% endfor %}
-        """)
+        """.encode("utf-8"))
 
         files.template(
             name="Create a templated file",

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -8,7 +8,7 @@ import sys
 import traceback
 from datetime import timedelta
 from fnmatch import fnmatch
-from io import StringIO
+from io import BytesIO
 
 from jinja2 import TemplateRuntimeError, TemplateSyntaxError, UndefinedError
 
@@ -884,8 +884,8 @@ def put(
         )
 
         files.put(
-            name="Upload a StringIO object",
-            src=StringIO("file contents"),
+            name="Upload a BytesIO object",
+            src=BytesIO("file contents"),
             dest="/etc/motd",
         )
     """
@@ -1043,7 +1043,7 @@ def template(src, dest, user=None, group=None, mode=None, create_remote_dir=True
             "entry 2"
         ]
 
-        template = StringIO("""
+        template = BytesIO("""
         name: "{{ foo_variable }}"
         dict_contents:
             str1: "{{ foo_dict.str1 }}"
@@ -1102,7 +1102,7 @@ def template(src, dest, user=None, group=None, mode=None, create_remote_dir=True
             ),
         )
 
-    output_file = StringIO(output)
+    output_file = BytesIO(output.encode("utf-8"))
     # Set the template attribute for nicer debugging
     output_file.template = src
 


### PR DESCRIPTION
Length of unicode strings consisting of multibyte characters differs from their size in bytes. Hence uploads of files and templates using unicode characters will fail with messages like
```--> Starting operation: tasks/app.py | scheduler crontab 
    Failed to upload file, retrying: size mismatch in put!  208 != 190
    Failed to upload file, retrying: size mismatch in put!  208 != 190
    Failed to upload file, retrying: size mismatch in put!  208 != 190
    [172.33.2.57] Command socket/SSH error: OSError('size mismatch in put!  208 != 190',)
    [172.33.2.57] Error: executed 0/1 commands
```
Using BytesIO will prevent this.