### PR TITLE
pyinfra/operations: Handle latest value in installing pip requirements file

### DIFF
--- a/pyinfra/operations/pip.py
+++ b/pyinfra/operations/pip.py
@@ -174,12 +174,13 @@ def packages(
         install_command_args.append(extra_install_args)
     install_command = " ".join(install_command_args)
 
+    upgrade_command = "{0} --upgrade".format(install_command)
     uninstall_command = " ".join([pip, "uninstall", "--yes"])
 
     # (un)Install requirements
     if requirements is not None:
         if present:
-            yield "{0} -r {1}".format(install_command, requirements)
+            yield "{0} -r {1}".format(upgrade_command if latest else install_command, requirements)
         else:
             yield "{0} -r {1}".format(uninstall_command, requirements)
 
@@ -199,7 +200,7 @@ def packages(
             present,
             install_command=install_command,
             uninstall_command=uninstall_command,
-            upgrade_command="{0} --upgrade".format(install_command),
+            upgrade_command=upgrade_command,
             version_join="==",
             latest=latest,
         )

--- a/tests/operations/pip.packages/install_latest_requirements.json
+++ b/tests/operations/pip.packages/install_latest_requirements.json
@@ -1,0 +1,12 @@
+{
+    "kwargs": {
+        "latest": true,
+        "requirements": "requirements.txt"
+    },
+    "facts": {},
+    "commands": [
+        "pip install --upgrade -r requirements.txt"
+    ],
+    "idempotent": false,
+    "disable_idempotent_warning_reason": "pip package requirements are always executed"
+}


### PR DESCRIPTION
Currently in the pip.packages operation, the `latest` parameter is only handled when packages argument is passed. This PR adds `--upgrade` to the final command when only a requirements file is specified.