### PR TITLE
Shallow copy data on retrieval from inventory

### DIFF
--- a/pyinfra/api/host.py
+++ b/pyinfra/api/host.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
+from copy import copy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -41,7 +42,6 @@ def extract_callable_datas(
         # the data is stored on the state temporarily.
         if callable(data):
             data = data()
-
         yield data
 
 
@@ -66,7 +66,10 @@ class HostData:
     def __getattr__(self, key: str):
         for data in extract_callable_datas(self.datas):
             try:
-                return data[key]
+                # Take a shallow copy of the object here, we don't want modifications
+                # to host.data.<X> to stick, instead setting host.data.<Y> = is the
+                # correct way to achieve this (see __setattr__).
+                return copy(data[key])
             except KeyError:
                 pass
 

--- a/tests/test_api/test_api_inventory.py
+++ b/tests/test_api/test_api_inventory.py
@@ -51,3 +51,24 @@ class TestInventoryApi(TestCase):
 
         assert inventory.get_host("somehost").data.override_data == "override_data"
         assert inventory.get_host("anotherhost").data.override_data == "override_data"
+
+    def test_inventory_group_data_not_shared(self):
+        group_data = {"test": {}}
+        hosts = ["hosthost", "anotherhost"]
+
+        inventory = Inventory(
+            (hosts, {}),
+            group=(hosts, group_data),
+        )
+
+        hosthost = inventory.get_host("hosthost")
+
+        # Test that modifying host.data.<X> *does not* stick (both on the same
+        # host and also other hosts).
+        hosthost.data.test["hi"] = "no"
+        assert hosthost.data.test == {}
+        assert inventory.get_host("anotherhost").data.test == {}
+
+        # Test that setting host.data.<X> *does* persist
+        hosthost.data.somethingelse = {"hello": "world"}
+        assert hosthost.data.somethingelse == {"hello": "world"}


### PR DESCRIPTION
Closes: #802

This prevents (in most cases) modification of shared inventory data objects that are fetched through the `host.data` object. Setting keys onto `host.data` still works as expected and is the correct way to handle this.