### PR TITLE
fix sphinx syntax

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,6 +1,6 @@
 Using the API
 =============
 
-In addition to :doc:`the pyinfra CLI <../cli>`, pyinfra provides a full Python API. As of `v1` this API can be considered mostly stable. An example of how to use the API is embedded below. See also :doc:`./reference`.
+In addition to :doc:`the pyinfra CLI <../cli>`, pyinfra provides a full Python API. As of ``v1`` this API can be considered mostly stable. An example of how to use the API is embedded below. See also :doc:`./reference`.
 
 .. literalinclude:: ../../examples/api_deploy.py


### PR DESCRIPTION
> for inline literals, use double backticks

```bash
pip install --user sphinx-lint
git ls-files --cached -z -- '*.rst' \
    | xargs --null -- python -m sphinxlint --enable all --disable line-too-long
```
