### PR TITLE
add py.typed marker to pyinfra package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README.md LICENSE.md CHANGELOG.md
+include README.md LICENSE.md CHANGELOG.md pyinfra/py.typed


### PR DESCRIPTION
Without it, when you're using pyinfra as a library, mypy won't actually check type annotations when you use pyinfra.

(see https://peps.python.org/pep-0561/#packaging-type-information)

Testing tested by writing a bit of code that violates type annotations:

```
from pyinfra.api import FactBase

class MyFact(FactBase):
    command = ['echo', 'hello']
```

before the change:

```
test.py:1: error: Skipping analyzing "pyinfra.api": module is installed, but missing library stubs or py.typed marker  [import]
    from pyinfra.api import FactBase
    ^
test.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)
```

after the change:

```
test.py: note: In class "MyFact":
test.py:4: error: Incompatible types in assignment (expression has type "list[str]", base class "FactBase" defined the type as "str | Callable[..., Any]")  [assignment]
        command = ['echo', 'hello']
                  ^~~~~~~~~~~~~~~~~
Found 1 error in 1 file (checked 1 source file)
```