### PR TITLE
Really do not create home when server.user create_home is False

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -1037,6 +1037,8 @@ def user(
 
         if create_home:
             args.append("-m")
+        else:
+            args.append("-M")
 
         # Users are often added by other operations (package installs), so check
         # for the user at runtime before adding.

--- a/tests/operations/server.user/add_group_exists.json
+++ b/tests/operations/server.user/add_group_exists.json
@@ -9,7 +9,7 @@
         "server.Os": "Linux"
     },
     "commands": [
-        "grep '^someuser:' /etc/passwd || useradd -d /home/someuser -g someuser someuser",
+        "grep '^someuser:' /etc/passwd || useradd -d /home/someuser -g someuser -M someuser",
         "mkdir -p /home/someuser",
         "chown someuser:someuser /home/someuser"
     ]

--- a/tests/operations/server.user/add_home_is_link.json
+++ b/tests/operations/server.user/add_home_is_link.json
@@ -14,6 +14,6 @@
         }
     },
     "commands": [
-        "grep '^someuser:' /etc/passwd || useradd -d homedir someuser"
+        "grep '^someuser:' /etc/passwd || useradd -d homedir -M someuser"
     ]
 }

--- a/tests/operations/server.user/add_non_unique.json
+++ b/tests/operations/server.user/add_non_unique.json
@@ -9,6 +9,6 @@
         "server.Groups": {}
     },
     "commands": [
-        "grep '^someuser:' /etc/passwd || useradd -d /home/someuser -o someuser"
+        "grep '^someuser:' /etc/passwd || useradd -d /home/someuser -o -M someuser"
     ]
 }


### PR DESCRIPTION
Home folders may be created by default following a setting in /etc/login.defs.
See https://linux.die.net/man/8/useradd.

Make sure it is not created when create_home is False.