### PR TITLE
Remove uses of pkg_resources and distutils

### DIFF
--- a/pyinfra/api/config.py
+++ b/pyinfra/api/config.py
@@ -1,8 +1,9 @@
 from os import path
 from typing import Optional
 
-# TODO: move to importlib.resources
-from pkg_resources import Requirement, ResolutionError, parse_version, require
+from pkg_resources import ResolutionError, require
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
 
 from pyinfra import __version__, state
 
@@ -53,10 +54,10 @@ config_defaults = {key: value for key, value in ConfigDefaults.__dict__.items() 
 def check_pyinfra_version(version: str):
     if not version:
         return
-    running_version = parse_version(__version__)
-    required_versions = Requirement.parse("pyinfra{0}".format(version))
+    running_version = Version(__version__)
+    required_versions = SpecifierSet(version)
 
-    if running_version not in required_versions:  # type: ignore[operator]
+    if running_version not in required_versions:
         raise PyinfraError(
             f"pyinfra version requirement not met (requires {version}, running {__version__})"
         )

--- a/pyinfra/api/connectors.py
+++ b/pyinfra/api/connectors.py
@@ -1,4 +1,7 @@
-import pkg_resources
+try:
+    from importlib_metadata import entry_points
+except ImportError:
+    from importlib.metadata import entry_points
 
 
 def _load_connector(entrypoint):
@@ -8,7 +11,7 @@ def _load_connector(entrypoint):
 def get_all_connectors():
     return {
         entrypoint.name: _load_connector(entrypoint)
-        for entrypoint in pkg_resources.iter_entry_points("pyinfra.connectors")
+        for entrypoint in entry_points(group="pyinfra.connectors")
     }
 
 

--- a/pyinfra/connectors/local.py
+++ b/pyinfra/connectors/local.py
@@ -1,5 +1,5 @@
 import os
-from distutils.spawn import find_executable
+from shutil import which
 from tempfile import mkstemp
 from typing import TYPE_CHECKING, Tuple
 
@@ -207,7 +207,7 @@ class LocalConnector(BaseConnector):
         return True
 
     def check_can_rsync(self):
-        if not find_executable("rsync"):
+        if not which("rsync"):
             raise NotImplementedError("The `rsync` binary is not available on this system.")
 
     def rsync(

--- a/pyinfra/connectors/ssh.py
+++ b/pyinfra/connectors/ssh.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import shlex
-from distutils.spawn import find_executable
 from random import uniform
+from shutil import which
 from socket import error as socket_error, gaierror
 from time import sleep
 from typing import TYPE_CHECKING, Any, Iterable, Optional, Tuple
@@ -539,7 +539,7 @@ class SSHConnector(BaseConnector):
         if self.data["ssh_password"]:
             raise NotImplementedError("Rsync does not currently work with SSH passwords.")
 
-        if not find_executable("rsync"):
+        if not which("rsync"):
             raise NotImplementedError("The `rsync` binary is not available on this system.")
 
     def rsync(

--- a/pyinfra/version.py
+++ b/pyinfra/version.py
@@ -1,6 +1,9 @@
 try:
-    from pkg_resources import get_distribution
+    try:
+        from importlib_metadata import version
+    except ImportError:
+        from importlib.metadata import version
 
-    __version__ = get_distribution("pyinfra").version
+    __version__ = version("pyinfra")
 except Exception:
     __version__ = "unknown"

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,13 @@ INSTALL_REQUIRES = (
     "pywinrm",
     "typeguard",
     "distro>=1.6,<2",
+    "packaging>=16.1",
     # Backport of graphlib used for DAG operation ordering
     'graphlib_backport ; python_version < "3.9"',
     # Backport of typing for Unpack (added 3.11)
     'typing-extensions ; python_version < "3.11"',
+    # Backport of importlib.metadata for entry_points(group=...) (added 3.10)
+    'importlib_metadata>=3.6 ; python_version < "3.10"',
 )
 
 TEST_REQUIRES = (

--- a/tests/test_api/test_api_operations.py
+++ b/tests/test_api/test_api_operations.py
@@ -390,7 +390,7 @@ class TestOperationsApi(PatchSSHTestCase):
         state = State(inventory, Config())
         connect_all(state)
 
-        with patch("pyinfra.connectors.ssh.find_executable", lambda x: None):
+        with patch("pyinfra.connectors.ssh.which", lambda x: None):
             with self.assertRaises(OperationError) as context:
                 add_op(state, files.rsync, "src", "dest")
 


### PR DESCRIPTION
This PR replaces uses of deprecated APIs from `pkg_resources` and `distutils` with modern equivalents from `importlib.*`, `packaging`, and the standard library's `shutil`. The one exception is that I added a new custom reimplementation of `pkg_resources.require()` because there's no equivalent to that in `importlib.*` or `packaging` (or the standard library).

I wasn't sure if there's any tests that would make sense to add here, since this PR isn't changing any functionality, and the only way I know of to reproduce the corresponding bug (#1088) seems to be installing pyinfra itself using pipx in Python 3.12 (and even then, it depends on some other environmental factors I haven't figured out yet), so it would be difficult to come up with a test that exercises that. Happy to take any suggestions if there's a test that would make sense to add here.

I note that the GitHub Actions workflow currently doesn't test pyinfra on Python 3.12, which would probably be good to add, but I'd consider that out of scope for this PR.

This should resolve #1088.