### PR TITLE
Docs: Add basic localhost example to "Using the API" page

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -39,14 +39,14 @@ Basic Localhost Example
    connect_all(state)
 
    # Start adding operations
-   add_op(
+   result1 = add_op(
        state,
        server.user,
        user="pyinfra",
        home="/home/pyinfra",
        shell="/bin/bash",
    )
-   add_op(
+   result2 = add_op(
        state,
        server.shell,
        name="Run some shell commands",
@@ -55,6 +55,11 @@ Basic Localhost Example
 
    # And finally we run the ops
    run_ops(state)
+
+   # add_op returns an OperationMeta for each op, letting you access stdout, stderr, etc. after they run
+   host = state.hosts.inventory['@local']
+   print(result1.changed, result1[host].stdout, result1[host].stderr)
+   print(result2.changed, result2[host].stdout, result2[host].stderr)
 
    # We can also get facts for all the hosts
    # https://docs.pyinfra.com/en/3.x/apidoc/pyinfra.api.facts.html

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -3,4 +3,59 @@ Using the API
 
 In addition to :doc:`the pyinfra CLI <../cli>`, pyinfra provides a full Python API. As of ``v3`` this API can be considered mostly stable. See the :doc:`./reference`.
 
-`An example of how to use the API can be found here <https://github.com/pyinfra-dev/pyinfra-examples/blob/main/.old/api_deploy.py>`_. Note: this is not yet tested and pending future updates.
+You can also reference `pyinfra's own main.py <https://github.com/pyinfra-dev/pyinfra/blob/3.x/pyinfra_cli/main.py>`_, and the `pyinfra API source code <https://github.com/pyinfra-dev/pyinfra/tree/3.x/pyinfra/api>`_.
+
+Full Example
+============
+
+`A full example of how to use the API can be found here <https://github.com/pyinfra-dev/pyinfra-examples/blob/main/.old/api_deploy.py>`_. (Note: this is not yet tested and is pending future updates)
+
+Basic Localhost Example
+=======================
+
+.. code:: python
+
+   from pyinfra.api import Config, Inventory, State
+   from pyinfra.api.connect import connect_all
+   from pyinfra.api.operation import add_op
+   from pyinfra.api.operations import run_ops
+   from pyinfra.api.facts import get_facts
+   from pyinfra.facts.server import Os
+   from pyinfra.operations import server
+
+   # Define your inventory (@local means execute on localhost using subprocess)
+   # https://docs.pyinfra.com/en/3.x/apidoc/pyinfra.api.inventory.html
+   inventory = Inventory((["@local"], {}))
+
+   # Define any config you need
+   # https://docs.pyinfra.com/en/3.x/apidoc/pyinfra.api.config.html
+   config = Config(SUDO=True)
+
+   # Set up the state object
+   # https://docs.pyinfra.com/en/3.x/apidoc/pyinfra.api.state.html
+   state = State(inventory=inventory, config=config)
+
+   # Connect to all the hosts
+   connect_all(state)
+
+   # Start adding operations
+   add_op(
+       state,
+       server.user,
+       user="pyinfra",
+       home="/home/pyinfra",
+       shell="/bin/bash",
+   )
+   add_op(
+       state,
+       server.shell,
+       name="Run some shell commands",
+       commands=["whoami", "echo $PATH", "bash --version"]
+   )
+
+   # And finally we run the ops
+   run_ops(state)
+
+   # We can also get facts for all the hosts
+   # https://docs.pyinfra.com/en/3.x/apidoc/pyinfra.api.facts.html
+   print(get_facts(state, Os))


### PR DESCRIPTION
Fixes: https://github.com/pyinfra-dev/pyinfra/issues/1211

This aims to improve the "getting started with the API" experience a bit:

- add link to API source code
- moves `.old/api_deploy.py` link to a `Full Example` section
- add `Basic Localhost Example` section
  - clearly shows what imports are necessary
  - demonstrates setting up an inventory using `@local` for localhost
  - demonstrates setting up a `Config` with `SUDO=True`
  - includes links to API References docs on `Inventory`, `Config`, and `facts`
  - demonstrates how to run ops and collect facts afterwards
