### PR TITLE
Fix for extra whitespace in DnfRepositories fact entries

### DIFF
--- a/pyinfra/facts/util/packaging.py
+++ b/pyinfra/facts/util/packaging.py
@@ -32,7 +32,7 @@ def _parse_yum_or_zypper_repositories(output):
             current_repo["name"] = line[1:-1]
 
         if current_repo and "=" in line:
-            key, value = line.split("=", 1)
+            key, value = re.split(r"\s*=\s*", line, maxsplit=1)
             current_repo[key] = value
 
     if current_repo:


### PR DESCRIPTION
On a clean RHEL 9.3 install, `pyinfra.facts.dnf.DnfRepositores` doesn't work as expected because there are extra spaces appended to dictionary keys, and prepanded to values.

That's because the parsing code splits on `'='` but doesn't handle whitespace.

Also relevant for the `3.x` branch