### PR TITLE
pyinfra/connectors: Fixed broken get for non-utf8 files (#1208)

### DIFF
--- a/pyinfra/connectors/chroot.py
+++ b/pyinfra/connectors/chroot.py
@@ -174,7 +174,7 @@ class ChrootConnector(BaseConnector):
             )
 
             # Load the temporary file and write it to our file or IO object
-            with open(temp_filename, encoding="utf-8") as temp_f:
+            with open(temp_filename, "rb") as temp_f:
                 with get_file_io(filename_or_io, "wb") as file_io:
                     data = temp_f.read()
                     data_bytes: bytes

--- a/pyinfra/connectors/local.py
+++ b/pyinfra/connectors/local.py
@@ -184,7 +184,7 @@ class LocalConnector(BaseConnector):
                 raise IOError(output.stderr)
 
             # Load our file or IO object and write it to the temporary file
-            with open(temp_filename, encoding="utf-8") as temp_f:
+            with open(temp_filename, "rb") as temp_f:
                 with get_file_io(filename_or_io, "wb") as file_io:
                     data_bytes: bytes
 


### PR DESCRIPTION
A small fix that allows for using the "get" operator on files with different encoding than utf8, which currently results in a UnicodeDecodeError. This fix should allow the get operation to be more encoding-agnostic. 

There is an example project in #1208 that demonstrates the currently broken behavior.