### PR TITLE
Add runit support

### DIFF
--- a/pyinfra/facts/runit.py
+++ b/pyinfra/facts/runit.py
@@ -1,0 +1,68 @@
+from pyinfra.api import FactBase
+
+
+class RunitStatus(FactBase):
+    """
+    Returns a dict of name -> status for runit services.
+
+    + service: optionally check only for a single service
+    + svdir: alternative ``SVDIR``
+
+    .. code:: python
+
+        {
+            'agetty-tty1': True,     # service is running
+            'dhcpcd': False,         # service is down
+            'wpa_supplicant': None,  # service is managed, but not running or down,
+                                     # possibly in a fail state
+        }
+    """
+
+    requires_command = "sv"
+    default = dict
+
+    def command(self, service=None, svdir="/var/service"):
+        if service is None:
+            return (
+                'export SVDIR="{0}" && '
+                'cd "$SVDIR" && find * -maxdepth 0 -exec sv status {{}} + 2>/dev/null'
+            ).format(svdir)
+        else:
+            return 'SVDIR="{0}" sv status "{1}"'.format(svdir, service)
+
+    def process(self, output):
+        services = {}
+        for line in output:
+            statusstr, service, _ = line.split(sep=": ", maxsplit=2)
+            status = None
+
+            if statusstr == "run":
+                status = True
+            elif statusstr == "down":
+                status = False
+            # another observable state is "fail"
+            # report as ``None`` for now
+
+            services[service] = status
+
+        return services
+
+
+class RunitManaged(FactBase):
+    """
+    Returns a set of all services managed by runit
+
+    + service: optionally check only for a single service
+    + svdir: alternative ``SVDIR``
+    """
+
+    default = set
+
+    def command(self, service=None, svdir="/var/service"):
+        if service is None:
+            return 'cd "{0}" && find -mindepth 1 -maxdepth 1 -type l -printf "%f\n"'.format(svdir)
+        else:
+            return 'cd "{0}" && test -h "{1}" && echo "{1}" || true'.format(svdir, service)
+
+    def process(self, output):
+        return set(output)

--- a/pyinfra/operations/runit.py
+++ b/pyinfra/operations/runit.py
@@ -1,0 +1,182 @@
+"""
+Manage runit services.
+"""
+
+from typing import Optional
+
+from pyinfra import host
+from pyinfra.api import operation
+from pyinfra.facts.files import File
+from pyinfra.facts.runit import RunitManaged, RunitStatus
+
+from .files import file, link
+from .util.service import handle_service_control
+
+
+@operation()
+def service(
+    service: str,
+    running: bool = True,
+    restarted: bool = False,
+    reloaded: bool = False,
+    command: Optional[str] = None,
+    enabled: Optional[bool] = None,
+    managed: bool = True,
+    svdir: str = "/var/service",
+    sourcedir: str = "/etc/sv",
+):
+    """
+    Manage the state of runit services.
+
+    + service: name of the service to manage
+    + running: whether the service should be running
+    + restarted: whether the service should be restarted
+    + reloaded: whether the service should be reloaded
+    + command: custom command to pass like: ``sv <command> <service>``
+    + enabled: whether this service should be enabled/disabled on boot
+    + managed: whether runit should manage this service
+
+      For services to be controlled, they first need to be managed by runit by
+      adding a symlink to the service in ``SVDIR``.
+      By setting ``managed=False`` the symlink will be removed.
+      Other options won't have any effect after that.
+      Although the ``<service>/down`` file can still be controlled with the
+      ``enabled`` option.
+
+    + svdir: alternative ``SVDIR``
+
+      An alternative ``SVDIR`` can be specified. This can be used for user services.
+
+    + sourcedir: where to search for available services
+
+      An alternative directory for available services can be specified.
+      Example: ``sourcedir=/etc/sv.local`` for services managed by the administrator.
+    """
+
+    was_managed = service in host.get_fact(RunitManaged, service=service, svdir=svdir)
+    was_auto = not host.get_fact(File, path="{0}/{1}/down".format(sourcedir, service))
+
+    # Disable autostart for previously unmanaged services.
+    #
+    # Where ``running=False`` is requested, this prevents one case of briefly
+    # starting and stopping the service.
+    if not was_managed and managed and was_auto:
+        yield from auto._inner(
+            service=service,
+            auto=False,
+            sourcedir=sourcedir,
+        )
+
+    yield from manage._inner(
+        service=service,
+        managed=managed,
+        svdir=svdir,
+        sourcedir=sourcedir,
+    )
+
+    # Service wasn't managed before, so wait for ``runsv`` to start.
+    # ``runsvdir`` will check at least every 5 seconds for new services.
+    # Wait for at most 10 seconds for the service to be managed, otherwise fail.
+    if not was_managed and managed:
+        yield from wait_runsv._inner(
+            service=service,
+            svdir=svdir,
+        )
+
+    if isinstance(enabled, bool):
+        yield from auto._inner(
+            service=service,
+            auto=enabled,
+            sourcedir=sourcedir,
+        )
+    else:
+        # restore previous state of ``<service>/down``
+        yield from auto._inner(
+            service=service,
+            auto=was_auto,
+            sourcedir=sourcedir,
+        )
+
+    # Services need to be managed by ``runit`` for the other options to make sense.
+    if not managed:
+        return
+
+    yield from handle_service_control(
+        host,
+        service,
+        host.get_fact(RunitStatus, service=service, svdir=svdir),
+        "SVDIR={0} sv {{1}} {{0}}".format(svdir),
+        running,
+        restarted,
+        reloaded,
+        command,
+    )
+
+
+@operation()
+def manage(
+    service: str,
+    managed: bool = True,
+    svdir: str = "/var/service",
+    sourcedir: str = "/etc/sv",
+):
+    """
+    Manage runit svdir links.
+
+    + service: name of the service to manage
+    + managed: whether the link should exist
+    + svdir: alternative ``SVDIR``
+    + sourcedir: where to search for available services
+    """
+
+    yield from link._inner(
+        path="{0}/{1}".format(svdir, service),
+        target="{0}/{1}".format(sourcedir, service),
+        present=managed,
+        create_remote_dir=False,
+    )
+
+
+@operation(is_idempotent=False)
+def wait_runsv(
+    service: str,
+    svdir: str = "/var/service",
+    timeout: int = 10,
+):
+    """
+    Wait for runsv for ``service`` to be available.
+
+    + service: name of the service to manage
+    + svdir: alternative ``SVDIR``
+    + timeout: time in seconds to wait
+    """
+
+    yield (
+        "export SVDIR={0}\n"
+        "for i in $(seq {1}); do\n"
+        "    sv status {2} > /dev/null && exit 0\n"
+        "    sleep 1;\n"
+        "done\n"
+        "exit 1"
+    ).format(svdir, timeout, service)
+
+
+@operation()
+def auto(
+    service: str,
+    auto: bool = True,
+    sourcedir: str = "/etc/sv",
+):
+    """
+    Start service automatically by managing the ``service/down`` file.
+
+    + service: name of the service to manage
+    + auto: whether the service should start automatically
+    + sourcedir: where to search for available services
+    """
+
+    yield from file._inner(
+        path="{0}/{1}/down".format(sourcedir, service),
+        present=not auto,
+        create_remote_dir=False,
+    )

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -38,6 +38,7 @@ from . import (
     openrc,
     pacman,
     pkg,
+    runit,
     systemd,
     sysvinit,
     upstart,
@@ -488,6 +489,9 @@ def service(
 
     elif host.get_fact(Which, command="initctl"):
         service_operation = upstart.service
+
+    elif host.get_fact(Which, command="sv"):
+        service_operation = runit.service
 
     elif (
         host.get_fact(Which, command="service")

--- a/tests/facts/runit.RunitManaged/single.json
+++ b/tests/facts/runit.RunitManaged/single.json
@@ -1,0 +1,11 @@
+{
+    "arg": ["agetty-tty1", "/var/service"],
+    "command": "cd \"/var/service\" && test -h \"agetty-tty1\" && echo \"agetty-tty1\" || true",
+    "requires_command": "sv",
+    "output": [
+        "agetty-tty1"
+    ],
+    "fact": [
+        "agetty-tty1"
+    ]
+}

--- a/tests/facts/runit.RunitManaged/status.json
+++ b/tests/facts/runit.RunitManaged/status.json
@@ -1,0 +1,21 @@
+{
+    "arg": [null, "/var/service"],
+    "command": "cd \"/var/service\" && find -mindepth 1 -maxdepth 1 -type l -printf \"%f\n\"",
+    "requires_command": "sv",
+    "output": [
+        "agetty-tty1",
+        "agetty-tty2",
+        "agetty-tty3",
+        "agetty-tty4",
+        "agetty-tty5",
+        "bar"
+    ],
+    "fact": [
+        "agetty-tty1",
+        "agetty-tty2",
+        "agetty-tty3",
+        "agetty-tty4",
+        "agetty-tty5",
+        "bar"
+    ]
+}

--- a/tests/facts/runit.RunitStatus/single.json
+++ b/tests/facts/runit.RunitStatus/single.json
@@ -1,0 +1,11 @@
+{
+    "arg": ["agetty-tty1", "/var/service"],
+    "command": "SVDIR=\"/var/service\" sv status \"agetty-tty1\"",
+    "requires_command": "sv",
+    "output": [
+        "run: agetty-tty1: (pid 1160) 1214497s"
+    ],
+    "fact": {
+        "agetty-tty1": true
+    }
+}

--- a/tests/facts/runit.RunitStatus/status.json
+++ b/tests/facts/runit.RunitStatus/status.json
@@ -1,0 +1,23 @@
+{
+    "arg": [null, "/var/service"],
+    "command": "export SVDIR=\"/var/service\" && cd \"$SVDIR\" && find * -maxdepth 0 -exec sv status {} + 2>/dev/null",
+    "requires_command": "sv",
+    "output": [
+        "run: agetty-tty1: (pid 1160) 1214497s",
+        "run: agetty-tty2: (pid 1159) 1214497s",
+        "run: agetty-tty3: (pid 1163) 1214497s",
+        "run: agetty-tty4: (pid 1161) 1214497s",
+        "down: agetty-tty5: 1214497s",
+        "fail: foo: unable to change to service directory: file does not exist",
+        "fail: bar: runsv not running"
+    ],
+    "fact": {
+        "agetty-tty1": true,
+        "agetty-tty2": true,
+        "agetty-tty3": true,
+        "agetty-tty4": true,
+        "agetty-tty5": false,
+        "foo": null,
+        "bar": null
+    }
+}

--- a/tests/operations/runit.manage/manage.json
+++ b/tests/operations/runit.manage/manage.json
@@ -1,0 +1,21 @@
+{
+    "args": ["nginx"],
+    "kwargs": {
+        "managed": true
+    },
+    "facts": {
+        "files.Link": {
+            "path=/var/service/nginx": null
+        },
+        "files.Directory": {
+            "path=/var/service": {
+                "user": "root",
+                "group": "root",
+                "mode": 644
+            }
+        }
+    },
+    "commands": [
+        "ln -s /etc/sv/nginx /var/service/nginx"
+    ]
+}

--- a/tests/operations/runit.manage/unmanage.json
+++ b/tests/operations/runit.manage/unmanage.json
@@ -1,0 +1,25 @@
+{
+    "args": ["nginx"],
+    "kwargs": {
+        "managed": false
+    },
+    "facts": {
+        "files.Link": {
+            "path=/var/service/nginx": {
+                "user": "root",
+                "group": "root",
+                "link_target": "/etc/sv/nginx"
+            }
+        },
+        "files.Directory": {
+            "path=/var/service": {
+                "user": "root",
+                "group": "root",
+                "mode": 644
+            }
+        }
+    },
+    "commands": [
+        "rm -f /var/service/nginx"
+    ]
+}

--- a/tests/operations/runit.service/disable.json
+++ b/tests/operations/runit.service/disable.json
@@ -1,0 +1,27 @@
+{
+    "args": ["nginx"],
+    "kwargs": {
+        "enabled": false
+    },
+    "facts": {
+        "runit.RunitManaged": {
+            "service=nginx, svdir=/var/service": ["nginx"]
+        },
+        "files.Link": {
+            "path=/var/service/nginx": {
+                "user": "root",
+                "group": "root",
+                "link_target": "/etc/sv/nginx"
+            }
+        },
+        "files.File": {
+            "path=/var/service/nginx/down": null
+        },
+        "runit.RunitStatus": {
+            "service=nginx, svdir=/var/service": {"nginx": true}
+        }
+    },
+    "commands": [
+        "touch /etc/sv/nginx/down"
+    ]
+}

--- a/tests/operations/runit.service/enable.json
+++ b/tests/operations/runit.service/enable.json
@@ -1,0 +1,32 @@
+{
+    "args": ["nginx"],
+    "kwargs": {
+        "enabled": true
+    },
+    "facts": {
+        "runit.RunitManaged": {
+            "service=nginx, svdir=/var/service": {}
+        },
+        "files.Link": {
+            "path=/var/service/nginx": null
+        },
+        "files.Directory": {
+            "path=/var/service": {
+                "user": "root",
+                "group": "root",
+                "mode": 644
+            }
+        },
+        "files.File": {
+            "path=/var/service/nginx/down": null
+        },
+        "runit.RunitStatus": {
+            "service=nginx, svdir=/var/service": {"nginx": true}
+        }
+    },
+    "commands": [
+        "touch /etc/sv/nginx/down",
+        "ln -s /etc/sv/nginx /var/service/nginx",
+        "export SVDIR=/var/service\nfor i in $(seq 10); do\n    sv status nginx > /dev/null && exit 0\n    sleep 1;\ndone\nexit 1"
+    ]
+}

--- a/tests/operations/server.service/start_runit.json
+++ b/tests/operations/server.service/start_runit.json
@@ -1,0 +1,29 @@
+{
+    "args": ["nginx"],
+    "facts": {
+        "server.Which": {
+            "command=sv": true
+        },
+        "runit.RunitManaged": {
+            "service=nginx, svdir=/var/service": ["nginx"]
+        },
+        "files.File": {
+            "path=/etc/sv/nginx/down": null
+        },
+        "files.Link": {
+            "path=/var/service/nginx": {
+                "user": "root",
+                "group": "root",
+                "link_target": "/etc/sv/nginx"
+            }
+        },
+        "runit.RunitStatus": {
+            "service=nginx, svdir=/var/service": {
+                "nginx": false
+            }
+        }
+    },
+    "commands": [
+        "SVDIR=/var/service sv start nginx"
+    ]
+}


### PR DESCRIPTION
This add support for runit service management for pyinfra 3.

While runit behaves a little different to other init systems, it's still possible to have compatibility with server.service, albeit with some limitations.

It's also possible to manage alternative SVDIRs and sources for services.