### PR TITLE
pyinfra/connectors: Fix overwriting of users known_hosts file (#1209)

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -13,6 +13,7 @@ extend-ignore-re = [
     "forr something in",
     "unknown tag 'forr'",
     "nd6 options=",
+    "4Ue1", # Ignore false positive in test_sshuserclient.py (EXAMPLE_KEY_1)
 ]
 
 [default.extend-words]


### PR DESCRIPTION
This fixes issue #1209, making it so that we append new keys to the users known_hosts file instead of overwriting it.

Additionally:
- Added a testcase that should discover this breaking in the future
- Broke out the append functionality into a "append_hostkey" function, making it so we don't needlessly reuse code for AskPolicy 
- Linting actually correct this time.
- Merged commits correctly this time. 

Previous behaviour when adding a new 
- Create a paramiko.HostKeys object 
- Read the users known_hosts file  
- Add the new key to the paramiko object.  
- Save the object, overwriting the users host_keys file without comments and entries incompatible with paramiko. 

New behaviour:
- Create a paramiko.HostKeyEntry object using the new hostname and
corresponding key.
- Append this key to the existing known_hosts file.