### PR TITLE
fix fact lookup for systemd units containing '.'

### DIFF
--- a/pyinfra/operations/systemd.py
+++ b/pyinfra/operations/systemd.py
@@ -85,7 +85,21 @@ def service(
         user_name=user_name,
     )
 
-    if "." not in service:
+    if not service.endswith(
+        (
+            ".service",
+            ".socket",
+            ".device",
+            ".mount",
+            ".automount",
+            ".swap",
+            ".target",
+            ".path",
+            ".timer",
+            ".slice",
+            ".scope",
+        )
+    ):
         service = "{0}.service".format(service)
 
     if daemon_reload:


### PR DESCRIPTION
e.g.:
- unit name is `postgresql@9.5-main.service`
- user calls `server.service(service="postgresql@9.5-main", ...)` Because the unit name contains a dot, the ".service" extension is not added and the fact lookup always returns False, even if the service is in fact enabled.

Fix: explicitly check for unit type endings instead of just a dot.