### PR TITLE
Fix docker.get_file for binary files

### DIFF
--- a/pyinfra/connectors/docker.py
+++ b/pyinfra/connectors/docker.py
@@ -265,17 +265,10 @@ class DockerConnector(BaseConnector):
             )
 
             # Load the temporary file and write it to our file or IO object
-            with open(temp_filename, encoding="utf-8") as temp_f:
+            with open(temp_filename, "rb") as temp_f:
                 with get_file_io(filename_or_io, "wb") as file_io:
                     data = temp_f.read()
-                    data_bytes: bytes
-
-                    if isinstance(data, str):
-                        data_bytes = data.encode()
-                    else:
-                        data_bytes = data
-
-                    file_io.write(data_bytes)
+                    file_io.write(data)
         finally:
             os.close(fd)
             os.remove(temp_filename)


### PR DESCRIPTION
The file to get is copied to a temp file, and then opened to read into memory. This would open the file in text mode (the default), which would fail on binary files that could not be decoded as utf8.

This changes the file opening to use binary mode. It also simplifies the rest of the code, which would try to handle both strings and bytes, but this is likely a remnant of py2 code (or the maybe copied from files.put where the passed file could possibly be a stream in text mode).