### PR TITLE
Update XBPS packaging system detection, fix:38dcd212

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -568,7 +568,7 @@ def packages(
     elif host.get_fact(Which, command="pacman"):
         package_operation = pacman.packages
 
-    elif host.get_fact(Which, command="xbps"):
+    elif host.get_fact(Which, command="xbps-install") or host.get_fact(Which, command="xbps"):
         package_operation = xbps.packages
 
     elif host.get_fact(Which, command="yum"):


### PR DESCRIPTION
Support for the XBPS package manager has been introduced by #342 by @Fizzadar and it's auto-detection in the "package" form in 38dcd21; unfortunately in the latter, there is no `xbps` command as far as I know, at least in the Void Linux distribution.

The output of [`xbps-query -f xbps`](https://man.voidlinux.org/xbps-query.1#f,) does not contains any `xbps` command; so I suggest to, at least, test `xbps-install` existence:

```
$ command -v xbps ; echo $?
1

$ xbps-query -f xbps
/usr/bin/xbps-alternatives
/usr/bin/xbps-checkvers
/usr/bin/xbps-create
/usr/bin/xbps-dgraph
/usr/bin/xbps-digest
/usr/bin/xbps-fbulk
/usr/bin/xbps-fetch
/usr/bin/xbps-install
/usr/bin/xbps-pkgdb
/usr/bin/xbps-query
/usr/bin/xbps-reconfigure
/usr/bin/xbps-remove
/usr/bin/xbps-rindex
/usr/bin/xbps-uchroot
/usr/bin/xbps-uhelper
/usr/bin/xbps-uunshare
/usr/share/bash-completion/completions/xbps
# ...
```

## System informations

uname -a:

    Linux dark-star 6.6.37_1 #1 SMP PREEMPT_DYNAMIC Fri Jul  5 15:49:51 UTC 2024 x86_64 GNU/Linux

lsb_release -a:

    LSB Version:    1.0
    Distributor ID: VoidLinux
    Description:    Void Linux
    Release:        rolling
    Codename:       void

cat /etc/os-release:
```sh
NAME="Void"
ID="void"
PRETTY_NAME="Void Linux"
HOME_URL="https://voidlinux.org/"
DOCUMENTATION_URL="https://docs.voidlinux.org/"
LOGO="void-logo"
ANSI_COLOR="0;38;2;71;128;97"

DISTRIB_ID="void"
```