### PR TITLE
Update `server.mount` to allow for `fs_type` and `device` options

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -276,10 +276,12 @@ def modprobe(module, present=True, force=False):
 @operation
 def mount(
     path,
+    device=None,
+    fs_type=None,
     mounted=True,
     options=None,
     # TODO: do we want to manage fstab here?
-    # update_fstab=False, device=None, fs_type=None,
+    # update_fstab=False,
 ):
     """
     Manage mounted filesystems.
@@ -296,7 +298,6 @@ def mount(
         This operation does not attempt to modify the on disk fstab file - for
         that you should use the `files.line operation <./files.html#files-line>`_.
     """
-
     options = options or []
     options_string = ",".join(options)
 
@@ -305,10 +306,13 @@ def mount(
 
     # Want mount but don't have?
     if mounted and not is_mounted:
-        yield "mount{0} {1}".format(
-            " -o {0}".format(options_string) if options_string else "",
+        yield "mount {0} {1} {2} {3}".format(
+            "-t {0}".format(fs_type) if fs_type else "",
+            "-o {0}".format(options_string) if options_string else "",
+            device if device else "",
             path,
         )
+        # Should we update facts with fs_type, device, etc? 
         mounts[path] = {"options": options}
 
     # Want no mount but mounted?

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -312,7 +312,7 @@ def mount(
             device if device else "",
             path,
         )
-        # Should we update facts with fs_type, device, etc? 
+        # Should we update facts with fs_type, device, etc?
         mounts[path] = {"options": options}
 
     # Want no mount but mounted?

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -276,10 +276,10 @@ def modprobe(module, present=True, force=False):
 @operation
 def mount(
     path,
-    device=None,
-    fs_type=None,
     mounted=True,
     options=None,
+    device=None,
+    fs_type=None,
     # TODO: do we want to manage fstab here?
     # update_fstab=False,
 ):

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -308,14 +308,14 @@ def mount(
     if mounted and not is_mounted:
         args = []
         if fs_type:
-            args.extend(['-t', fs_type])
+            args.extend(["-t", fs_type])
         if options_string:
-            args.extend(['-o', options_string])
+            args.extend(["-o", options_string])
         if device:
             args.append(device)
         args.append(path)
 
-        yield StringCommand('mount', *args)
+        yield StringCommand("mount", *args)
         # Should we update facts with fs_type, device, etc?
         mounts[path] = {"options": options}
 

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -306,10 +306,10 @@ def mount(
 
     # Want mount but don't have?
     if mounted and not is_mounted:
-        yield "mount {0} {1} {2} {3}".format(
-            "-t {0}".format(fs_type) if fs_type else "",
-            "-o {0}".format(options_string) if options_string else "",
-            device if device else "",
+        yield "mount{0}{1}{2} {3}".format(
+            " -t {0}".format(fs_type) if fs_type else "",
+            " -o {0}".format(options_string) if options_string else "",
+            " {0}".format(device) if device else "",
             path,
         )
         # Should we update facts with fs_type, device, etc?

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -306,12 +306,16 @@ def mount(
 
     # Want mount but don't have?
     if mounted and not is_mounted:
-        yield "mount{0}{1}{2} {3}".format(
-            " -t {0}".format(fs_type) if fs_type else "",
-            " -o {0}".format(options_string) if options_string else "",
-            " {0}".format(device) if device else "",
-            path,
-        )
+        args = []
+        if fs_type:
+            args.extend(['-t', fs_type])
+        if options_string:
+            args.extend(['-o', options_string])
+        if device:
+            args.append(device)
+        args.append(path)
+
+        yield StringCommand('mount', *args)
         # Should we update facts with fs_type, device, etc?
         mounts[path] = {"options": options}
 

--- a/tests/operations/server.mount/mount_device.json
+++ b/tests/operations/server.mount/mount_device.json
@@ -1,0 +1,12 @@
+{
+    "args": ["/data"],
+    "kwargs": {
+        "device": "/dev/sdb1"
+    },
+    "facts": {
+        "server.Mounts": {}
+    },
+    "commands": [
+        "mount /dev/sdb1 /data"
+    ]
+}

--- a/tests/operations/server.mount/mount_device_fstype.json
+++ b/tests/operations/server.mount/mount_device_fstype.json
@@ -1,0 +1,13 @@
+{
+    "args": ["/data"],
+    "kwargs": {
+        "device": "/dev/sdc3",
+        "fs_type": "xfs"
+    },
+    "facts": {
+        "server.Mounts": {}
+    },
+    "commands": [
+        "mount -t xfs /dev/sdc3 /data"
+    ]
+}


### PR DESCRIPTION
This might require a review round before it's good to merge, depending on how "complete" you want to make this. Areas for potential improvement (either now or later - your choice):

1. Updating facts with more 'complete' information (fs type, device, etc)
2. Handling the case where mount is already mounted but fs_type or device is different (the former I'm not sure how that'd work, but I could see someone cloning data to another partition and wanting to swap to the cloned device)

Fixes #963 