### PR TITLE
Allow single function _if

### DIFF
--- a/pyinfra/api/arguments.py
+++ b/pyinfra/api/arguments.py
@@ -170,7 +170,7 @@ class MetaArguments(TypedDict):
     name: str
     _ignore_errors: bool
     _continue_on_error: bool
-    _if: List[Callable[[], bool]]
+    _if: Union[List[Callable[[], bool]], Callable[[], bool], None]
 
 
 meta_argument_meta: dict[str, ArgumentMeta] = {
@@ -191,7 +191,7 @@ meta_argument_meta: dict[str, ArgumentMeta] = {
         default=lambda _: False,
     ),
     "_if": ArgumentMeta(
-        "Only run this operation if these functions returns True",
+        "Only run this operation if these functions return True",
         default=lambda _: [],
     ),
 }

--- a/pyinfra/api/arguments_typed.py
+++ b/pyinfra/api/arguments_typed.py
@@ -61,7 +61,7 @@ class PyinfraOperation(Generic[P], Protocol):
         name: Optional[str] = None,
         _ignore_errors: bool = False,
         _continue_on_error: bool = False,
-        _if: Optional[List[Callable[[], bool]]] = None,
+        _if: Union[List[Callable[[], bool]], Callable[[], bool], None] = None,
         #
         # ExecutionArguments
         #

--- a/pyinfra/api/operation.py
+++ b/pyinfra/api/operation.py
@@ -263,10 +263,12 @@ def _wrap_operation(func: Callable[P, Generator], _set_in_op: bool = True) -> Py
         # *would* be made based on the *current* remote state.
 
         def command_generator() -> Iterator[PyinfraCommand]:
-            # Check global _if_ argument function and do nothing if returns False
+            # Check global _if argument function and do nothing if returns False
             if state.is_executing:
                 _ifs = global_arguments.get("_if")
-                if _ifs and not all(_if() for _if in _ifs):
+                if isinstance(_ifs, list) and not all(_if() for _if in _ifs):
+                    return
+                elif callable(_ifs) and not _ifs():
                     return
 
             host.in_op = _set_in_op


### PR DESCRIPTION
Always requiring `_if` to be a list requires a lot of unnecessary syntax in the common special case of exactly one condition, so this commit allows to specify a single condition directly.