### PR TITLE
Fix sudo password handling

### DIFF
--- a/pyinfra/connectors/util.py
+++ b/pyinfra/connectors/util.py
@@ -339,7 +339,7 @@ def make_unix_command(
             [
                 "env",
                 "SUDO_ASKPASS={0}".format(_sudo_askpass_path),
-                MaskString("{0}={1}".format(SUDO_ASKPASS_ENV_VAR, _sudo_password)),
+                MaskString("{0}='{1}'".format(SUDO_ASKPASS_ENV_VAR, _sudo_password)),
             ],
         )
 

--- a/pyinfra/connectors/util.py
+++ b/pyinfra/connectors/util.py
@@ -274,12 +274,11 @@ def make_unix_command_for_host(
         # If no sudo, we've nothing to do here
         return make_unix_command(command, **command_arguments)
 
-    # Ensure the sudo password is set from either the direct arguments or any
-    # connector data value.
-    command_arguments["_sudo_password"] = command_arguments.get(
-        "_sudo_password",
-        host.connector_data.get("prompted_sudo_password"),
-    )
+    # If the sudo password is not set in the direct arguments,
+    # set it from the connector data value.
+    if "_sudo_password" not in command_arguments or not command_arguments["_sudo_password"]:
+        command_arguments["_sudo_password"] = host.connector_data.get("prompted_sudo_password")
+
     if command_arguments["_sudo_password"]:
         # Ensure the askpass path is correctly set and passed through
         _ensure_sudo_askpass_set_for_host(host)

--- a/pyinfra/connectors/util.py
+++ b/pyinfra/connectors/util.py
@@ -338,7 +338,7 @@ def make_unix_command(
             [
                 "env",
                 "SUDO_ASKPASS={0}".format(_sudo_askpass_path),
-                MaskString("{0}='{1}'".format(SUDO_ASKPASS_ENV_VAR, _sudo_password)),
+                MaskString("{0}={1}".format(SUDO_ASKPASS_ENV_VAR, shlex.quote(_sudo_password))),
             ],
         )
 

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -494,7 +494,7 @@ class TestSSHConnector(TestCase):
         fake_ssh.exec_command.assert_called_with(
             (
                 "env SUDO_ASKPASS=/tmp/pyinfra-sudo-askpass-XXXXXXXXXXXX "
-                "PYINFRA_SUDO_PASSWORD=password "
+                "PYINFRA_SUDO_PASSWORD='password' "
                 "sudo -H -A -k sh -c 'echo Šablony'"
             ),
             get_pty=False,
@@ -536,7 +536,7 @@ class TestSSHConnector(TestCase):
         assert fake_getpass.called
         fake_ssh.exec_command.assert_called_with(
             "env SUDO_ASKPASS=/tmp/pyinfra-sudo-askpass-XXXXXXXXXXXX "
-            "PYINFRA_SUDO_PASSWORD=PASSWORD sudo -H -A -k sh -c 'echo hi'",
+            "PYINFRA_SUDO_PASSWORD='PASSWORD' sudo -H -A -k sh -c 'echo hi'",
             get_pty=False,
         )
 


### PR DESCRIPTION
First, thank you for pyinfra. I have been using pyinfra 2 to manage my personal dev machines after trying fabric and ansible, and really liked it, but with version 3's addition of `_if`, it is perfect for what I need.

The only issue I had when switching to 3.x was that the sudo password pompt no longer worked. Pyinfra would ask for the sudo password, but then immediately fail.

The problem was that the connector utility function that handled setting the sudo password was checking to see if `_sudo_password` was in the argument list, but not checking if it was set. Something like (i've shorted some var names)

```
a['_sudo_password'] = a.get( '_sudo_password', h.data.get('prompted_sudo_password')
```
but `a['_sudo_password']` is set to `None`, so the prompted password never get used.

The other issue was that the command string that was generated to pass the sudo password to an askpass executable was not quoting the password

```
PYINFRA_SUDO_PASSWORD=password
```

which does not work if the password contains special shell characters like `;' or spaces.