### PR TITLE
Fix `server.reboot` operation

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -89,7 +89,7 @@ def reboot(delay=10, interval=1, reboot_timeout=300):
         sleep(delay)
         max_retries = round(reboot_timeout / interval)
 
-        host.connection = None  # remove the connection object
+        host.connected = False  # assume disconnected state after reboot
         retries = 0
 
         while True:


### PR DESCRIPTION
Code was still using a deprecated `host.connection` variable, it has been properly updated to use `host.connected` now.

This follows up on this https://github.com/pyinfra-dev/pyinfra/pull/1178 and fixes https://github.com/pyinfra-dev/pyinfra/issues/1194 I believe.