### PR TITLE
Add ZFS operations and facts

### DIFF
--- a/pyinfra/facts/zfs.py
+++ b/pyinfra/facts/zfs.py
@@ -1,0 +1,37 @@
+"""
+Manage ZFS filesystems.
+"""
+
+from pyinfra.api import FactBase
+
+
+class _ZFSResourceBase(FactBase):
+    default = dict
+
+    @staticmethod
+    def process(output):
+        datasets = {}
+        for line in output:
+            dataset, property, value, source = tuple(line.split("\t"))
+            if dataset not in datasets:
+                datasets[dataset] = {}
+            datasets[dataset][property] = value
+        return datasets
+
+
+class Pools(_ZFSResourceBase):
+    command = "zpool get -H all"
+
+class Datasets(_ZFSResourceBase):
+    command = "zfs get -H all"
+
+class Filesystems(_ZFSResourceBase):
+    command = "zfs get -t filesystem -H all"
+
+
+class Snapshots(_ZFSResourceBase):
+    command = "zfs get -t snapshot -H all"
+
+
+class Volumes(_ZFSResourceBase):
+    command = "zfs get -t volume -H all"

--- a/pyinfra/facts/zfs.py
+++ b/pyinfra/facts/zfs.py
@@ -2,36 +2,49 @@
 Manage ZFS filesystems.
 """
 
-from pyinfra.api import FactBase
+from pyinfra.api import FactBase, ShortFactBase
 
 
-class _ZFSResourceBase(FactBase):
-    default = dict
+def _process_zfs_props_table(output):
+    datasets = {}
+    for line in output:
+        dataset, property, value, source = tuple(line.split("\t"))
+        if dataset not in datasets:
+            datasets[dataset] = {}
+        datasets[dataset][property] = value
+    return datasets
 
+
+class Pools(FactBase):
+    command = "zpool get -H all"
     @staticmethod
     def process(output):
-        datasets = {}
-        for line in output:
-            dataset, property, value, source = tuple(line.split("\t"))
-            if dataset not in datasets:
-                datasets[dataset] = {}
-            datasets[dataset][property] = value
-        return datasets
+        return _process_zfs_props_table(output)
 
 
-class Pools(_ZFSResourceBase):
-    command = "zpool get -H all"
-
-class Datasets(_ZFSResourceBase):
+class Datasets(FactBase):
     command = "zfs get -H all"
+    @staticmethod
+    def process(output):
+        return _process_zfs_props_table(output)
 
-class Filesystems(_ZFSResourceBase):
-    command = "zfs get -t filesystem -H all"
+class Filesystems(ShortFactBase):
+    fact=Datasets
+
+    @staticmethod
+    def process_data(data):
+        return {name:props for name, props in data.items() if props.get("type") == "filesystem"}
 
 
-class Snapshots(_ZFSResourceBase):
-    command = "zfs get -t snapshot -H all"
+class Snapshots(ShortFactBase):
+    fact=Datasets
+    @staticmethod
+    def process_data(data):
+        return {name:props for name, props in data.items() if props.get("type") == "snapshot"}
 
 
-class Volumes(_ZFSResourceBase):
-    command = "zfs get -t volume -H all"
+class Volumes(ShortFactBase):
+    fact=Datasets
+    @staticmethod
+    def process_data(data):
+        return {name:props for name, props in data.items() if props.get("type") == "volume"}

--- a/pyinfra/facts/zfs.py
+++ b/pyinfra/facts/zfs.py
@@ -6,7 +6,7 @@ from pyinfra.api import FactBase, ShortFactBase
 
 
 def _process_zfs_props_table(output):
-    datasets = {}
+    datasets: dict = {}
     for line in output:
         dataset, property, value, source = tuple(line.split("\t"))
         if dataset not in datasets:

--- a/pyinfra/facts/zfs.py
+++ b/pyinfra/facts/zfs.py
@@ -16,7 +16,8 @@ def _process_zfs_props_table(output):
 
 
 class Pools(FactBase):
-    command = "zpool get -H all"
+    def command(self):
+        return "zpool get -H all"
 
     @staticmethod
     def process(output):
@@ -24,7 +25,8 @@ class Pools(FactBase):
 
 
 class Datasets(FactBase):
-    command = "zfs get -H all"
+    def command(self):
+        return "zfs get -H all"
 
     @staticmethod
     def process(output):

--- a/pyinfra/facts/zfs.py
+++ b/pyinfra/facts/zfs.py
@@ -17,6 +17,7 @@ def _process_zfs_props_table(output):
 
 class Pools(FactBase):
     command = "zpool get -H all"
+
     @staticmethod
     def process(output):
         return _process_zfs_props_table(output)
@@ -24,27 +25,31 @@ class Pools(FactBase):
 
 class Datasets(FactBase):
     command = "zfs get -H all"
+
     @staticmethod
     def process(output):
         return _process_zfs_props_table(output)
 
+
 class Filesystems(ShortFactBase):
-    fact=Datasets
+    fact = Datasets
 
     @staticmethod
     def process_data(data):
-        return {name:props for name, props in data.items() if props.get("type") == "filesystem"}
+        return {name: props for name, props in data.items() if props.get("type") == "filesystem"}
 
 
 class Snapshots(ShortFactBase):
-    fact=Datasets
+    fact = Datasets
+
     @staticmethod
     def process_data(data):
-        return {name:props for name, props in data.items() if props.get("type") == "snapshot"}
+        return {name: props for name, props in data.items() if props.get("type") == "snapshot"}
 
 
 class Volumes(ShortFactBase):
-    fact=Datasets
+    fact = Datasets
+
     @staticmethod
     def process_data(data):
-        return {name:props for name, props in data.items() if props.get("type") == "volume"}
+        return {name: props for name, props in data.items() if props.get("type") == "volume"}

--- a/pyinfra/operations/zfs.py
+++ b/pyinfra/operations/zfs.py
@@ -1,0 +1,172 @@
+"""
+Manage ZFS filesystems.
+"""
+
+from pyinfra import host
+from pyinfra.api import operation
+from pyinfra.facts.zfs import Datasets, Snapshots
+
+
+@operation()
+def dataset(
+    dataset_name,
+    present=True,
+    recursive=True,
+    sparse=None,
+    volume_size=None,
+    properties={},
+    **extra_props,
+):
+    """
+    Create, destroy or set properties on a  ZFS dataset (e.g. filesystem,
+    volume, snapshot).
+
+    + dataset_name: name of the filesystem to operate on
+    + present: whether the named filesystem should exist
+    + recursive: whether to create parent datasets, or destroy child datasets
+    + sparse: for volumes, whether to create a sparse volume with no allocation
+    + volume_size: the size of the volume
+    + properties: the ZFS properties that should be set on the dataset.
+    + **extra_props: additional props; merged with `properties` for convenience
+
+    **Examples:**
+
+    .. code:: python
+
+    zfs.dataset(
+        "tank/srv",
+        mountpoint="/srv",
+        compression="lz4",
+        properties={"com.sun:auto_snapshot": "true"}
+    )
+    zfs.dataset("tank/vm-disks/db_srv_04", volume_size="32G") # creates a volume
+    zfs.dataset("tank/home@old_version", present=False)
+
+    """
+
+    noop_msg = "{0} is already {1}".format(dataset_name, "present" if present else "absent")
+
+    properties.update(extra_props)
+
+    datasets = host.get_fact(Datasets)
+
+    existing_dataset = datasets.get(dataset_name)
+
+    if present and not existing_dataset:
+        args = ["-o {0}={1}".format(prop, value) for prop, value in properties.items()]
+        if recursive:
+            args.append("-p")
+        if sparse:
+            args.append("-s")
+        if volume_size:
+            args.append("-V {0}".format(volume_size))
+
+        yield "zfs create {0} {1}".format(" ".join(args), dataset_name)
+
+    elif present and existing_dataset:
+        prop_args = [
+            "{0}={1}".format(prop, value)
+            for prop, value in properties.items() - existing_dataset.items()
+        ]
+        if prop_args:
+            yield "zfs set {0} {1}".format(" ".join(prop_args), dataset_name)
+        else:
+            host.noop(noop_msg)
+
+    elif existing_dataset and not present:
+        recursive_arg = "-r" if recursive else ""
+        yield "zfs destroy {0} {1}".format(recursive_arg, dataset_name)
+
+    else:
+        host.noop(noop_msg)
+
+
+@operation()
+def snapshot(snapshot_name, present=True, recursive=False, properties={}, **extra_props):
+    """
+    Create or destroy a ZFS snapshot, or modify its properties.
+
+    + dataset_name: name of the filesystem to operate on
+    + present: whether the named filesystem should exist
+    + recursive: whether to snapshot child datasets
+    + properties: the ZFS properties that should be set on the snapshot.
+    + **extra_props: additional props; merged with `properties` for convenience
+
+    **Examples:**
+
+    .. code:: python
+
+    zfs.snapshot("tank/home@weekly_backup")
+
+    """
+    properties.update(extra_props)
+    snapshots = host.get_fact(Snapshots)
+
+    if snapshot_name in snapshots or not present:
+        yield from dataset._inner(snapshot_name, present=present, properties=properties)
+
+    else:
+        args = ["-o {0}={1}".format(prop, value) for prop, value in properties.items()]
+        if recursive:
+            args.append("-r")
+        yield "zfs snap {0} {1}".format(" ".join(args), snapshot_name)
+
+
+@operation()
+def volume(
+    volume_name, size, sparse=False, present=True, recursive=False, properties={}, **extra_props
+):
+    """
+    Create or destroy a ZFS volume, or modify its properties.
+
+    + volume_name: name of the volume to operate on
+    + size: the size of the volume
+    + sparse: create a sparse volume
+    + present: whether the named volume should exist
+    + recursive: whether to create parent datasets or destroy child datasets
+    + properties: the ZFS properties that should be set on the snapshot.
+    + **extra_props: additional props; merged with `properties` for convenience
+
+    **Examples:**
+
+    .. code:: python
+
+    zfs.volume("tank/vm-disks/db_srv_04", "32G")
+
+    """
+    properties.update(extra_props)
+    yield from dataset._inner(
+        volume_name,
+        volume_size=size,
+        present=present,
+        sparse=sparse,
+        recursive=recursive,
+        properties=properties,
+    )
+
+
+@operation()
+def filesystem(fs_name, present=True, recursive=False, properties={}, **extra_props):
+    """
+    Create or destroy a ZFS filesystem, or modify its properties.
+
+    + fs_name: name of the volume to operate on
+    + present: whether the named volume should exist
+    + recursive: whether to create parent datasets or destroy child datasets
+    + properties: the ZFS properties that should be set on the snapshot.
+    + **extra_props: additional props; merged with `properties` for convenience
+
+    **Examples:**
+
+    .. code:: python
+
+    zfs.filesystem("tank/vm-disks/db_srv_04", "32G")
+
+    """
+    properties.update(extra_props)
+    yield from dataset._inner(
+        fs_name,
+        present=present,
+        recursive=recursive,
+        properties=properties,
+    )

--- a/pyinfra/operations/zfs.py
+++ b/pyinfra/operations/zfs.py
@@ -61,7 +61,7 @@ def dataset(
         if volume_size:
             args.append("-V {0}".format(volume_size))
 
-        args.sort() # dicts are unordered, so make sure the test results are deterministic
+        args.sort()  # dicts are unordered, so make sure the test results are deterministic
 
         yield "zfs create {0} {1}".format(" ".join(args), dataset_name)
 

--- a/pyinfra/operations/zfs.py
+++ b/pyinfra/operations/zfs.py
@@ -11,7 +11,7 @@ from pyinfra.facts.zfs import Datasets, Snapshots
 def dataset(
     dataset_name,
     present=True,
-    recursive=True,
+    recursive=False,
     sparse=None,
     volume_size=None,
     properties={},
@@ -61,6 +61,8 @@ def dataset(
         if volume_size:
             args.append("-V {0}".format(volume_size))
 
+        args.sort() # dicts are unordered, so make sure the test results are deterministic
+
         yield "zfs create {0} {1}".format(" ".join(args), dataset_name)
 
     elif present and existing_dataset:
@@ -68,6 +70,7 @@ def dataset(
             "{0}={1}".format(prop, value)
             for prop, value in properties.items() - existing_dataset.items()
         ]
+        prop_args.sort()
         if prop_args:
             yield "zfs set {0} {1}".format(" ".join(prop_args), dataset_name)
         else:

--- a/pyinfra_cli/__main__.py
+++ b/pyinfra_cli/__main__.py
@@ -1,4 +1,3 @@
-import os
 import signal
 import sys
 

--- a/tests/facts/zfs.Datasets/datasets.json
+++ b/tests/facts/zfs.Datasets/datasets.json
@@ -1,0 +1,23 @@
+{
+    "command": "zfs get -H all",
+    "output": ["""tank	size	2.71T	-
+tank	feature@encryption	enabled	local
+tank	com.sun:auto_snapshot	true	-
+tank/home	com.sun:auto_snapshot	true	inherited from tank
+tank/home@old	encryption	off	default
+"""],
+    "fact": {
+        "tank": {
+            "size": "2.71T",
+            "feature@encryption": "enabled",
+            "com.sun:auto_snapshot": "true",
+        },
+        "tank/home": {
+            "com.sun:auto_snapshot": "true",
+        }
+        "tank/home@old": {
+            "encryption": "off",
+        }
+
+    }
+}

--- a/tests/facts/zfs.Datasets/datasets.json
+++ b/tests/facts/zfs.Datasets/datasets.json
@@ -1,23 +1,33 @@
 {
     "command": "zfs get -H all",
-    "output": ["""tank	size	2.71T	-
-tank	feature@encryption	enabled	local
-tank	com.sun:auto_snapshot	true	-
-tank/home	com.sun:auto_snapshot	true	inherited from tank
-tank/home@old	encryption	off	default
-"""],
+    "output": [
+        "tank\ttype\tfilesystem\t-",
+        "tank\tsize\t2.71T\t-",
+        "tank\tfeature@encryption\tenabled\tlocal",
+        "tank\tcom.sun:auto_snapshot\ttrue\t-",
+        "tank/home\ttype\tfilesystem\t-",
+        "tank/home\tcom.sun:auto_snapshot\ttrue\tinherited from tank",
+        "tank/home@old\ttype\tsnapshot\t-",
+        "tank/home@old\tencryption\toff\tdefault",
+        "tank/myvol\ttype\tvolume\t-"
+    ],
     "fact": {
         "tank": {
+            "type": "filesystem",
             "size": "2.71T",
             "feature@encryption": "enabled",
-            "com.sun:auto_snapshot": "true",
+            "com.sun:auto_snapshot": "true"
         },
         "tank/home": {
-            "com.sun:auto_snapshot": "true",
-        }
+            "type": "filesystem",
+            "com.sun:auto_snapshot": "true"
+        },
+        "tank/myvol": {
+            "type": "volume"
+        },
         "tank/home@old": {
-            "encryption": "off",
+            "type": "snapshot",
+            "encryption": "off"
         }
-
     }
 }

--- a/tests/facts/zfs.Filesystems/filesystems.json
+++ b/tests/facts/zfs.Filesystems/filesystems.json
@@ -1,11 +1,26 @@
 {
-    "command": "zfs get -t filesystem -H all",
-    "output": ["""
-tank/home	compression	lz4	-
-"""],
+    "command": "zfs get -H all",
+    "output": [
+        "tank\ttype\tfilesystem\t-",
+        "tank\tsize\t2.71T\t-",
+        "tank\tfeature@encryption\tenabled\tlocal",
+        "tank\tcom.sun:auto_snapshot\ttrue\t-",
+        "tank/home\ttype\tfilesystem\t-",
+        "tank/home\tcom.sun:auto_snapshot\ttrue\tinherited from tank",
+        "tank/home@old\ttype\tsnapshot\t-",
+        "tank/home@old\tencryption\toff\tdefault",
+        "tank/myvol\ttype\tvolume\t-"
+    ],
     "fact": {
-        "tank/home": {
-            "compression": "lz4",
+        "tank": {
+            "type": "filesystem",
+            "size": "2.71T",
+            "feature@encryption": "enabled",
+            "com.sun:auto_snapshot": "true"
         },
+        "tank/home": {
+            "type": "filesystem",
+            "com.sun:auto_snapshot": "true"
+        }
     }
 }

--- a/tests/facts/zfs.Filesystems/filesystems.json
+++ b/tests/facts/zfs.Filesystems/filesystems.json
@@ -1,0 +1,11 @@
+{
+    "command": "zfs get -t filesystem -H all",
+    "output": ["""
+tank/home	compression	lz4	-
+"""],
+    "fact": {
+        "tank/home": {
+            "compression": "lz4",
+        },
+    }
+}

--- a/tests/facts/zfs.Pools/pools.json
+++ b/tests/facts/zfs.Pools/pools.json
@@ -1,0 +1,11 @@
+{
+    "command": "zpool get -H all",
+    "output": ["""tank	compression	lz4	-
+tank	ashift	12	local
+"""],
+    "fact": {
+        "tank/zvol1": {
+            "compression": "lz4",
+        },
+    }
+}

--- a/tests/facts/zfs.Pools/pools.json
+++ b/tests/facts/zfs.Pools/pools.json
@@ -1,11 +1,13 @@
 {
     "command": "zpool get -H all",
-    "output": ["""tank	compression	lz4	-
-tank	ashift	12	local
-"""],
+    "output": [
+        "tank\tcompression\tlz4\t-",
+        "tank\tashift\t12\tlocal"
+    ],
     "fact": {
-        "tank/zvol1": {
+        "tank": {
             "compression": "lz4",
-        },
+            "ashift": "12"
+        }
     }
 }

--- a/tests/facts/zfs.Snapshots/snapshots.json
+++ b/tests/facts/zfs.Snapshots/snapshots.json
@@ -1,0 +1,9 @@
+{
+    "command": "zfs get -t snapshot -H all",
+    "output": ["tank/home@old	compression	lz4	-"],
+    "fact": {
+        "tank/home@old": {
+            "compression": "lz4",
+        },
+    }
+}

--- a/tests/facts/zfs.Snapshots/snapshots.json
+++ b/tests/facts/zfs.Snapshots/snapshots.json
@@ -1,9 +1,20 @@
 {
-    "command": "zfs get -t snapshot -H all",
-    "output": ["tank/home@old	compression	lz4	-"],
+    "command": "zfs get -H all",
+    "output": [
+        "tank\ttype\tfilesystem\t-",
+        "tank\tsize\t2.71T\t-",
+        "tank\tfeature@encryption\tenabled\tlocal",
+        "tank\tcom.sun:auto_snapshot\ttrue\t-",
+        "tank/home\ttype\tfilesystem\t-",
+        "tank/home\tcom.sun:auto_snapshot\ttrue\tinherited from tank",
+        "tank/home@old\ttype\tsnapshot\t-",
+        "tank/home@old\tencryption\toff\tdefault",
+        "tank/myvol\ttype\tvolume\t-"
+    ],
     "fact": {
         "tank/home@old": {
-            "compression": "lz4",
-        },
+            "type": "snapshot",
+            "encryption": "off"
+        }
     }
 }

--- a/tests/facts/zfs.Volumes/volumes.json
+++ b/tests/facts/zfs.Volumes/volumes.json
@@ -1,0 +1,9 @@
+{
+    "command": "zfs get -t volume -H all",
+    "output": ["tank/zvol1	compression	lz4	-"],
+    "fact": {
+        "tank/zvol1": {
+            "compression": "lz4",
+        },
+    }
+}

--- a/tests/facts/zfs.Volumes/volumes.json
+++ b/tests/facts/zfs.Volumes/volumes.json
@@ -1,9 +1,19 @@
 {
-    "command": "zfs get -t volume -H all",
-    "output": ["tank/zvol1	compression	lz4	-"],
+    "command": "zfs get -H all",
+    "output": [
+        "tank\ttype\tfilesystem\t-",
+        "tank\tsize\t2.71T\t-",
+        "tank\tfeature@encryption\tenabled\tlocal",
+        "tank\tcom.sun:auto_snapshot\ttrue\t-",
+        "tank/home\ttype\tfilesystem\t-",
+        "tank/home\tcom.sun:auto_snapshot\ttrue\tinherited from tank",
+        "tank/home@old\ttype\tsnapshot\t-",
+        "tank/home@old\tencryption\toff\tdefault",
+        "tank/myvol\ttype\tvolume\t-"
+    ],
     "fact": {
-        "tank/zvol1": {
-            "compression": "lz4",
-        },
+        "tank/myvol": {
+            "type": "volume"
+        }
     }
 }

--- a/tests/operations/zfs.dataset/create.json
+++ b/tests/operations/zfs.dataset/create.json
@@ -1,0 +1,18 @@
+{
+  "args": [
+    "tank/home/james"
+  ],
+  "kwargs": {
+    "present": true,
+    "mountpoint": "/home/james",
+    "properties": {
+      "com.sun:auto_snapshot": "true"
+    }
+  },
+  "facts": {
+    "zfs.Datasets": {}
+  },
+  "commands": [
+    "zfs create -o com.sun:auto_snapshot=true -o mountpoint=/home/james tank/home/james"
+  ]
+}

--- a/tests/operations/zfs.dataset/create_noop.json
+++ b/tests/operations/zfs.dataset/create_noop.json
@@ -1,0 +1,18 @@
+{
+  "args": [
+    "tank/home/james"
+  ],
+  "kwargs": {
+    "present": true,
+    "compression": "lz4"
+  },
+  "facts": {
+    "zfs.Datasets": {
+        "tank/home/james": {
+            "compression": "lz4"
+        }
+    }
+  },
+  "commands": [],
+  "noop_description": "tank/home/james is already present"
+}

--- a/tests/operations/zfs.dataset/create_recursive.json
+++ b/tests/operations/zfs.dataset/create_recursive.json
@@ -1,0 +1,16 @@
+{
+  "args": [
+    "tank/myzvol"
+  ],
+  "kwargs": {
+    "present": true,
+    "recursive": true,
+    "compression": "lz4"
+  },
+  "facts": {
+    "zfs.Datasets": {}
+  },
+  "commands": [
+    "zfs create -o compression=lz4 -p tank/myzvol"
+  ]
+}

--- a/tests/operations/zfs.dataset/create_sparse.json
+++ b/tests/operations/zfs.dataset/create_sparse.json
@@ -1,0 +1,17 @@
+{
+  "args": [
+    "tank/myzvol"
+  ],
+  "kwargs": {
+    "present": true,
+    "sparse": true,
+    "compression": "lz4",
+    "volume_size": "5G"
+  },
+  "facts": {
+    "zfs.Datasets": {}
+  },
+  "commands": [
+    "zfs create -V 5G -o compression=lz4 -s tank/myzvol"
+  ]
+}

--- a/tests/operations/zfs.dataset/create_volume.json
+++ b/tests/operations/zfs.dataset/create_volume.json
@@ -1,0 +1,16 @@
+{
+  "args": [
+    "tank/myzvol"
+  ],
+  "kwargs": {
+    "present": true,
+    "compression": "lz4",
+    "volume_size": "5G"
+  },
+  "facts": {
+    "zfs.Datasets": {}
+  },
+  "commands": [
+    "zfs create -V 5G -o compression=lz4 tank/myzvol"
+  ]
+}

--- a/tests/operations/zfs.dataset/delete.json
+++ b/tests/operations/zfs.dataset/delete.json
@@ -1,0 +1,18 @@
+{
+  "args": [
+    "tank/home/james"
+  ],
+  "kwargs": {
+    "present": false
+  },
+  "facts": {
+    "zfs.Datasets": {
+      "tank/home/james": {
+        "mountpoint": "/home/james"
+      }
+    }
+  },
+  "commands": [
+    "zfs destroy  tank/home/james"
+  ]
+}

--- a/tests/operations/zfs.dataset/delete_noop.json
+++ b/tests/operations/zfs.dataset/delete_noop.json
@@ -1,0 +1,13 @@
+{
+  "args": [
+    "tank/home/james"
+  ],
+  "kwargs": {
+    "present": false
+  },
+  "facts": {
+    "zfs.Datasets": {}
+  },
+  "commands": [],
+  "noop_description": "tank/home/james is already absent"
+}

--- a/tests/operations/zfs.dataset/delete_recursive.json
+++ b/tests/operations/zfs.dataset/delete_recursive.json
@@ -1,0 +1,22 @@
+{
+  "args": [
+    "tank/home"
+  ],
+  "kwargs": {
+    "present": false,
+    "recursive": true
+  },
+  "facts": {
+    "zfs.Datasets": {
+      "tank/home": {
+        "mountpoint": "/home"
+      },
+      "tank/home/james": {
+        "mountpoint": "/home/james"
+      }
+    }
+  },
+  "commands": [
+    "zfs destroy -r tank/home"
+  ]
+}

--- a/tests/operations/zfs.dataset/set_props.json
+++ b/tests/operations/zfs.dataset/set_props.json
@@ -1,0 +1,25 @@
+{
+  "args": [
+    "tank/home/james"
+  ],
+  "kwargs": {
+    "present": true,
+    "mountpoint": "/home/james",
+    "compression": "lz4",
+    "properties": {
+      "com.sun:auto_snapshot": "true"
+    }
+  },
+  "facts": {
+    "zfs.Datasets": {
+        "tank/home/james": {
+            "compression": "zstd",
+            "mountpoint": "/home/james",
+            "com.sun:auto_snapshot": "false"
+        }
+    }
+  },
+  "commands": [
+    "zfs set com.sun:auto_snapshot=true compression=lz4 tank/home/james"
+  ]
+}

--- a/tests/operations/zfs.filesystem/create.json
+++ b/tests/operations/zfs.filesystem/create.json
@@ -1,0 +1,18 @@
+{
+  "args": [
+    "tank/home/james"
+  ],
+  "kwargs": {
+    "present": true,
+    "mountpoint": "/home/james",
+    "properties": {
+      "com.sun:auto_snapshot": "true"
+    }
+  },
+  "facts": {
+    "zfs.Datasets": {}
+  },
+  "commands": [
+    "zfs create -o com.sun:auto_snapshot=true -o mountpoint=/home/james tank/home/james"
+  ]
+}

--- a/tests/operations/zfs.filesystem/delete.json
+++ b/tests/operations/zfs.filesystem/delete.json
@@ -1,0 +1,18 @@
+{
+  "args": [
+    "tank/home/james"
+  ],
+  "kwargs": {
+    "present": false
+  },
+  "facts": {
+    "zfs.Datasets": {
+      "tank/home/james": {
+        "mountpoint": "/home/james"
+      }
+    }
+  },
+  "commands": [
+    "zfs destroy  tank/home/james"
+  ]
+}

--- a/tests/operations/zfs.snapshot/create.json
+++ b/tests/operations/zfs.snapshot/create.json
@@ -1,0 +1,17 @@
+{
+  "args": [
+    "tank/home/james@2024-02-29"
+  ],
+  "kwargs": {
+    "present": true,
+    "properties": {
+      "com.example:created_timestamp": "1583020799"
+    }
+  },
+  "facts": {
+    "zfs.Snapshots": {}
+  },
+  "commands": [
+    "zfs snap -o com.example:created_timestamp=1583020799 tank/home/james@2024-02-29"
+  ]
+}

--- a/tests/operations/zfs.volume/create.json
+++ b/tests/operations/zfs.volume/create.json
@@ -1,0 +1,15 @@
+{
+  "args": [
+    "tank/myzvol", "5G"
+  ],
+  "kwargs": {
+    "present": true,
+    "compression": "lz4"
+  },
+  "facts": {
+    "zfs.Datasets": {}
+  },
+  "commands": [
+    "zfs create -V 5G -o compression=lz4 tank/myzvol"
+  ]
+}


### PR DESCRIPTION
This MR adds facts and operations for dealing with ZFS filesystems, and tests to cover them.

Most of the logic is in `pyinfra.facts.zfs.Datasets` and `pyinfra.operations.zfs.dataset` ("dataset" being the broad ZFS term for either a filesystem, a block volume or a snapshot) but I've also added convenience functions for each specific type of dataset, to make it a little easier to understand when in use.