### PR TITLE
Quote systemd service name

### DIFF
--- a/pyinfra/operations/systemd.py
+++ b/pyinfra/operations/systemd.py
@@ -4,6 +4,8 @@ Manage systemd services.
 
 from __future__ import annotations
 
+import shlex
+
 from pyinfra import host
 from pyinfra.api import StringCommand, operation
 from pyinfra.facts.systemd import SystemdEnabled, SystemdStatus, _make_systemctl_cmd
@@ -140,8 +142,8 @@ def service(
 
         # Isn't enabled and want enabled?
         if not is_enabled and enabled is True:
-            yield "{0} enable {1}".format(systemctl_cmd, service)
+            yield "{0} enable {1}".format(systemctl_cmd, shlex.quote(service))
 
         # Is enabled and want disabled?
         elif is_enabled and enabled is False:
-            yield "{0} disable {1}".format(systemctl_cmd, service)
+            yield "{0} disable {1}".format(systemctl_cmd, shlex.quote(service))

--- a/pyinfra/operations/util/service.py
+++ b/pyinfra/operations/util/service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shlex
+
 from pyinfra.api import Host
 
 
@@ -19,26 +21,26 @@ def handle_service_control(
     # Need down but running
     if running is False:
         if is_running:
-            yield formatter.format(name, "stop")
+            yield formatter.format(shlex.quote(name), "stop")
         else:
             host.noop("service {0} is stopped".format(name))
 
     # Need running but down
     if running is True:
         if not is_running:
-            yield formatter.format(name, "start")
+            yield formatter.format(shlex.quote(name), "start")
         else:
             host.noop("service {0} is running".format(name))
 
     # Only restart if the service is already running
     if restarted and is_running:
-        yield formatter.format(name, "restart")
+        yield formatter.format(shlex.quote(name), "restart")
 
     # Only reload if the service is already reloaded
     if reloaded and is_running:
-        yield formatter.format(name, "reload")
+        yield formatter.format(shlex.quote(name), "reload")
 
     # Always execute arbitrary commands as these may or may not rely on the service
     # being up or down
     if command:
-        yield formatter.format(name, command)
+        yield formatter.format(shlex.quote(name), command)


### PR DESCRIPTION
Mount unit names can contain backslashes, because systemd escapes dashes in file names and requires unit names to match mount points. So a mount unit for `/my-mount` has to be started with `systemctl start my\x2dmount.mount` which fails at the moment.