### PR TITLE
Allow passing arguments to jinja2.Environment() when rendering templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ venv/
 .cache/
 .mypy_cache/
 .pytest_cache/
+.python-version
 
 .vagrant*
 

--- a/pyinfra/api/util.py
+++ b/pyinfra/api/util.py
@@ -139,12 +139,13 @@ def get_operation_order_from_stack(state: "State"):
     return line_numbers
 
 
-def get_template(filename_or_io: str | IO):
+def get_template(filename_or_io: str | IO, jinja_env_kwargs: dict[str, Any] | None = None):
     """
     Gets a jinja2 ``Template`` object for the input filename or string, with caching
     based on the filename of the template, or the SHA1 of the input string.
     """
-
+    if jinja_env_kwargs is None:
+        jinja_env_kwargs = {}
     file_data = get_file_io(filename_or_io, mode="r")
     cache_key = file_data.cache_key
 
@@ -158,6 +159,7 @@ def get_template(filename_or_io: str | IO):
         undefined=StrictUndefined,
         keep_trailing_newline=True,
         loader=FileSystemLoader(getcwd()),
+        **jinja_env_kwargs,
     ).from_string(template_string)
 
     if cache_key:

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -915,7 +915,8 @@ def template(
     user: str | None = None,
     group: str | None = None,
     mode: str | None = None,
-    create_remote_dir=True,
+    create_remote_dir: bool = True,
+    jinja_env_kwargs: dict[str, Any] | None = None,
     **data,
 ):
     '''
@@ -927,11 +928,17 @@ def template(
     + group: group to own the files
     + mode: permissions of the files
     + create_remote_dir: create the remote directory if it doesn't exist
+    + jinja_env_kwargs: keyword arguments to be passed into the jinja Environment()
 
     ``create_remote_dir``:
         If the remote directory does not exist it will be created using the same
         user & group as passed to ``files.put``. The mode will *not* be copied over,
         if this is required call ``files.directory`` separately.
+
+    ``jinja_env_kwargs``:
+        To have more control over how jinja2 renders your template, you can pass
+        a dict with arguments that will be passed as keyword args to the jinja2
+        `Environment() <https://jinja.palletsprojects.com/en/3.0.x/api/#jinja2.Environment>`_.
 
     Notes:
        Common convention is to store templates in a "templates" directory and
@@ -1002,7 +1009,7 @@ def template(
 
     # Render and make file-like it's output
     try:
-        output = get_template(src).render(data)
+        output = get_template(src, jinja_env_kwargs).render(data)
     except (TemplateRuntimeError, TemplateSyntaxError, UndefinedError) as e:
         trace_frames = [
             frame


### PR DESCRIPTION
It seems that with the current test setup we can only create unit tests for operations that check the commands that are being yielded by those operations. I don't see an easy option to create a test to verify that the `jinja_env_kwargs` passed into the `files.template()` operation are being passed onto the jinja2 `Environment()`.

If you want to me to write a test for that, you'll have to give me some pointers :)