### PR TITLE
systemd: assume localhost if user is given but not machine

### DIFF
--- a/pyinfra/facts/systemd.py
+++ b/pyinfra/facts/systemd.py
@@ -32,6 +32,9 @@ def _make_systemctl_cmd(user_mode=False, machine=None, user_name=None):
             systemctl_cmd.append("--machine={1}@{0}".format(machine, user_name))
         else:
             systemctl_cmd.append("--machine={0}".format(machine))
+    elif user_name is not None:
+        # If only the user is given, assume that the connection should be made to the local machine
+        systemctl_cmd.append("--machine={0}@.host".format(user_name))
 
     return StringCommand(*systemctl_cmd)
 


### PR DESCRIPTION
Should make the `machine=".host"` redundant in `systemd` facts and operations.