### PR TITLE
Ensure that Fact#command does not take global arguments

### DIFF
--- a/pyinfra/api/arguments.py
+++ b/pyinfra/api/arguments.py
@@ -9,6 +9,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Type,
     TypeVar,
     Union,
     cast,
@@ -228,6 +229,11 @@ class AllArguments(ConnectorArguments, MetaArguments, ExecutionArguments):
     pass
 
 
+def all_global_arguments() -> List[tuple[str, Type]]:
+    """Return all global arguments and their types."""
+    return list(get_type_hints(AllArguments).items())
+
+
 all_argument_meta: dict[str, ArgumentMeta] = {
     **auth_argument_meta,
     **shell_argument_meta,
@@ -305,7 +311,7 @@ def pop_global_arguments(
     arguments: dict[str, Any] = {}
     found_keys: list[str] = []
 
-    for key, type_ in get_type_hints(AllArguments).items():
+    for key, type_ in all_global_arguments():
         if keys_to_check and key not in keys_to_check:
             continue
 

--- a/pyinfra/facts/deb.py
+++ b/pyinfra/facts/deb.py
@@ -1,4 +1,5 @@
 import re
+import shlex
 
 from pyinfra.api import FactBase
 
@@ -54,8 +55,10 @@ class DebPackage(FactBase):
 
     requires_command = "dpkg"
 
-    def command(self, name):
-        return "! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}".format(name)
+    def command(self, package):
+        return "! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}".format(
+            shlex.quote(package)
+        )
 
     def process(self, output):
         data = {}

--- a/pyinfra/facts/pacman.py
+++ b/pyinfra/facts/pacman.py
@@ -1,3 +1,5 @@
+import shlex
+
 from pyinfra.api import FactBase
 
 from .util.packaging import parse_packages
@@ -21,9 +23,9 @@ class PacmanUnpackGroup(FactBase):
 
     default = list
 
-    def command(self, name):
+    def command(self, package):
         # Accept failure here (|| true) for invalid/unknown packages
-        return 'pacman -S --print-format "%n" {0} || true'.format(name)
+        return 'pacman -S --print-format "%n" {0} || true'.format(shlex.quote(package))
 
     def process(self, output):
         return output

--- a/pyinfra/facts/rpm.py
+++ b/pyinfra/facts/rpm.py
@@ -1,4 +1,5 @@
 import re
+import shlex
 
 from pyinfra.api import FactBase
 
@@ -19,7 +20,7 @@ class RpmPackages(FactBase):
         }
     """
 
-    command = 'rpm --queryformat "{0}" -qa'.format(rpm_query_format)
+    command = "rpm --queryformat {0} -qa".format(shlex.quote(rpm_query_format))
     requires_command = "rpm"
 
     default = dict
@@ -42,12 +43,12 @@ class RpmPackage(FactBase):
 
     requires_command = "rpm"
 
-    def command(self, name):
+    def command(self, package):
         return (
-            'rpm --queryformat "{0}" -q {1} || '
+            "rpm --queryformat {0} -q {1} || "
             "! test -e {1} || "
-            'rpm --queryformat "{0}" -qp {1} 2> /dev/null'
-        ).format(rpm_query_format, name)
+            "rpm --queryformat {0} -qp {1} 2> /dev/null"
+        ).format(shlex.quote(rpm_query_format), shlex.quote(package))
 
     def process(self, output):
         for line in output:
@@ -69,11 +70,11 @@ class RpmPackageProvides(FactBase):
     requires_command = "repoquery"
 
     @staticmethod
-    def command(name):
+    def command(package):
         # Accept failure here (|| true) for invalid/unknown packages
-        return 'repoquery --queryformat "{0}" --whatprovides {1} || true'.format(
-            rpm_query_format,
-            name,
+        return "repoquery --queryformat {0} --whatprovides {1} || true".format(
+            shlex.quote(rpm_query_format),
+            shlex.quote(package),
         )
 
     @staticmethod

--- a/pyinfra/operations/apt.py
+++ b/pyinfra/operations/apt.py
@@ -233,18 +233,14 @@ def deb(src, present=True, force=False):
         src = temp_filename
 
     # Check for file .deb information (if file is present)
-    info = host.get_fact(DebPackage, name=src)
+    info = host.get_fact(DebPackage, package=src)
     current_packages = host.get_fact(DebPackages)
 
     exists = False
 
     # We have deb info! Check against installed packages
-    if info:
-        if (
-            info["name"] in current_packages
-            and info.get("version") in current_packages[info["name"]]
-        ):
-            exists = True
+    if info and info.get("version") in current_packages.get(info.get("name"), {}):
+        exists = True
 
     # Package does not exist and we want?
     if present:

--- a/pyinfra/operations/dnf.py
+++ b/pyinfra/operations/dnf.py
@@ -207,8 +207,5 @@ def packages(
         upgrade_command="dnf update -y",
         version_join="=",
         latest=latest,
-        expand_package_fact=lambda package: host.get_fact(
-            RpmPackageProvides,
-            name=package,
-        ),
+        expand_package_fact=lambda package: host.get_fact(RpmPackageProvides, package=package),
     )

--- a/pyinfra/operations/pacman.py
+++ b/pyinfra/operations/pacman.py
@@ -75,8 +75,5 @@ def packages(
         present,
         install_command="pacman --noconfirm -S",
         uninstall_command="pacman --noconfirm -R",
-        expand_package_fact=lambda package: host.get_fact(
-            PacmanUnpackGroup,
-            name=package,
-        ),
+        expand_package_fact=lambda package: host.get_fact(PacmanUnpackGroup, package=package),
     )

--- a/pyinfra/operations/util/packaging.py
+++ b/pyinfra/operations/util/packaging.py
@@ -171,12 +171,12 @@ def ensure_rpm(state, host, files, source, present, package_manager_command):
         source = temp_filename
 
     # Check for file .rpm information
-    info = host.get_fact(RpmPackage, name=source)
+    info = host.get_fact(RpmPackage, package=source)
     exists = False
 
     # We have info!
     if info:
-        current_package = host.get_fact(RpmPackage, name=info["name"])
+        current_package = host.get_fact(RpmPackage, package=info["name"])
         if current_package and current_package["version"] == info["version"]:
             exists = True
 

--- a/pyinfra/operations/yum.py
+++ b/pyinfra/operations/yum.py
@@ -207,8 +207,5 @@ def packages(
         upgrade_command="yum update -y",
         version_join="=",
         latest=latest,
-        expand_package_fact=lambda package: host.get_fact(
-            RpmPackageProvides,
-            name=package,
-        ),
+        expand_package_fact=lambda package: host.get_fact(RpmPackageProvides, package=package),
     )

--- a/tests/facts/rpm.RpmPackage/package.json
+++ b/tests/facts/rpm.RpmPackage/package.json
@@ -1,6 +1,6 @@
 {
     "arg": "somepackage",
-    "command": "rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -q somepackage || ! test -e somepackage || rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -qp somepackage 2> /dev/null",
+    "command": "rpm --queryformat '%{NAME} %{VERSION}-%{RELEASE}\\n' -q somepackage || ! test -e somepackage || rpm --queryformat '%{NAME} %{VERSION}-%{RELEASE}\\n' -qp somepackage 2> /dev/null",
     "requires_command": "rpm",
     "output": [
         "pydash 3.48.0"

--- a/tests/facts/rpm.RpmPackageProvides/package.json
+++ b/tests/facts/rpm.RpmPackageProvides/package.json
@@ -1,6 +1,6 @@
 {
     "arg": "vim",
-    "command": "repoquery --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" --whatprovides vim || true",
+    "command": "repoquery --queryformat '%{NAME} %{VERSION}-%{RELEASE}\\n' --whatprovides vim || true",
     "requires_command": "repoquery",
     "output": [
         "vim-enhanced 8.0.1763-15.el8"

--- a/tests/facts/rpm.RpmPackages/packages.json
+++ b/tests/facts/rpm.RpmPackages/packages.json
@@ -1,5 +1,5 @@
 {
-    "command": "rpm --queryformat \"%{NAME} %{VERSION}-%{RELEASE}\\n\" -qa",
+    "command": "rpm --queryformat '%{NAME} %{VERSION}-%{RELEASE}\\n' -qa",
     "requires_command": "rpm",
     "output": [
         "pydash 3.48.0"

--- a/tests/operations/apt.deb/add_existing.json
+++ b/tests/operations/apt.deb/add_existing.json
@@ -6,7 +6,7 @@
             "path=_tempfile_": ""
         },
         "deb.DebPackage": {
-            "name=_tempfile_": {
+            "package=_tempfile_": {
                 "name": "test",
                 "version": 0
             }

--- a/tests/operations/apt.deb/remove_existing.json
+++ b/tests/operations/apt.deb/remove_existing.json
@@ -9,7 +9,7 @@
             "path=_tempfile_": ""
         },
         "deb.DebPackage": {
-            "name=_tempfile_": {
+            "package=_tempfile_": {
                 "name": "test",
                 "version": 0
             }

--- a/tests/operations/dnf.packages/add_packages.json
+++ b/tests/operations/dnf.packages/add_packages.json
@@ -9,9 +9,9 @@
             "something": [""]
         },
         "rpm.RpmPackageProvides": {
-            "name=git": null,
-            "name=python-devel": null,
-            "name=something": null
+            "package=git": null,
+            "package=python-devel": null,
+            "package=something": null
         }
     },
     "commands": [

--- a/tests/operations/dnf.packages/install_with_args.json
+++ b/tests/operations/dnf.packages/install_with_args.json
@@ -6,7 +6,7 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackageProvides": {
-            "name=docker-ce": null
+            "package=docker-ce": null
         }
     },
     "commands": [

--- a/tests/operations/dnf.packages/install_with_nobest.json
+++ b/tests/operations/dnf.packages/install_with_nobest.json
@@ -6,7 +6,7 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackageProvides": {
-            "name=docker-ce": null
+            "package=docker-ce": null
         }
     },
     "commands": [

--- a/tests/operations/dnf.packages/noop_add_package_alias.json
+++ b/tests/operations/dnf.packages/noop_add_package_alias.json
@@ -5,7 +5,7 @@
             "vim-enhanced": ["abc"]
         },
         "rpm.RpmPackageProvides": {
-            "name=vim": [["vim-enhanced", "abc"]]
+            "package=vim": [["vim-enhanced", "abc"]]
         }
     },
     "commands": [],

--- a/tests/operations/dnf.packages/remove_package.json
+++ b/tests/operations/dnf.packages/remove_package.json
@@ -14,9 +14,9 @@
             "vim-common": ["8.2.1081-1.fc32"]
         },
         "rpm.RpmPackageProvides": {
-            "name=git": null,
-            "name=vim-enhanced": null,
-            "name=vim-common": null
+            "package=git": null,
+            "package=vim-enhanced": null,
+            "package=vim-common": null
         }
     },
     "commands": [

--- a/tests/operations/dnf.packages/uninstall_with_args.json
+++ b/tests/operations/dnf.packages/uninstall_with_args.json
@@ -11,7 +11,7 @@
             "git": [""]
         },
         "rpm.RpmPackageProvides": {
-            "name=git": null
+            "package=git": null
         }
     },
     "commands": [

--- a/tests/operations/dnf.rpm/add.json
+++ b/tests/operations/dnf.rpm/add.json
@@ -3,11 +3,11 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "abc"
             },
-            "name=something": null
+            "package=something": null
         }
     },
     "commands": [

--- a/tests/operations/dnf.rpm/add_existing.json
+++ b/tests/operations/dnf.rpm/add_existing.json
@@ -2,11 +2,11 @@
     "args": ["something.rpm"],
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.1"
             }
         }

--- a/tests/operations/dnf.rpm/add_existing_upgrade.json
+++ b/tests/operations/dnf.rpm/add_existing_upgrade.json
@@ -2,11 +2,11 @@
     "args": ["something.rpm"],
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.0"
             }
         }

--- a/tests/operations/dnf.rpm/add_url.json
+++ b/tests/operations/dnf.rpm/add_url.json
@@ -6,7 +6,7 @@
             "path=_tempfile_.rpm": null
         },
         "rpm.RpmPackage": {
-            "name=_tempfile_.rpm": null
+            "package=_tempfile_.rpm": null
         },
         "server.Which": {
             "command=curl": "yes"

--- a/tests/operations/dnf.rpm/remove.json
+++ b/tests/operations/dnf.rpm/remove.json
@@ -5,11 +5,11 @@
     },
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.1"
             }
         }

--- a/tests/operations/pacman.packages/add_packages.json
+++ b/tests/operations/pacman.packages/add_packages.json
@@ -2,8 +2,8 @@
     "args": [["curl", "xorg-fonts"]],
     "facts": {
         "pacman.PacmanUnpackGroup": {
-            "name=curl": ["curl"],
-            "name=xorg-fonts": ["xorg-font-util", "xorg-fonts-encodings"]
+            "package=curl": ["curl"],
+            "package=xorg-fonts": ["xorg-font-util", "xorg-fonts-encodings"]
         },
         "pacman.PacmanPackages": {}
     },

--- a/tests/operations/pacman.packages/add_packages_group_expand.json
+++ b/tests/operations/pacman.packages/add_packages_group_expand.json
@@ -2,7 +2,7 @@
     "args": [["xorg-fonts"]],
     "facts": {
         "pacman.PacmanUnpackGroup": {
-            "name=xorg-fonts": ["xorg-font-util", "xorg-font-encodings"]
+            "package=xorg-fonts": ["xorg-font-util", "xorg-font-encodings"]
         },
         "pacman.PacmanPackages": {}
     },

--- a/tests/operations/pacman.packages/remove_packages.json
+++ b/tests/operations/pacman.packages/remove_packages.json
@@ -5,8 +5,8 @@
     },
     "facts": {
         "pacman.PacmanUnpackGroup": {
-            "name=curl": ["curl"],
-            "name=i-dont-exist": []
+            "package=curl": ["curl"],
+            "package=i-dont-exist": []
         },
         "pacman.PacmanPackages": {
             "curl": "1"

--- a/tests/operations/pacman.packages/remove_packages_expand.json
+++ b/tests/operations/pacman.packages/remove_packages_expand.json
@@ -5,9 +5,9 @@
     },
     "facts": {
         "pacman.PacmanUnpackGroup": {
-            "name=curl": ["curl"],
-            "name=i-dont-exist": [],
-            "name=xorg-fonts": ["xorg-font-util", "xorg-font-encodings"]
+            "package=curl": ["curl"],
+            "package=i-dont-exist": [],
+            "package=xorg-fonts": ["xorg-font-util", "xorg-font-encodings"]
         },
         "pacman.PacmanPackages": {
             "curl": ["1"],

--- a/tests/operations/pacman.packages/upgrade_update.json
+++ b/tests/operations/pacman.packages/upgrade_update.json
@@ -6,7 +6,7 @@
     },
     "facts": {
         "pacman.PacmanUnpackGroup": {
-            "name=curl": ["curl"]
+            "package=curl": ["curl"]
         },
         "pacman.PacmanPackages": {
             "curl": ["1"]

--- a/tests/operations/yum.packages/add_packages.json
+++ b/tests/operations/yum.packages/add_packages.json
@@ -9,9 +9,9 @@
             "something": [""]
         },
         "rpm.RpmPackageProvides": {
-            "name=git": null,
-            "name=python-devel": null,
-            "name=something": null
+            "package=git": null,
+            "package=python-devel": null,
+            "package=something": null
         }
     },
     "commands": [

--- a/tests/operations/yum.packages/add_packages_alias.json
+++ b/tests/operations/yum.packages/add_packages_alias.json
@@ -5,7 +5,7 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackageProvides": {
-            "name=vim": [["vim-enhanced", "1.2.3"]]
+            "package=vim": [["vim-enhanced", "1.2.3"]]
         }
     },
     "commands": [

--- a/tests/operations/yum.packages/add_packages_alias_different_version.json
+++ b/tests/operations/yum.packages/add_packages_alias_different_version.json
@@ -7,7 +7,7 @@
             "vim-enhanced": ["2.3.4"]
         },
         "rpm.RpmPackageProvides": {
-            "name=vim": [["vim-enhanced", "1.2.3"]]
+            "package=vim": [["vim-enhanced", "1.2.3"]]
         }
     },
     "commands": [

--- a/tests/operations/yum.packages/add_packages_alias_multiple_version.json
+++ b/tests/operations/yum.packages/add_packages_alias_multiple_version.json
@@ -6,11 +6,11 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackageProvides": {
-            "name=vim": [
+            "package=vim": [
                 ["vim-enhanced", "1.2.3"],
                 ["vim-enhanced", "2.3.4"]
             ],
-            "name=kernel": [
+            "package=kernel": [
                 ["kernel", "abc"],
                 ["kernel-core", "abc"]
             ]

--- a/tests/operations/yum.packages/install_with_args.json
+++ b/tests/operations/yum.packages/install_with_args.json
@@ -6,7 +6,7 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackageProvides": {
-            "name=docker-ce": null
+            "package=docker-ce": null
         }
     },
     "commands": [

--- a/tests/operations/yum.packages/install_with_nobest.json
+++ b/tests/operations/yum.packages/install_with_nobest.json
@@ -6,7 +6,7 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackageProvides": {
-            "name=docker-ce": null
+            "package=docker-ce": null
         }
     },
     "commands": [

--- a/tests/operations/yum.packages/noop_add_packages_alias.json
+++ b/tests/operations/yum.packages/noop_add_packages_alias.json
@@ -7,7 +7,7 @@
             "vim-enhanced": ["1.2.3"]
         },
         "rpm.RpmPackageProvides": {
-            "name=vim": [["vim-enhanced", "1.2.3"]]
+            "package=vim": [["vim-enhanced", "1.2.3"]]
         }
     },
     "commands": [],

--- a/tests/operations/yum.packages/noop_add_packages_alias_multiple_version.json
+++ b/tests/operations/yum.packages/noop_add_packages_alias_multiple_version.json
@@ -7,7 +7,7 @@
             "vim-enhanced": ["1.2.3"]
         },
         "rpm.RpmPackageProvides": {
-            "name=vim": [
+            "package=vim": [
                 ["vim-enhanced", "1.2.3"],
                 ["vim-enhanced", "2.3.4"],
                 ["vim-enhanced", "4.5.6"]

--- a/tests/operations/yum.packages/remove_package.json
+++ b/tests/operations/yum.packages/remove_package.json
@@ -14,9 +14,9 @@
             "vim-common": ["8.2.1081-1.fc32"]
         },
         "rpm.RpmPackageProvides": {
-            "name=git": null,
-            "name=vim-enhanced": null,
-            "name=vim-common": null
+            "package=git": null,
+            "package=vim-enhanced": null,
+            "package=vim-common": null
         }
     },
     "commands": [

--- a/tests/operations/yum.packages/remove_packages_alias_multiple_version.json
+++ b/tests/operations/yum.packages/remove_packages_alias_multiple_version.json
@@ -10,7 +10,7 @@
             "vim-enhanced": ["1.2.3"]
         },
         "rpm.RpmPackageProvides": {
-            "name=vim": [
+            "package=vim": [
                 ["vim-enhanced", "1.2.3"],
                 ["vim-enhanced", "2.3.4"],
                 ["vim-enhanced", "4.5.6"]

--- a/tests/operations/yum.packages/uninstall_with_args.json
+++ b/tests/operations/yum.packages/uninstall_with_args.json
@@ -11,7 +11,7 @@
             "git": [""]
         },
         "rpm.RpmPackageProvides": {
-            "name=git": null
+            "package=git": null
         }
     },
     "commands": [

--- a/tests/operations/yum.rpm/add.json
+++ b/tests/operations/yum.rpm/add.json
@@ -3,11 +3,11 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "abc"
             },
-            "name=something": null
+            "package=something": null
         }
     },
     "commands": [

--- a/tests/operations/yum.rpm/add_existing.json
+++ b/tests/operations/yum.rpm/add_existing.json
@@ -2,11 +2,11 @@
     "args": ["something.rpm"],
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.1"
             }
         }

--- a/tests/operations/yum.rpm/add_existing_upgrade.json
+++ b/tests/operations/yum.rpm/add_existing_upgrade.json
@@ -2,11 +2,11 @@
     "args": ["something.rpm"],
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.0"
             }
         }

--- a/tests/operations/yum.rpm/add_url.json
+++ b/tests/operations/yum.rpm/add_url.json
@@ -6,7 +6,7 @@
             "path=_tempfile_.rpm": null
         },
         "rpm.RpmPackage": {
-            "name=_tempfile_.rpm": null
+            "package=_tempfile_.rpm": null
         },
         "server.Which": {
             "command=curl": "yes"

--- a/tests/operations/yum.rpm/remove.json
+++ b/tests/operations/yum.rpm/remove.json
@@ -5,11 +5,11 @@
     },
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.1"
             }
         }

--- a/tests/operations/zypper.rpm/add.json
+++ b/tests/operations/zypper.rpm/add.json
@@ -3,11 +3,11 @@
     "facts": {
         "rpm.RpmPackages": {},
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "abc"
             },
-            "name=something": null
+            "package=something": null
         }
     },
     "commands": [

--- a/tests/operations/zypper.rpm/add_existing.json
+++ b/tests/operations/zypper.rpm/add_existing.json
@@ -2,11 +2,11 @@
     "args": ["something.rpm"],
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.1"
             }
         }

--- a/tests/operations/zypper.rpm/add_existing_upgrade.json
+++ b/tests/operations/zypper.rpm/add_existing_upgrade.json
@@ -2,11 +2,11 @@
     "args": ["something.rpm"],
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.0"
             }
         }

--- a/tests/operations/zypper.rpm/add_url.json
+++ b/tests/operations/zypper.rpm/add_url.json
@@ -6,7 +6,7 @@
             "path=_tempfile_.rpm": null
         },
         "rpm.RpmPackage": {
-            "name=_tempfile_.rpm": null
+            "package=_tempfile_.rpm": null
         },
         "server.Which": {
             "command=curl": "yes"

--- a/tests/operations/zypper.rpm/remove.json
+++ b/tests/operations/zypper.rpm/remove.json
@@ -5,11 +5,11 @@
     },
     "facts": {
         "rpm.RpmPackage": {
-            "name=something.rpm": {
+            "package=something.rpm": {
                 "name": "something",
                 "version": "1.1"
             },
-            "name=something": {
+            "package=something": {
                 "version": "1.1"
             }
         }


### PR DESCRIPTION
A recent commit c89e21142523b540ba8cf18dc8d54daf5113773c changed getting facts so that arguments to `FactBase#command` clashing with global arguments are filtered from the kwargs. This includes the often used argument `name` and facts like `DebPackage` broke as a result.

This PR introduces a check that subclasses of `FactBase` don't take any global arguments in their `command` method and updates all existing facts and tests accordingly. There is also a tiny bit of improved shell quoting in the deb, pacman and rpm facts.