### PR TITLE
Fix Users and Groups module for FreeBSD

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -424,7 +424,7 @@ class Users(FactBase):
     command = """
         for i in `cat /etc/passwd | cut -d: -f1`; do
             ENTRY=`grep ^$i: /etc/passwd`;
-            LASTLOG=`lastlog -u $i | grep ^$i | tr -s ' '`;
+            LASTLOG=`(lastlog -u $i 2> /dev/null || lastlogin $i 2> /dev/null) | grep ^$i | tr -s ' '`;
             echo "$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG";
         done
     """.strip()

--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -424,7 +424,8 @@ class Users(FactBase):
     command = """
         for i in `cat /etc/passwd | cut -d: -f1`; do
             ENTRY=`grep ^$i: /etc/passwd`;
-            LASTLOG=`(lastlog -u $i 2> /dev/null || lastlogin $i 2> /dev/null) | grep ^$i | tr -s ' '`;
+            LASTLOG_RAW=`(lastlog -u $i 2> /dev/null || lastlogin $i 2> /dev/null)`;
+            LASTLOG=`echo $LASTLOG_RAW | grep ^$i | tr -s ' '`;
             echo "$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG";
         done
     """.strip()

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -22,7 +22,6 @@ from pyinfra.facts.server import (
     Locales,
     Mounts,
     Os,
-    LinuxName,
     Sysctl,
     Users,
     Which,
@@ -821,7 +820,6 @@ def group(group, present=True, system=False, gid=None):
 
         # Groups are often added by other operations (package installs), so check
         # for the group at runtime before adding.
-        os = host.get_fact(Os)
         group_add_command = "groupadd"
         if os_type == "FreeBSD":
             group_add_command = "pw groupadd"

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -794,7 +794,7 @@ def group(group, present=True, system=False, gid=None):
     # Group exists but we don't want them?
     if not present and is_present:
         if os_type == "FreeBSD":
-            yield "pw groupdel {0}".format(group)
+            yield "pw groupdel -n {0}".format(group)
         else:
             yield "groupdel {0}".format(group)
         groups.remove(group)

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -789,11 +789,15 @@ def group(group, present=True, system=False, gid=None):
     """
 
     groups = host.get_fact(Groups)
+    os_type = host.get_fact(Os)
     is_present = group in groups
 
     # Group exists but we don't want them?
     if not present and is_present:
-        yield "groupdel {0}".format(group)
+        if os_type == "FreeBSD":
+            yield "pw groupdel {0}".format(group)
+        else:
+            yield "groupdel {0}".format(group)
         groups.remove(group)
 
     # Group doesn't exist and we want it?
@@ -804,22 +808,24 @@ def group(group, present=True, system=False, gid=None):
         if system and "BSD" not in host.get_fact(Os):
             args.append("-r")
 
-        args.append(group)
+        if os_type == "FreeBSD":
+            args.append("-n {0}".format(group))
+        else:
+            args.append(group)
 
         if gid:
-            args.append("--gid {0}".format(gid))
+            if os_type == "FreeBSD":
+                args.append("-g {0}".format(gid))
+            else:
+                args.append("--gid {0}".format(gid))
 
         # Groups are often added by other operations (package installs), so check
         # for the group at runtime before adding.
         os = host.get_fact(Os)
         group_add_command = "groupadd"
-        if os == "FreeBSD":
+        if os_type == "FreeBSD":
             group_add_command = "pw groupadd"
-        yield "grep '^{0}:' /etc/group || {2} {1}".format(
-            group,
-            " ".join(args),
-            group_add_command
-        )
+        yield "grep '^{0}:' /etc/group || {2} {1}".format(group, " ".join(args), group_add_command)
         groups.append(group)
 
 
@@ -993,7 +999,7 @@ def user(
     users = host.get_fact(Users)
     existing_groups = host.get_fact(Groups)
     existing_user = users.get(user)
-
+    os_type = host.get_fact(Os)
     if groups is None:
         groups = []
 
@@ -1005,7 +1011,10 @@ def user(
     # User not wanted?
     if not present:
         if existing_user:
-            yield "userdel {0}".format(user)
+            if os_type == "FreeBSD":
+                yield "pw userdel -n {0}".format(user)
+            else:
+                yield "userdel {0}".format(user)
             users.pop(user)
         return
 
@@ -1035,7 +1044,10 @@ def user(
             args.append("-r")
 
         if uid:
-            args.append("--uid {0}".format(uid))
+            if os_type == "FreeBSD":
+                args.append("-u {0}".format(uid))
+            else:
+                args.append("--uid {0}".format(uid))
 
         if comment:
             args.append("-c '{0}'".format(comment))
@@ -1048,16 +1060,21 @@ def user(
 
         # Users are often added by other operations (package installs), so check
         # for the user at runtime before adding.
-        os = host.get_fact(Os)
+
         add_user_command = "useradd"
-        if os == "FreeBSD":
-            add_user_command = "pw user add"
-            user = f"-n {user}"
-        yield "grep '^{2}:' /etc/passwd || {0} {1} {2}".format(
-            add_user_command,
-            " ".join(args),
-            user,
-        )
+        if os_type == "FreeBSD":
+            add_user_command = "pw useradd"
+            yield "grep '^{2}:' /etc/passwd || {0} -n {2} {1}".format(
+                add_user_command,
+                " ".join(args),
+                user,
+            )
+        else:
+            yield "grep '^{2}:' /etc/passwd || {0} {1} {2}".format(
+                add_user_command,
+                " ".join(args),
+                user,
+            )
         users[user] = {
             "comment": comment,
             "home": home,
@@ -1091,7 +1108,10 @@ def user(
 
         # Need to mod the user?
         if args:
-            yield "usermod {0} {1}".format(" ".join(args), user)
+            if os_type == "FreeBSD":
+                yield "pw usermod -n {1} {0}".format(" ".join(args), user)
+            else:
+                yield "usermod {0} {1}".format(" ".join(args), user)
             if comment:
                 existing_user["comment"] = comment
             if home:

--- a/tests/facts/server.Users/mixed.json
+++ b/tests/facts/server.Users/mixed.json
@@ -8,7 +8,7 @@
         "freebsd:*:1001:1001:FreeBSD:/home/freebsd:/bin/sh|freebsd|freebsd|freebsd pts/0 10.1.10.10 Thu Aug 31 05:37:58 2023",
         "freebsdnologin:*:1001:1001:FreeBSD NoLogin:/home/freebsdnologin:/bin/sh|freebsdnologin|freebsdnologin|"
     ],
-    "command": "for i in `cat /etc/passwd | cut -d: -f1`; do\n            ENTRY=`grep ^$i: /etc/passwd`;\n            LASTLOG=`(lastlog -u $i 2> /dev/null || lastlogin $i 2> /dev/null) | grep ^$i | tr -s ' '`;\n            echo \"$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG\";\n        done",
+    "command": "for i in `cat /etc/passwd | cut -d: -f1`; do\n            ENTRY=`grep ^$i: /etc/passwd`;\n            LASTLOG_RAW=`(lastlog -u $i 2> /dev/null || lastlogin $i 2> /dev/null)`;\n            LASTLOG=`echo $LASTLOG_RAW | grep ^$i | tr -s ' '`;\n            echo \"$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG\";\n        done",
     "fact": {
         "root": {
             "home": "/root",

--- a/tests/facts/server.Users/mixed.json
+++ b/tests/facts/server.Users/mixed.json
@@ -4,9 +4,11 @@
         "_tesTy.test:x:1004:1004::/home/_tesTy.test:/bin/ksh|_tesTy.test|_tesTy.test pyinfra|_tesTy.test pts/0 host-ip Sat Jun 12 13:43:42 -0600 2021",
         "test.testy:x:1003:1003:Testy,,,:/home/test.testy:/bin/ksh|test.testy||test.testy Fri Jun 11 22:26:04 -0600 2021",
         "noshell:x:1002:1002:noshell comment with spaces:/home/noshell:|noshell||noshell **Never logged in**",
-        "nohome:x:1002:1002:nohome comment::/bin/bash|nohome||**Never logged in**"
+        "nohome:x:1002:1002:nohome comment::/bin/bash|nohome||**Never logged in**",
+        "freebsd:*:1001:1001:FreeBSD:/home/freebsd:/bin/sh|freebsd|freebsd|freebsd pts/0 10.1.10.10 Thu Aug 31 05:37:58 2023",
+        "freebsdnologin:*:1001:1001:FreeBSD NoLogin:/home/freebsdnologin:/bin/sh|freebsdnologin|freebsdnologin|"
     ],
-    "command": "for i in `cat /etc/passwd | cut -d: -f1`; do\n            ENTRY=`grep ^$i: /etc/passwd`;\n            LASTLOG=`lastlog -u $i | grep ^$i | tr -s ' '`;\n            echo \"$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG\";\n        done",
+    "command": "for i in `cat /etc/passwd | cut -d: -f1`; do\n            ENTRY=`grep ^$i: /etc/passwd`;\n            LASTLOG=`(lastlog -u $i 2> /dev/null || lastlogin $i 2> /dev/null) | grep ^$i | tr -s ' '`;\n            echo \"$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG\";\n        done",
     "fact": {
         "root": {
             "home": "/root",
@@ -69,6 +71,28 @@
             "groups": [],
             "uid": 1002,
             "gid": 1002,
+            "lastlog": null,
+            "login_time": null
+        },
+        "freebsd": {
+            "home": "/home/freebsd",
+            "comment": "FreeBSD",
+            "shell": "/bin/sh",
+            "group": "freebsd",
+            "groups": [],
+            "uid": 1001,
+            "gid": 1001,
+            "lastlog": "Thu Aug 31 05:37:58 2023",
+            "login_time": "2023-08-31T05:37:58"
+        },
+        "freebsdnologin": {
+            "home": "/home/freebsdnologin",
+            "comment": "FreeBSD NoLogin",
+            "shell": "/bin/sh",
+            "group": "freebsdnologin",
+            "groups": [],
+            "uid": 1001,
+            "gid": 1001,
             "lastlog": null,
             "login_time": null
         }

--- a/tests/operations/server.group/add.freebsd.json
+++ b/tests/operations/server.group/add.freebsd.json
@@ -1,0 +1,14 @@
+{
+    "args": ["somegroup"],
+    "kwargs": {
+        "gid" : 1000,
+        "system": true
+    },
+    "facts": {
+        "server.Groups": [],
+        "server.Os": "FreeBSD"
+    },
+    "commands": [
+        "grep '^somegroup:' /etc/group || pw groupadd -n somegroup -g 1000"
+    ]
+}

--- a/tests/operations/server.group/delete.freebsd.json
+++ b/tests/operations/server.group/delete.freebsd.json
@@ -1,0 +1,15 @@
+{
+    "args": ["somegroup"],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "server.Groups": [
+            "somegroup"
+        ],
+        "server.Os": "FreeBSD"
+    },
+    "commands": [
+        "pw groupdel -n somegroup"
+    ]
+}

--- a/tests/operations/server.group/delete.json
+++ b/tests/operations/server.group/delete.json
@@ -6,7 +6,8 @@
     "facts": {
         "server.Groups": [
             "somegroup"
-        ]
+        ],
+        "server.Os": "Linux"
     },
     "commands": [
         "groupdel somegroup"

--- a/tests/operations/server.user/add.json
+++ b/tests/operations/server.user/add.json
@@ -11,6 +11,7 @@
         "create_home": true
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {},
         "server.Groups": {},
         "files.Directory": {

--- a/tests/operations/server.user/add_home_is_link.json
+++ b/tests/operations/server.user/add_home_is_link.json
@@ -4,6 +4,7 @@
         "home": "homedir"
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {},
         "server.Groups": {},
         "files.Directory": {

--- a/tests/operations/server.user/add_invalid_home_is_file.json
+++ b/tests/operations/server.user/add_invalid_home_is_file.json
@@ -4,6 +4,7 @@
         "home": "homedir"
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {},
         "server.Groups": {},
         "files.Directory": {

--- a/tests/operations/server.user/add_non_unique.json
+++ b/tests/operations/server.user/add_non_unique.json
@@ -5,6 +5,7 @@
         "ensure_home": false
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {},
         "server.Groups": {}
     },

--- a/tests/operations/server.user/delete.freebsd.json
+++ b/tests/operations/server.user/delete.freebsd.json
@@ -1,0 +1,19 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "server.Os": "FreeBSD",
+        "server.Users": {
+            "someuser": {
+                "home": "/home",
+                "shell": "/bin/bash"
+            }
+        },
+        "server.Groups": {}
+    },
+    "commands": [
+        "pw userdel -n someuser"
+    ]
+}

--- a/tests/operations/server.user/delete.json
+++ b/tests/operations/server.user/delete.json
@@ -4,6 +4,7 @@
         "present": false
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {
             "someuser": {
                 "home": "/home",

--- a/tests/operations/server.user/edit.json
+++ b/tests/operations/server.user/edit.json
@@ -8,6 +8,7 @@
         "comment": "New Full Name"
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {
             "someuser": {
                 "comment": "Full Name",

--- a/tests/operations/server.user/key_files.json
+++ b/tests/operations/server.user/key_files.json
@@ -12,6 +12,7 @@
         "dirs": {}
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {
             "someuser": {
                 "home": "homedir",

--- a/tests/operations/server.user/keys.json
+++ b/tests/operations/server.user/keys.json
@@ -5,6 +5,7 @@
         "public_keys": ["abc"]
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {
             "someuser": {
                 "home": "homedir",

--- a/tests/operations/server.user/keys_delete.json
+++ b/tests/operations/server.user/keys_delete.json
@@ -6,6 +6,7 @@
         "delete_keys": true
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {
             "someuser": {
                 "home": "homedir",

--- a/tests/operations/server.user/keys_nohome.json
+++ b/tests/operations/server.user/keys_nohome.json
@@ -4,6 +4,7 @@
         "public_keys": ["abc"]
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {
             "root": {
                 "home": "/root",

--- a/tests/operations/server.user/keys_single.json
+++ b/tests/operations/server.user/keys_single.json
@@ -5,6 +5,7 @@
         "public_keys": "abc"
     },
     "facts": {
+        "server.Os": "Linux",
         "server.Users": {
             "someuser": {
                 "home": "homedir",


### PR DESCRIPTION
This PR took an unexpected turn; initially, my intention was to address the user-related issues on FreeBSD. However, I found myself delving deep into the codebase.

The current version appears to be functioning correctly. I've implemented a check to ensure compatibility with FreeBSD by utilizing the pw command. Nevertheless, I'm uncertain about retaining these exceptions within the codebase.