### PR TITLE
Parse os-release for Servers Incompatible with lsb_release

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -307,6 +307,43 @@ class LsbRelease(FactBase):
         return items
 
 
+class OsRelease(FactBase):
+    """
+    Returns a dictionary of release information stored in ``/etc/os-release``.
+
+    .. code:: python
+
+        {
+          "name": "EndeavourOS",
+          "pretty_name": "EndeavourOS",
+          "id": "endeavouros",
+          "id_like": "arch",
+          "build_id": "2024.06.25",
+          ...
+        }
+    """
+
+    def command(self):
+        return "cat /etc/os-release"
+
+    def process(self, output):
+        items = {}
+
+        for line in output:
+            if "=" not in line:
+                continue
+
+            key, value = line.split("=", 1)
+            key = key.strip().lower()
+
+            value = value.strip()
+            value = value.strip('"')
+
+            items[key] = value
+
+        return items
+
+
 class Sysctl(FactBase):
     """
     Returns a dictionary of sysctl settings and values.

--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -330,16 +330,9 @@ class OsRelease(FactBase):
         items = {}
 
         for line in output:
-            if "=" not in line:
-                continue
-
-            key, value = line.split("=", 1)
-            key = key.strip().lower()
-
-            value = value.strip()
-            value = value.strip('"')
-
-            items[key] = value
+            if "=" in line:
+                key, value = line.split("=", 1)
+                items[key.strip().lower()] = value.strip().strip('"')
 
         return items
 


### PR DESCRIPTION

# Summary

This PR adds support for extracting OS info from servers that don't support `lsb_release` by parsing the `os-release` file.

# Benefits

- Ensures compatibility with lightweight distributions that lack `lsb_release`.
- Provides more consistent OS information across different environments.
