### PR TITLE
docs/using-operations.rst: fix _if example and extend it

### DIFF
--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -143,10 +143,27 @@ All operations return an operation meta object which provides information about 
         user="myuser",
     )
 
+    create_otheruser = server.user(
+        name="Create user otheruser",
+        user="otheruser",
+    )
+
     server.shell(
-        name="Bootstrap user",
+        name="Bootstrap myuser",
         commands=["..."],
-        _if=create_user,
+        _if=create_user.did_change,
+    )
+
+    # A list can be provided to run an operation if **all** functions return true
+    server.shell(
+        commands=["echo 'Both myuser and otheruser changed'"],
+        _if=[create_user.did_change, create_otheruser.did_change],
+    )
+
+    # You can also build your own lamba functions to achieve, e.g. an OR condition
+    server.shell(
+        commands=["echo 'myuser or otheruser changed'"],
+        _if=lambda: create_user.did_change() or create_otheruser.did_change(),
     )
 
 Operation Output


### PR DESCRIPTION
The current example for `_if` doesn't work, I've fixed it and extended it to also cover building "OR" cases, which are probably quite a common occurrence.