### PR TITLE
server/user_authorized_keys: Support multiple keys in a single file

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -881,11 +881,11 @@ def user_authorized_keys(
 
         if path.exists(try_path):
             with open(try_path, "r") as f:
-                return f.read().strip()
+                return [key.strip() for key in f.readlines()]
 
-        return key.strip()
+        return [key.strip()]
 
-    public_keys = list(map(read_any_pub_key_file, public_keys))
+    public_keys = [key for key_or_file in public_keys for key in read_any_pub_key_file(key_or_file)]
 
     # Ensure .ssh directory
     # note that this always outputs commands unless the SSH user has access to the


### PR DESCRIPTION
For each key argument passed to user_authorized_keys, if it refers to a local file that file is read and interpreted as a single key. Then for each of these keys, files.file is ran to check that the given key is present on the target.

However, when such a file contains multiple keys (which is not unreasonable, since the `~/.ssh/authorized_keys` file also can contain multiple keys), these would all be interpreted as a single key, and passed to files.file (and through there, to grep) as a single argument containing newlines. It seems this did not work as you would expect, and would (it seems) only check for presence of the first line not all of them (and even if it would check for all, then the order would be fixed instead of flexible).

This commit changes the reading of such local files to split into lines and then interpret each line as a different key, and check for each key separately, making this work as you would expect.