### PR TITLE
server.reboot operation quickfix

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -94,7 +94,7 @@ def reboot(delay=10, interval=1, reboot_timeout=300):
 
         while True:
             host.connect(show_errors=False)
-            if host.connection:
+            if host.connected:
                 break
 
             if retries > max_retries:


### PR DESCRIPTION
Implements the quick fix from https://github.com/pyinfra-dev/pyinfra/issues/1110#issuecomment-2155997354

While it does not fix #1110 completely, it at least makes `server.reboot` work again.

Currently based on #1177 

Tested, and it seems to have worked:

```sh
$ pyinfra inventory.py --limit myserver --sudo server.reboot                                  
--> Loading config...
--> Loading inventory...
--> Connecting to hosts...
    [myserver] Connected

--> Preparing operations...
--> Preparing operation...
    [myserver] Ready: reboot

--> Detected changes:
    Operation       Change                                Conditional Change   
    server.reboot   1 (myserver)   -                    

    Detected changes may not include every change pyinfra will execute.
    Hidden side effects of operations may alter behaviour of future operations,
    this will be shown in the results. The remote state will always be updated
    to reflect the state defined by the input operations.

    Detected changes displayed above, skip this step with -y
                             
--> Beginning operation run...
--> Starting operation: server.reboot 
    [myserver] Success

--> Results:
    Operation       Hosts   Success   Error   No Change   
    server.reboot   1       1         -       -           

--> Disconnecting from hosts...
```