### PR TITLE
Fix issue where we strip a newline when public key is read

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -862,7 +862,7 @@ def user_authorized_keys(
 
         if path.exists(try_path):
             with open(try_path, "r") as f:
-                return f.read()
+                return f.read().strip()
 
         return key
 

--- a/tests/operations/server.user/key_files.json
+++ b/tests/operations/server.user/key_files.json
@@ -7,7 +7,7 @@
     "local_files": {
         "files": {
             "somefile.pub": "somekeydata",
-            "anotherfile.pub": "someotherkeydata"
+            "anotherfile.pub": "someotherkeydata\n"
         },
         "dirs": {}
     },


### PR DESCRIPTION
The public key is read with the newline appended to the string.  This caused the `process` command in FindInFile to return any existing files.

Fixes #999 