### PR TITLE
Add arguments to `operations.script_template`

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -189,7 +189,7 @@ def script(src, args=()):
 
 
 @operation(is_idempotent=False)
-def script_template(src, **data):
+def script_template(src, args=(), **data):
     """
     Generate, upload and execute a local script template on the remote host.
 
@@ -215,7 +215,7 @@ def script_template(src, **data):
     yield from files.template(src, temp_file, **data)
 
     yield chmod(temp_file, "+x")
-    yield temp_file
+    yield StringCommand(temp_file, *args)
 
 
 @operation


### PR DESCRIPTION
I was going to fix `operations.script` as well, but it seems like someone got to that first (and gave prior art to copy).

fixes #964