### PR TITLE
pyinfra/operations: fix crontab comparison

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -723,11 +723,11 @@ def crontab(
         if any(
             (
                 special_time != existing_crontab.get("special_time"),
-                minute != existing_crontab.get("minute"),
-                hour != existing_crontab.get("hour"),
-                month != existing_crontab.get("month"),
-                day_of_week != existing_crontab.get("day_of_week"),
-                day_of_month != existing_crontab.get("day_of_month"),
+                try_int(minute) != existing_crontab.get("minute"),
+                try_int(hour) != existing_crontab.get("hour"),
+                try_int(month) != existing_crontab.get("month"),
+                try_int(day_of_week) != existing_crontab.get("day_of_week"),
+                try_int(day_of_month) != existing_crontab.get("day_of_month"),
                 existing_crontab_command != command,
             ),
         ):

--- a/tests/operations/server.crontab/add_existing_int.json
+++ b/tests/operations/server.crontab/add_existing_int.json
@@ -1,0 +1,22 @@
+{
+    "args": ["this_is_a_command"],
+    "kwargs": {
+        "minute": "0",
+        "hour": "0"
+    },
+    "facts": {
+        "server.Crontab": {
+            "user=None": {
+                "this_is_a_command": {
+                    "minute": 0,
+                    "hour": 0,
+                    "month": "*",
+                    "day_of_week": "*",
+                    "day_of_month": "*"
+                }
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "crontab this_is_a_command exists"
+}


### PR DESCRIPTION
The Crontab fact tries to convert numerical values from 'str' to 'int', but the crontab operation was doing a direct comparison of the values provided (whether they were strings or ints).

Mimic what the Crontab fact does and use 'try_int' to compare. Also, add a test to confirm this behaviour doesn't regress.