### PR TITLE
server/user_authorized_keys: Do not hardcode homedir

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -25,12 +25,14 @@ class User(FactBase):
     command = "echo $USER"
 
 
-class Home(FactBase):
+class Home(FactBase[Optional[str]]):
     """
-    Returns the home directory of the current user.
+    Returns the home directory of the given user, or the current user if no user is given.
     """
 
-    command = "echo $HOME"
+    @staticmethod
+    def command(user=""):
+        return f"echo ~{user}"
 
 
 class Path(FactBase):

--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -18,6 +18,7 @@ from pyinfra.facts.files import Directory, FindInFile, Link
 from pyinfra.facts.server import (
     Crontab,
     Groups,
+    Home,
     Hostname,
     KernelModules,
     Locales,
@@ -858,7 +859,9 @@ def user_authorized_keys(
     """
 
     if not authorized_key_directory:
-        authorized_key_directory = f"/home/{user}/.ssh/"
+        home = host.get_fact(Home, user=user)
+        authorized_key_directory = f"{home}/.ssh"
+
     if not authorized_key_filename:
         authorized_key_filename = "authorized_keys"
 

--- a/tests/facts/server.Home/home.json
+++ b/tests/facts/server.Home/home.json
@@ -1,5 +1,5 @@
 {
-    "command": "echo $HOME",
+    "command": "echo ~",
     "output": ["/home/pyinfra"],
     "fact": "/home/pyinfra"
 }

--- a/tests/facts/server.Home/root.json
+++ b/tests/facts/server.Home/root.json
@@ -1,0 +1,6 @@
+{
+    "arg": ["root"],
+    "command": "echo ~root",
+    "output": ["/root"],
+    "fact": "/root"
+}

--- a/tests/facts/server.Home/some_user.json
+++ b/tests/facts/server.Home/some_user.json
@@ -1,0 +1,6 @@
+{
+    "arg": ["some_user"],
+    "command": "echo ~some_user",
+    "output": ["/home/some_user"],
+    "fact": "/home/some_user"
+}


### PR DESCRIPTION
This PR makes setting authorized_keys for root work by no longer hardcoding `/home/{user}` as a user's homedir. For this, the `server.Home` fact is extended to allow looking up the homedir of other users than the current user too.

See individual commit messages for more details.