### PR TITLE
Fix apt sources not being parsed correctly

### DIFF
--- a/pyinfra/facts/apt.py
+++ b/pyinfra/facts/apt.py
@@ -9,7 +9,7 @@ from .util import make_cat_files_command
 
 
 def parse_apt_repo(name):
-    regex = r"^(deb(?:-src)?)(?:\s+\[([^\]]+)\])?\s+([^\s]+)\s+([a-z-]+)\s+([a-z-\s]*)$"
+    regex = r"^(deb(?:-src)?)(?:\s+\[([^\]]+)\])?\s+([^\s]+)\s+([^\s]+)\s+([a-z-\s]*)$"
 
     matches = re.match(regex, name)
 

--- a/tests/facts/apt.AptSources/sources.json
+++ b/tests/facts/apt.AptSources/sources.json
@@ -2,6 +2,7 @@
     "output": [
         "deb http://archive.ubuntu.com/ubuntu trusty restricted",
         "deb-src [arch=amd64,i386] http://archive.ubuntu.com/ubuntu trusty main",
+        "deb [arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse",
         "nope"
     ],
     "command": "(! test -f /etc/apt/sources.list || cat /etc/apt/sources.list) && (cat /etc/apt/sources.list.d/*.list || true)",
@@ -25,6 +26,18 @@
             ],
             "options": {
                 "arch": ["amd64", "i386"]
+            }
+        },
+        {
+            "url": "https://repo.mongodb.org/apt/ubuntu",
+            "distribution": "jammy/mongodb-org/7.0",
+            "type": "deb",
+            "components": [
+                "multiverse"
+            ],
+            "options": {
+                "arch": ["amd64", "arm64"],
+                "signed-by": "/usr/share/keyrings/mongodb-server-7.0.gpg"
             }
         }
     ]


### PR DESCRIPTION
Hello! 

I recently started playing with pyinfra and encountered issue that after installing MongoDB I could not find related data in `AptSources` fact. 

Seems like that issue rooted in pyinfra expecting distribution name to comply with regexp `[a-z-]+`, but after quick research I did not found any requirements that distribution name cannot contain other symbols and as we can see mongodb developers do use those symbols. 

This PR updates regexp in `parse_apt_repo` function to be more permissive to distribution names and adds test for this scenario.

Reproduction of issue:
```python
from pyinfra import host
from pyinfra.operations import apt, server, python
from pyinfra.facts.apt import AptSources


def print_fact():
    print("facts", host.get_fact(AptSources))


apt.update()

apt.packages(
    packages=["curl", "gpg"]
)

server.shell(
    commands=[
        "curl -fsSL https://www.mongodb.org/static/pgp/server-7.0.asc | gpg -o /usr/share/keyrings/mongodb-server-7.0.gpg --dearmor",
        "echo 'deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-7.0.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse' | \
         tee /etc/apt/sources.list.d/mongodb-org-7.0.list > /dev/null"
    ]
)

python.call(
    function=print_fact
)
```  

Mongodb docs: https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu/