### PR TITLE
`files.Block`: fixed couple of bugs, added `try_prevent_shell_expansion` and support for `content: list[str]`

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -19,6 +19,7 @@ from pyinfra.api import (
     FileUploadCommand,
     OperationError,
     OperationTypeError,
+    OperationValueError,
     QuoteString,
     RsyncCommand,
     StringCommand,
@@ -1736,12 +1737,16 @@ def block(
     cmd = None
     if present:
         if not content:
-            raise ValueError("'content' must be supplied when 'present' == True")
+            raise OperationValueError("'content' must be supplied when 'present' == True")
         if line:
             if before == after:
-                raise ValueError("only one of 'before' or 'after' used when 'line` is specified")
+                raise OperationValueError(
+                    "only one of 'before' or 'after' used when 'line` is specified"
+                )
         elif before != after:
-            raise ValueError("'line' must be supplied or 'before' and 'after' must be equal")
+            raise OperationValueError(
+                "'line' must be supplied or 'before' and 'after' must be equal"
+            )
         if isinstance(content, str):
             # convert string to list of lines
             content = content.split("\n")

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -1759,10 +1759,8 @@ def block(
             cmd = StringCommand(
                 f"cat {stdin}{redirect}",
                 q_path,
-                f"<<{here}"
-                if not try_prevent_shell_expansion
-                else f"<<'{here}'",
-                f"\n{the_block}\n{here}"
+                f"<<{here}" if not try_prevent_shell_expansion else f"<<'{here}'",
+                f"\n{the_block}\n{here}",
             )
         elif current == []:  # markers not found and have a pattern to match (not start or end)
             regex = adjust_regex(line, escape_regex_characters)
@@ -1775,16 +1773,15 @@ def block(
             )
             cmd = StringCommand(
                 out_prep,
-                prog, q_path,
-                f'"{the_block}"'
-                if not try_prevent_shell_expansion
-                else f"'{the_block}'",
+                prog,
+                q_path,
+                f'"{the_block}"' if not try_prevent_shell_expansion else f"'{the_block}'",
                 "> $OUT &&",
-                real_out
+                real_out,
             )
         else:
             if (len(current) != len(content)) or (
-                    not all(lines[0] == lines[1] for lines in zip(content, current))
+                not all(lines[0] == lines[1] for lines in zip(content, current))
             ):  # marked_block found but text is different
                 prog = (
                     'awk \'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=""}}'

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -1759,9 +1759,9 @@ def block(
             cmd = StringCommand(
                 f"cat {stdin}{redirect}",
                 q_path,
-                f"<<{here}" \
-                    if not try_prevent_shell_expansion \
-                    else f"<<'{here}'",
+                f"<<{here}"
+                if not try_prevent_shell_expansion
+                else f"<<'{here}'",
                 f"\n{the_block}\n{here}"
             )
         elif current == []:  # markers not found and have a pattern to match (not start or end)
@@ -1776,9 +1776,9 @@ def block(
             cmd = StringCommand(
                 out_prep,
                 prog, q_path,
-                f'"{the_block}"' \
-                    if not try_prevent_shell_expansion \
-                    else f"'{the_block}'",
+                f'"{the_block}"'
+                if not try_prevent_shell_expansion
+                else f"'{the_block}'",
                 "> $OUT &&",
                 real_out
             )
@@ -1794,9 +1794,9 @@ def block(
                     out_prep,
                     prog,
                     q_path,
-                    '"' + "\n".join(content) + '"' \
-                        if not try_prevent_shell_expansion \
-                        else "'" + "\n".join(content) + "'",
+                    '"' + "\n".join(content) + '"'
+                    if not try_prevent_shell_expansion
+                    else "'" + "\n".join(content) + "'",
                     "> $OUT &&",
                     real_out,
                 )

--- a/tests/operations/files.block/add_existing_block_different_content.json
+++ b/tests/operations/files.block/add_existing_block_different_content.json
@@ -12,6 +12,6 @@
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1} f' /home/someone/something $\"should be this\" > $OUT && chmod $(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something ) $OUT &&  (chown $(stat -c \"%U:%G\" /home/someone/something 2>/dev/null) $OUT ||  chown -n $(stat -f \"%u:%g\" /home/someone/something ) $OUT)  && mv \"$OUT\" /home/someone/something"
+        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1; next} f' /home/someone/something \"should be this\" > $OUT && chmod $(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something ) $OUT &&  (chown $(stat -c \"%U:%G\" /home/someone/something 2>/dev/null) $OUT ||  chown -n $(stat -f \"%u:%g\" /home/someone/something ) $OUT)  && mv \"$OUT\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_existing_block_different_content_and_backup.json
+++ b/tests/operations/files.block/add_existing_block_different_content_and_backup.json
@@ -13,6 +13,6 @@
         }
     },
     "commands": [
-        "cp /home/someone/something /home/someone/something.a-timestamp && OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1} f' /home/someone/something $\"should be this\" > $OUT && chmod $(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something ) $OUT &&  (chown $(stat -c \"%U:%G\" /home/someone/something 2>/dev/null) $OUT ||  chown -n $(stat -f \"%u:%g\" /home/someone/something ) $OUT)  && mv \"$OUT\" /home/someone/something"
+        "cp /home/someone/something /home/someone/something.a-timestamp && OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1; next} f' /home/someone/something \"should be this\" > $OUT && chmod $(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something ) $OUT &&  (chown $(stat -c \"%U:%G\" /home/someone/something 2>/dev/null) $OUT ||  chown -n $(stat -f \"%u:%g\" /home/someone/something ) $OUT)  && mv \"$OUT\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_line_given_but_before_eq_after.json
+++ b/tests/operations/files.block/add_line_given_but_before_eq_after.json
@@ -13,7 +13,7 @@
         }
     },
     "exception": {
-        "names": ["ValueError"],
+        "names": ["OperationValueError"],
         "message": "only one of 'before' or 'after' used when 'line` is specified"
     }
 }

--- a/tests/operations/files.block/add_no_content_provided.json
+++ b/tests/operations/files.block/add_no_content_provided.json
@@ -7,7 +7,7 @@
         }
     },
     "exception": {
-        "names": ["ValueError"],
+        "names": ["OperationValueError"],
         "message": "'content' must be supplied when 'present' == True"
     }
 }

--- a/tests/operations/files.block/add_no_existing_block_and_no_line.json
+++ b/tests/operations/files.block/add_no_existing_block_and_no_line.json
@@ -12,6 +12,6 @@
         }
     },
     "commands": [
-        "cat > /home/someone/something <<PYINFRAHERE\n# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\nPYINFRAHERE"
+        "cat > /home/someone/something <<PYINFRAHERE \n# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\nPYINFRAHERE"
     ]
 }

--- a/tests/operations/files.block/add_no_existing_block_line_provided.json
+++ b/tests/operations/files.block/add_no_existing_block_line_provided.json
@@ -12,6 +12,6 @@
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  awk 'BEGIN {x=ARGV[2]; ARGV[2]=\"\"}  f!=1 && /^.*before this.*$/ { print x; f=1} END {if (f==0) print ARGV[2] } { print }' /home/someone/something $\"# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\" > $OUT && chmod $(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something ) $OUT &&  (chown $(stat -c \"%U:%G\" /home/someone/something 2>/dev/null) $OUT ||  chown -n $(stat -f \"%u:%g\" /home/someone/something ) $OUT)  && mv \"$OUT\" /home/someone/something"
+        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  awk 'BEGIN {x=ARGV[2]; ARGV[2]=\"\"}  f!=1 && /^.*before this.*$/ { print x; f=1} END {if (f==0) print ARGV[2] } { print }' /home/someone/something \"# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\" > $OUT && chmod $(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something ) $OUT &&  (chown $(stat -c \"%U:%G\" /home/someone/something 2>/dev/null) $OUT ||  chown -n $(stat -f \"%u:%g\" /home/someone/something ) $OUT)  && mv \"$OUT\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_no_existing_block_line_provided_escape_regex.json
+++ b/tests/operations/files.block/add_no_existing_block_line_provided_escape_regex.json
@@ -13,6 +13,6 @@
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  awk 'BEGIN {x=ARGV[2]; ARGV[2]=\"\"}  f!=1 && /^.*before this \\*.*$/ { print x; f=1} END {if (f==0) print ARGV[2] } { print }' /home/someone/something $\"# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\" > $OUT && chmod $(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something ) $OUT &&  (chown $(stat -c \"%U:%G\" /home/someone/something 2>/dev/null) $OUT ||  chown -n $(stat -f \"%u:%g\" /home/someone/something ) $OUT)  && mv \"$OUT\" /home/someone/something"
+        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  awk 'BEGIN {x=ARGV[2]; ARGV[2]=\"\"}  f!=1 && /^.*before this \\*.*$/ { print x; f=1} END {if (f==0) print ARGV[2] } { print }' /home/someone/something \"# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\" > $OUT && chmod $(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something ) $OUT &&  (chown $(stat -c \"%U:%G\" /home/someone/something 2>/dev/null) $OUT ||  chown -n $(stat -f \"%u:%g\" /home/someone/something ) $OUT)  && mv \"$OUT\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_no_existing_file.json
+++ b/tests/operations/files.block/add_no_existing_file.json
@@ -12,6 +12,6 @@
         }
     },
     "commands": [
-        "cat > /home/someone/something <<PYINFRAHERE\n# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\nPYINFRAHERE"
+        "cat > /home/someone/something <<PYINFRAHERE \n# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\nPYINFRAHERE"
     ]
 }

--- a/tests/operations/files.block/add_no_line_given_but_before_ne_after.json
+++ b/tests/operations/files.block/add_no_line_given_but_before_ne_after.json
@@ -12,7 +12,7 @@
         }
     },
     "exception": {
-        "names": ["ValueError"],
+        "names": ["OperationValueError"],
         "message": "'line' must be supplied or 'before' and 'after' must be equal"
     }
 }


### PR DESCRIPTION
https://github.com/pyinfra-dev/pyinfra/issues/1028
Removed dollar signs, looks like they were typo
https://github.com/pyinfra-dev/pyinfra/issues/984
As https://github.com/pyinfra-dev/pyinfra/issues/984#issuecomment-1565657899, renamed `files.marked_block` in documentation to `files.block`
https://github.com/pyinfra-dev/pyinfra/issues/1031
Adjusted `awk` to prevent duplications
https://github.com/pyinfra-dev/pyinfra/issues/1029
Added `try_prevent_shell_expansion` parameter to partially help with mentioned issue

And also changed type for `content` to` str | list[str]`. This makes it more unified with `facts.files.Block`, that already returns `list[str]`