### PR TITLE
Remove Unused Dependency: Colorama

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ INSTALL_REQUIRES = (
     "gevent>=1.5",
     "paramiko>=2.7,<3",  # 2.7 (2019) adds OpenSSH key format + Match SSH config
     "click>2",
-    "colorama<1",  # Windows color support for click
     "jinja2>2,<4",
     "python-dateutil>2,<3",
     "setuptools",


### PR DESCRIPTION
## Summary

Hello @Fizzadar,

I hope you're doing well! I've just opened this pull request that proposes the removal of the unused `colorama` dependency from the `setup.py` configuration file. It's part of an ongoing research endeavor focusing on the identification and elimination of code bloat within software projects. Your insights on this would be really valuable.

## Rationale

The `colorama` library was integrated into the project via ea1410a, and was later utilised on 
`pyinfra_cli/__main__.py.` However, its usage was discontinued in a subsequent commit, ca3ca9c, where it was removed in favor of `click` . Despite this change in the codebase, `colorama`  continued to be listed in the project's dependency files. Removing this unused dependency can reduce the overall footprint of the application, mitigate potential security risks, and simplify the dependency management process.

## Changes

- Removed the `colorama`  dependency from the `setup.py` file.

## Impact

- Reduced package size: Eliminating this unused dependency will decrease the overall size of the installed packages.

- Simplified dependency tree: A leaner list of dependencies aids in more straightforward project maintenance and faster installations.

