### PR TITLE
Add informations on cli output about module when fact or operation was not found

### DIFF
--- a/tests/test_cli/test_cli_exceptions.py
+++ b/tests/test_cli/test_cli_exceptions.py
@@ -44,7 +44,13 @@ class TestCliExceptions(TestCase):
     def test_no_fact_cls(self):
         self.assert_cli_exception(
             ["my-server.net", "fact", "server.NotAFact"],
-            "No such attribute in module server: NotAFact",
+            (
+                "No such attribute in module server: NotAFact\n"
+                "Available facts in module are: User, Home, Path, TmpDir, Hostname, Kernel, "
+                "KernelVersion, Os, OsVersion, Arch, Command, Which, Date, MacosVersion, Mounts, "
+                "KernelModules, LsbRelease, OsRelease, Sysctl, Groups, Users, LinuxDistribution, "
+                "Selinux, LinuxGui, Locales, SecurityLimits"
+            ),
         )
 
 

--- a/tests/test_cli/test_cli_util.py
+++ b/tests/test_cli/test_cli_util.py
@@ -32,11 +32,16 @@ class TestCliUtil(TestCase):
             get_func_and_args(("no.op",))
         assert context.exception.message == "No such module: no"
 
-    def test_setup_no_op(self):
+    def test_setup_not_exists_op(self):
         with self.assertRaises(CliError) as context:
-            get_func_and_args(("server.no",))
+            get_func_and_args(("server.not_exists",))
 
-        assert context.exception.message == "No such attribute in module server: no"
+        assert context.exception.message == (
+            "No such attribute in module server: not_exists\n"
+            "Available operations are: reboot, wait, shell, script, script_template, "
+            "modprobe, mount, hostname, sysctl, service, packages, crontab, group, "
+            "user_authorized_keys, user, locale, security_limit"
+        )
 
     def test_setup_op_and_args(self):
         commands = ("pyinfra.operations.server.user", "one", "two", "hello=world")

--- a/tests/test_cli/test_cli_util.py
+++ b/tests/test_cli/test_cli_util.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from datetime import datetime
 from io import StringIO
@@ -36,12 +37,13 @@ class TestCliUtil(TestCase):
         with self.assertRaises(CliError) as context:
             get_func_and_args(("server.not_exists",))
 
-        assert context.exception.message == (
-            "No such attribute in module server: not_exists\n"
-            "Available operations are: reboot, wait, shell, script, script_template, "
-            "modprobe, mount, hostname, sysctl, service, packages, crontab, group, "
-            "user_authorized_keys, user, locale, security_limit"
-        )
+        for part in [
+            r"^No such attribute in module server: not_exists$",
+            r"Available operations are: .*",
+            r".* modprobe, .*",
+            r".* mount, .*",
+        ]:
+            assert re.search(part, context.exception.message, re.MULTILINE)
 
     def test_setup_op_and_args(self):
         commands = ("pyinfra.operations.server.user", "one", "two", "hello=world")


### PR DESCRIPTION
Hello folks,

If the operation or fact was not found, it will display the ones available, and if no one is available, Warn the user about the possibility that he have a py file or a folder with the same name as the module

If you have a directory wich have the same name as the pyinfra module you want to use, pyinfra will try to look inside form the operations/facts (wich seems to be the wanted behavior)

So I added a message to inform about this possibility if the module/fact is not found:
```
find . -name incus
./incus
pyinfra inventory.py --debug --limit=lx1 fact incus.IncusProfiles
--> pyinfra error: No such attribute in module incus: IncusProfiles
No facts found. Maybe you have a file or folder named `incus` in the current folder ?
```


In the same time I added this:

```
pyinfra inventory.py --debug --limit=lx1 fact incus.IncusProfilesNOEXIST
--> pyinfra error: No such attribute in module incus: IncusProfilesNOEXIST
Available facts in module are: IncusInstances, IncusProfiles, IncusTestFact
```

This is a suggestion, tell me what you think.