### PR TITLE
Update minimum python version to 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
           - os: macos-12
             python-version: "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ["py36"]
+target-version = ["py38"]
 
 [tool.isort]
 profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -128,6 +128,7 @@ if __name__ == "__main__":
                 "vagrant = pyinfra.connectors.vagrant:VagrantInventoryConnector",
             ],
         },
+        python_requires=">=3.8",
         install_requires=INSTALL_REQUIRES,
         extras_require={
             "test": TEST_REQUIRES,
@@ -144,7 +145,6 @@ if __name__ == "__main__":
             "License :: OSI Approved :: MIT License",
             "Operating System :: OS Independent",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.7",
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This PR updates the minimum required python version to 3.8 and specifies that explicitly in `setup.py`. Version 3.7 has been [end-of-lifed for a year](https://devguide.python.org/versions/) at this point.

This should also fix the error in PR #1107.

Does pyinfra have an explicit compatibility policy? Does it make sense for this project to be compatible with all python versions out there? Since this is not a library but a standalone tool like ansible, it does not really have to support all active python versions, but could also rely on some newer language features, or do I see that incorrectly?