### PR TITLE
Custom data via `pyinfra.local.include`

### DIFF
--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -227,6 +227,37 @@ Including files can be used to break out operations across multiple files. Files
     # Include & call all the operations in tasks/install_something.py
     local.include("tasks/install_something.py")
 
+Additional data can be passed across files via the ``data`` param to parameterize tasks and is available in ``host.data``. For example `tasks/create_user.py` could look like:
+
+.. code:: python
+
+    from getpass import getpass
+
+    from pyinfra import host
+    from pyinfra.operations import server
+
+    group = host.data.get("group")
+    user = host.data.get("user")
+
+    server.group(
+        name=f"Ensure {group} is present",
+        group=group,
+    )
+    server.user(
+        name=f"Ensure {user} is present",
+        user=user,
+        group=group,
+    )
+
+And and be called by other deploy scripts or tasks:
+
+.. code:: python
+
+    from pyinfra import local
+
+    for group, user in (("admin", "Bob"), ("admin", "Joe")):
+        local.include("tasks/create_user.py", data={"group": group, "user": user})
+
 See more in :doc:`examples: groups & roles <./examples/groups_roles>`.
 
 

--- a/pyinfra/local.py
+++ b/pyinfra/local.py
@@ -1,4 +1,5 @@
 from os import path
+from typing import Any, Optional
 
 import click
 
@@ -10,7 +11,7 @@ from pyinfra.connectors.util import run_local_process
 from pyinfra.context import ctx_state
 
 
-def include(filename: str):
+def include(filename: str, data: Optional[dict[str, Any]] = None):
     """
     Executes a local python file within the ``pyinfra.state.cwd``
     directory.
@@ -33,7 +34,7 @@ def include(filename: str):
 
         from pyinfra_cli.util import exec_file
 
-        with host.deploy(path.relpath(filename, state.cwd), None, None, in_deploy=False):
+        with host.deploy(path.relpath(filename, state.cwd), None, data, in_deploy=False):
             exec_file(filename)
 
         # One potential solution to the above is to add local as an actual

--- a/pyinfra/local.py
+++ b/pyinfra/local.py
@@ -1,5 +1,5 @@
 from os import path
-from typing import Any, Optional
+from typing import Optional
 
 import click
 
@@ -11,7 +11,7 @@ from pyinfra.connectors.util import run_local_process
 from pyinfra.context import ctx_state
 
 
-def include(filename: str, data: Optional[dict[str, Any]] = None):
+def include(filename: str, data: Optional[dict] = None):
     """
     Executes a local python file within the ``pyinfra.state.cwd``
     directory.

--- a/tests/test_cli/deploy/deploy.py
+++ b/tests/test_cli/deploy/deploy.py
@@ -47,6 +47,9 @@ elif host.name == "anotherhost":
 # Include the whole file again, but for all hosts
 local.include(path.join("tasks", "a_task.py"))
 
+# Include a deploy file, with custom specified data
+local.include(path.join("tasks", "b_task.py"), data={"keyword": "Important", "id": 1})
+
 # Execute the @deploy function
 my_deploy()
 

--- a/tests/test_cli/deploy/tasks/b_task.py
+++ b/tests/test_cli/deploy/tasks/b_task.py
@@ -1,0 +1,7 @@
+from pyinfra import host
+from pyinfra.operations import server
+
+server.shell(
+    name=f"{host.data.get('keyword')} task operation",
+    commands=f"echo {host.data.get('id')}",
+)

--- a/tests/test_cli/test_cli_deploy.py
+++ b/tests/test_cli/test_cli_deploy.py
@@ -43,26 +43,28 @@ class TestCliDeployState(PatchSSHTestCase):
                     assert executed is False
 
     def test_deploy(self):
-        task_file_path = path.join("tasks", "a_task.py")
+        a_task_file_path = path.join("tasks", "a_task.py")
+        b_task_file_path = path.join("tasks", "b_task.py")
         nested_task_path = path.join("tasks", "another_task.py")
         correct_op_name_and_host_names = [
             ("First main operation", True),  # true for all hosts
             ("Second main operation", ("somehost",)),
-            ("{0} | First task operation".format(task_file_path), ("anotherhost",)),
-            ("{0} | Task order loop 1".format(task_file_path), ("anotherhost",)),
-            ("{0} | 2nd Task order loop 1".format(task_file_path), ("anotherhost",)),
-            ("{0} | Task order loop 2".format(task_file_path), ("anotherhost",)),
-            ("{0} | 2nd Task order loop 2".format(task_file_path), ("anotherhost",)),
+            ("{0} | First task operation".format(a_task_file_path), ("anotherhost",)),
+            ("{0} | Task order loop 1".format(a_task_file_path), ("anotherhost",)),
+            ("{0} | 2nd Task order loop 1".format(a_task_file_path), ("anotherhost",)),
+            ("{0} | Task order loop 2".format(a_task_file_path), ("anotherhost",)),
+            ("{0} | 2nd Task order loop 2".format(a_task_file_path), ("anotherhost",)),
             (
-                "{0} | {1} | Second task operation".format(task_file_path, nested_task_path),
+                "{0} | {1} | Second task operation".format(a_task_file_path, nested_task_path),
                 ("anotherhost",),
             ),
-            ("{0} | First task operation".format(task_file_path), True),
-            ("{0} | Task order loop 1".format(task_file_path), True),
-            ("{0} | 2nd Task order loop 1".format(task_file_path), True),
-            ("{0} | Task order loop 2".format(task_file_path), True),
-            ("{0} | 2nd Task order loop 2".format(task_file_path), True),
-            ("{0} | {1} | Second task operation".format(task_file_path, nested_task_path), True),
+            ("{0} | First task operation".format(a_task_file_path), True),
+            ("{0} | Task order loop 1".format(a_task_file_path), True),
+            ("{0} | 2nd Task order loop 1".format(a_task_file_path), True),
+            ("{0} | Task order loop 2".format(a_task_file_path), True),
+            ("{0} | 2nd Task order loop 2".format(a_task_file_path), True),
+            ("{0} | {1} | Second task operation".format(a_task_file_path, nested_task_path), True),
+            ("{0} | Important task operation".format(b_task_file_path), True),
             ("My deploy | First deploy operation", True),
             ("My deploy | My nested deploy | First nested deploy operation", True),
             ("My deploy | Second deploy operation", True),


### PR DESCRIPTION
This PR addresses #1173 by adding a `data` argument for parameterizing tasks making it simpler to reuse tasks across deploy or other task scripts. A quick example would be creating a new system user to run redis, mysql, etc., that could be called by the task that configures those services. 

This PR also includes a brief addition to the testing suite to demonstrate the changes and a light addition to the documentation. In particular if there's feedback on the unit testing that would be appreciated, I wasn't sure how detailed to make the testing changes or the best strategy for testing the new addition.