### PR TITLE
Do not mistake inventory files for python modules

### DIFF
--- a/pyinfra/api/inventory.py
+++ b/pyinfra/api/inventory.py
@@ -37,6 +37,10 @@ class Inventory:
 
     state: "State"
 
+    @staticmethod
+    def empty():
+        return Inventory(([], {}))
+
     def __init__(self, names_data, override_data=None, **groups):
         # Setup basics
         self.groups = defaultdict(list)  # lists of Host objects

--- a/pyinfra_cli/util.py
+++ b/pyinfra_cli/util.py
@@ -154,9 +154,11 @@ def try_import_module_attribute(path, prefix=None, raise_for_none=True):
     if ":" in path:
         # Allow a.module.name:function syntax
         mod_path, attr_name = path.rsplit(":", 1)
-    else:
+    elif "." in path:
         # And also a.module.name.function
         mod_path, attr_name = path.rsplit(".", 1)
+    else:
+        return None
 
     possible_modules = [mod_path]
     if prefix:


### PR DESCRIPTION
Check for inventory files first, so that they are never mistaken for python modules or hostnames and avoid unnecessary warnings. Also, support IPv6-only hosts.

Fixes #1069.