### PR TITLE
facts/Which: switch to shell built-in

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -121,12 +121,12 @@ class Command(FactBase[str]):
 
 class Which(FactBase[Optional[str]]):
     """
-    Returns the path of a given command, if available.
+    Returns the path of a given command according to `command -v`, if available.
     """
 
     @staticmethod
     def command(command):
-        return "which {0} || true".format(command)
+        return "command -v {0} || true".format(command)
 
 
 class Date(FactBase[datetime]):

--- a/tests/facts/server.Which/which.json
+++ b/tests/facts/server.Which/which.json
@@ -1,6 +1,6 @@
 {
     "arg": "python",
-    "command": "which python || true",
+    "command": "command -v python || true",
     "output": ["/usr/local/bin/python"],
     "fact": "/usr/local/bin/python"
 }


### PR DESCRIPTION
`which` isn't a shell built-in and distributions started deprecating its usage [0].

The recommendation is to use `command -v` for scripts as a replacement.

[0]: https://salsa.debian.org/debian/debianutils/-/blob/5aeca1e3b14c08b5ab92995e91efcc2b3806a639/debian/NEWS#L7-16