### PR TITLE
Fix typos

### DIFF
--- a/docs/api/connectors.md
+++ b/docs/api/connectors.md
@@ -1,6 +1,6 @@
 # Writing Connectors
 
-[Connectors](../connectors) enable pyinfra to directly integrate with other tools and systems. Connectos are written as Python classes.
+[Connectors](../connectors) enable pyinfra to directly integrate with other tools and systems. Connectors are written as Python classes.
 
 ## Inventory Connector
 
@@ -66,7 +66,7 @@ class LocalConnector(BaseConnector):
         and then writing it to the upload location.
 
         Returns:
-            bool: indicating succes or failure.
+            bool: indicating success or failure.
         """
 
     def get_file(

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,7 +1,7 @@
 Example Deploys
 ===============
 
-If you are getting started with pyinfra checkout `the examples on Github <https://github.com/Fizzadar/pyinfra/tree/2.x/examples>`_ which should properly introduce the file/folder structure as well as operation basics.
+If you are getting started with pyinfra checkout `the examples on GitHub <https://github.com/Fizzadar/pyinfra/tree/2.x/examples>`_ which should properly introduce the file/folder structure as well as operation basics.
 
 Included here is a set of documented example deploys highlighting common patterns and best practices:
 

--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -85,7 +85,7 @@ Adding data to inventories is covered in detail here: :doc:`inventory-data`. Dat
 Host Facts
 ~~~~~~~~~~
 
-Facts allow you to use information about the target host to control and configure operations. A good example is switching between ``apt`` & ``yum`` depending on the Linux distribution. Facts are imported from ``pyinfra.facts.*`` and can be retreived using the ``host.get_fact`` function:
+Facts allow you to use information about the target host to control and configure operations. A good example is switching between ``apt`` & ``yum`` depending on the Linux distribution. Facts are imported from ``pyinfra.facts.*`` and can be retrieved using the ``host.get_fact`` function:
 
 .. code:: python
 

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -268,7 +268,7 @@ def line(
         it will be append to the end of the file.
 
     Ensure new line:
-        This will ensure that the ``line`` being appended is always on a seperate new
+        This will ensure that the ``line`` being appended is always on a separate new
         line in case the file doesn't end with a newline character.
 
 


### PR DESCRIPTION
Found few misspellings.

Please consider using typos, it is single Rust binary.
