### PR TITLE
Update dev dependencies and clean up mypy errors

### DIFF
--- a/pyinfra/api/arguments_typed.py
+++ b/pyinfra/api/arguments_typed.py
@@ -77,5 +77,4 @@ class PyinfraOperation(Generic[P], Protocol):
         # op kwargs
         #
         **kwargs: P.kwargs,
-    ) -> "OperationMeta":
-        ...
+    ) -> "OperationMeta": ...

--- a/pyinfra/api/config.py
+++ b/pyinfra/api/config.py
@@ -1,7 +1,7 @@
 try:
     import importlib_metadata
 except ImportError:
-    import importlib.metadata as importlib_metadata
+    import importlib.metadata as importlib_metadata  # type: ignore[no-redef]
 from os import path
 from typing import Iterable, Optional, Set
 

--- a/pyinfra/api/connectors.py
+++ b/pyinfra/api/connectors.py
@@ -1,7 +1,7 @@
 try:
     from importlib_metadata import entry_points
 except ImportError:
-    from importlib.metadata import entry_points
+    from importlib.metadata import entry_points  # type: ignore[assignment]
 
 
 def _load_connector(entrypoint):

--- a/pyinfra/api/host.py
+++ b/pyinfra/api/host.py
@@ -33,7 +33,9 @@ if TYPE_CHECKING:
     from pyinfra.api.state import State
 
 
-def extract_callable_datas(datas: list[Union[Callable[..., Any], Any]]) -> Generator[Any, Any, Any]:
+def extract_callable_datas(
+    datas: list[Union[Callable[..., Any], Any]],
+) -> Generator[Any, Any, Any]:
     for data in datas:
         # Support for dynamic data, ie @deploy wrapped data defaults where
         # the data is stored on the state temporarily.
@@ -336,12 +338,10 @@ class Host:
     T = TypeVar("T")
 
     @overload
-    def get_fact(self, name_or_cls: Type[FactBase[T]], *args, **kwargs) -> T:
-        ...
+    def get_fact(self, name_or_cls: Type[FactBase[T]], *args, **kwargs) -> T: ...
 
     @overload
-    def get_fact(self, name_or_cls: Type[ShortFactBase[T]], *args, **kwargs) -> T:
-        ...
+    def get_fact(self, name_or_cls: Type[ShortFactBase[T]], *args, **kwargs) -> T: ...
 
     def get_fact(self, name_or_cls, *args, **kwargs):
         """

--- a/pyinfra/api/util.py
+++ b/pyinfra/api/util.py
@@ -301,19 +301,27 @@ def make_hash(obj):
             if isinstance(obj, int)
             # Constants - the values can change between hosts but we should still
             # group them under the same operation hash.
-            else "_PYINFRA_CONSTANT"
-            if obj in (True, False, None)
-            # Plain strings
-            else obj
-            if isinstance(obj, str)
-            # Objects with __name__s
-            else obj.__name__
-            if hasattr(obj, "__name__")
-            # Objects with names
-            else obj.name
-            if hasattr(obj, "name")
-            # Repr anything else
-            else repr(obj)
+            else (
+                "_PYINFRA_CONSTANT"
+                if obj in (True, False, None)
+                # Plain strings
+                else (
+                    obj
+                    if isinstance(obj, str)
+                    # Objects with __name__s
+                    else (
+                        obj.__name__
+                        if hasattr(obj, "__name__")
+                        # Objects with names
+                        else (
+                            obj.name
+                            if hasattr(obj, "name")
+                            # Repr anything else
+                            else repr(obj)
+                        )
+                    )
+                )
+            )
         )
 
     return sha1_hash(hash_string)

--- a/pyinfra/connectors/base.py
+++ b/pyinfra/connectors/base.py
@@ -108,8 +108,7 @@ class BaseConnector(abc.ABC):
         print_output: bool,
         print_input: bool,
         **arguments: Unpack["ConnectorArguments"],
-    ) -> tuple[bool, "CommandOutput"]:
-        ...
+    ) -> tuple[bool, "CommandOutput"]: ...
 
     @abc.abstractmethod
     def put_file(
@@ -120,8 +119,7 @@ class BaseConnector(abc.ABC):
         print_output: bool = False,
         print_input: bool = False,
         **arguments: Unpack["ConnectorArguments"],
-    ) -> bool:
-        ...
+    ) -> bool: ...
 
     @abc.abstractmethod
     def get_file(
@@ -132,8 +130,7 @@ class BaseConnector(abc.ABC):
         print_output: bool = False,
         print_input: bool = False,
         **arguments: Unpack["ConnectorArguments"],
-    ) -> bool:
-        ...
+    ) -> bool: ...
 
     def check_can_rsync(self):
         raise NotImplementedError("This connector does not support rsync")

--- a/pyinfra/context.py
+++ b/pyinfra/context.py
@@ -4,6 +4,7 @@ are imported and used throughout pyinfra and end user deploy code (CLI mode).
 
 These variables always represent the current executing pyinfra context.
 """
+
 from contextlib import contextmanager
 from types import ModuleType
 from typing import TYPE_CHECKING

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -1601,9 +1601,11 @@ def block(
                     out_prep,
                     prog,
                     q_path,
-                    '"' + "\n".join(content) + '"'
-                    if not try_prevent_shell_expansion
-                    else "'" + "\n".join(content) + "'",
+                    (
+                        '"' + "\n".join(content) + '"'
+                        if not try_prevent_shell_expansion
+                        else "'" + "\n".join(content) + "'"
+                    ),
                     "> $OUT &&",
                     real_out,
                 )

--- a/pyinfra/operations/selinux.py
+++ b/pyinfra/operations/selinux.py
@@ -1,6 +1,7 @@
 """
 Provides operations to set SELinux file contexts, booleans and port types.
 """
+
 from pyinfra import host
 from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.selinux import FileContext, FileContextMapping, SEBoolean, SEPort, SEPorts

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 1
 
 [flake8]
 exclude = .git,venv,build
-ignore = W503,C815,C816
+ignore = W503,C815,C816,E704
 # See: https://github.com/PyCQA/pycodestyle/issues/373
 extend-ignore = E203
 max-line-length = 100

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,11 @@ TEST_REQUIRES = (
     "coverage==7.5.1",
     "pytest-cov==5.0.0",
     # Formatting & linting
-    "black==22.3.0",
-    "isort==5.10.1",
-    "flake8==4.0.1",
-    "flake8-black==0.3.0",
-    "flake8-isort==4.1.1",
+    "black==24.4.2",
+    "isort==5.13.2",
+    "flake8==7.0.0",
+    "flake8-black==0.3.6",
+    "flake8-isort==6.1.1",
     # Typing
     "mypy",
     "types-cryptography",

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ INSTALL_REQUIRES = (
 
 TEST_REQUIRES = (
     # Unit testing
-    "pytest==7.2.0",
-    "coverage==6.5",
-    "pytest-cov==4.0.0",
+    "pytest==8.2.1",
+    "coverage==7.5.1",
+    "pytest-cov==5.0.0",
     # Formatting & linting
     "black==22.3.0",
     "isort==5.10.1",

--- a/tests/words.txt
+++ b/tests/words.txt
@@ -127,6 +127,7 @@ e501
 ed25519
 endian
 entrypoint
+envs
 envvar
 epel
 excuted
@@ -171,6 +172,7 @@ greenlets
 groupname
 hacky
 hashability
+hbutils
 hklm
 homedir
 homepath
@@ -305,6 +307,7 @@ remote
 remoteforward
 repo
 repos
+reqs
 rfind
 rlimit
 rol


### PR DESCRIPTION
I was about to start working on a small fix when I noticed that `pytest` gave me over 1,000 warnings on python 3.12. So I took the opportunity to update the test dependencies. Everything still works, warnings are down to 47 and code coverage gives the same numbers while feeling a bit faster. I did not measure. While I was at it, I also upgraded the formatting dependencies and tacked on a small fix of two typing errors that mypy complains about.

Best,
Marten