### PR TITLE
PyinfraOperation: Put *args first so that mypy correctly handles inner operation args

### DIFF
--- a/pyinfra/api/arguments_typed.py
+++ b/pyinfra/api/arguments_typed.py
@@ -32,6 +32,11 @@ class PyinfraOperation(Generic[P], Protocol):
     def __call__(
         self,
         #
+        # op args
+        # needs to be first
+        #
+        *args: P.args,
+        #
         # ConnectorArguments
         #
         # Auth
@@ -69,9 +74,8 @@ class PyinfraOperation(Generic[P], Protocol):
         _run_once: bool = False,
         _serial: bool = False,
         #
-        # The op itself
+        # op kwargs
         #
-        *args: P.args,
         **kwargs: P.kwargs,
     ) -> "OperationMeta":
         ...


### PR DESCRIPTION
This is not a mypy issue - unnamed arguments are passed in order so if PyinfraOperation were a real class instead of a protocol then PyinfraOperation.__call__("a", "b") would pass "a" and "b" to _sudo and _sudo_user.

This is the minimum fix to avoid errors like these:

```
pyinfra_deploy.py:6: error: Too few arguments for "__call__" of "PyinfraOperation"  [call-arg]
pyinfra_deploy.py:7: error: Argument 1 to "__call__" of "PyinfraOperation" has incompatible type "str"; expected "bool"  [arg-type]
```

I saw https://github.com/pyinfra-dev/pyinfra/pull/1082 and this change is not included