### PR TITLE
CI: Use macos-13 instead of macos-12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
         os: [ubuntu-20.04, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         include:
-          - os: macos-12
+          - os: macos-13
             python-version: "3.11"
           - os: windows-2022
             python-version: "3.11"


### PR DESCRIPTION
The image is deprecated: https://github.com/actions/runner-images/issues/10721

There will be _brownouts_ (failed builds) in November and it is destined to be removed in early December.