### PR TITLE
Fix server Users fact when user description contains a pipe character

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -439,7 +439,7 @@ class Users(FactBase):
         rex = r"[A-Z][a-z]{2} [A-Z][a-z]{2} {1,2}\d+ .+$"
 
         for line in output:
-            entry, group, user_groups, lastlog, password = line.split("|")
+            entry, group, user_groups, lastlog, password = line.rsplit("|", 4)
 
             if entry:
                 # Parse out the comment/home/shell


### PR DESCRIPTION
There is an unrecoverable exception when one of the user description does contains a pipe.

@Fizzadar It makes the entire Users fact not usable, and prior versions of pyinfra also have the issue. It would be great to have a new version released after this is merged. 