### PR TITLE
Deal with tab aligned dpkg output correctly

### DIFF
--- a/pyinfra/facts/deb.py
+++ b/pyinfra/facts/deb.py
@@ -48,8 +48,8 @@ class DebPackage(FactBase):
     """
 
     _regexes = {
-        "name": r"^Package: ({0})$".format(DEB_PACKAGE_NAME_REGEX),
-        "version": r"^Version: ({0})$".format(DEB_PACKAGE_VERSION_REGEX),
+        "name": r"^Package:\s+({0})$".format(DEB_PACKAGE_NAME_REGEX),
+        "version": r"^Version:\s+({0})$".format(DEB_PACKAGE_VERSION_REGEX),
     }
 
     requires_command = "dpkg"

--- a/tests/facts/deb.DebPackage/whitespace.json
+++ b/tests/facts/deb.DebPackage/whitespace.json
@@ -1,0 +1,28 @@
+{
+    "arg": "/root/tivsm-api64.amd64.deb",
+    "output": [
+      " new Debian package, version 2.0.",
+      " size 73275616 bytes: control archive=1079 bytes.",
+      "     123 bytes,     5 lines      changelog",
+      "       2 bytes,     1 lines      compat",
+      "     336 bytes,     9 lines      control",
+      "     147 bytes,     4 lines      copyright",
+      "      14 bytes,     1 lines      install",
+      "     237 bytes,    10 lines   *  postinst             #!/bin/sh",
+      "     377 bytes,    20 lines   *  prerm                #!/bin/sh",
+      "     156 bytes,    11 lines   *  rules                #!/usr/bin/make",
+      " Version:\t\t8.1.21-0",
+      " Maintainer:\t\tIBM",
+      " Section:\t\tUtilities/Archiving",
+      " Homepage:\t\thttp://www.ibm.com/software/tivoli/products/storage-mgr/",
+      " Package:\t\ttivsm-api64",
+      " Architecture:\t\tamd64",
+      " Description:\t\tThis is the IBM Storage Protect Linux API",
+      " Pre-Depends:\t\tgskcrypt64 (>= 8.0-55.31),",
+      "                                   gskssl64   (>= 8.0-55.31)"
+    ],
+    "fact": {
+        "name": "tivsm-api64",
+        "version": "8.1.21-0"
+    }
+}


### PR DESCRIPTION
Hey, thanks for the great package!

When I use the `DebPackage` fact on a .deb file, I noticed that it always returned an empty dictionary. This is caused on my system because at least some versions of dpkg align their output with tabs to make it look nice.

In this PR, I have added a complete and real output of dpkg with tab alignment and extended the regexes to parse this output correctly.

This should probably also go in the 3.x branch.

PS: Is there a way to signal an error in the `process` of a `Fact`? If so, it might make sense to signal an error if `DebPackage` is about to return an empty dictionary.