### PR TITLE
facts/systemd: sockets are in 'listening' state when running, add it …

### DIFF
--- a/pyinfra/facts/systemd.py
+++ b/pyinfra/facts/systemd.py
@@ -58,7 +58,7 @@ class SystemdStatus(FactBase[Dict[str, bool]]):
     default = dict
 
     state_key = "SubState"
-    state_values = ["running", "waiting", "exited"]
+    state_values = ["running", "waiting", "exited", "listening"]
 
     def command(
         self,


### PR DESCRIPTION
Untested, but this should fix `systemd.service` always being marked as `changed` when using it to start socket units.

This appears to be for sockets where the underlying service hasn't been started yet, but the socket unit is still active.
I wanted to do e.g. the following, but it would keep marking the operation as changed:

```python
systemd.service(service="podman.socket", running=True, enabled=True,
    user_mode=True,
    machine=".host", # FIXME: required for user_name to work
    user_name="runner",
    _sudo=True)
```

Draft, since this is just the idea for a fix, and this will probably require changes to the tests.