### PR TITLE
Fix docker.network() documentation and network removal

### DIFF
--- a/pyinfra/operations/docker.py
+++ b/pyinfra/operations/docker.py
@@ -231,8 +231,8 @@ def network(
     """
     Manage docker networks
 
-    + network_name: Image name
-    + driver: Container image and tag ex: nginx:alpine
+    + network: Network name
+    + driver: Network driver ex: bridge or overlay
     + gateway: IPv4 or IPv6 Gateway for the master subnet
     + ip_range: Allocate container ip from a sub-range
     + ipam_driver: IP Address Management Driver
@@ -251,8 +251,7 @@ def network(
 
         # Create Docker network
         docker.network(
-            name="Create nginx network",
-            network_name="nginx",
+            network="nginx",
             attachable=True,
             present=True,
         )

--- a/pyinfra/operations/docker.py
+++ b/pyinfra/operations/docker.py
@@ -288,7 +288,7 @@ def network(
 
         yield handle_docker(
             resource="network",
-            command="create",
+            command="remove",
             network=network,
         )
 

--- a/tests/operations/docker.network/remove_network.json
+++ b/tests/operations/docker.network/remove_network.json
@@ -1,0 +1,14 @@
+{
+    "kwargs": {
+        "network": "nginx",
+        "present": false
+    },
+    "facts": {
+        "docker.DockerNetwork": {
+            "object_id=nginx": []
+        }
+    },
+    "commands": [
+        "docker network rm nginx"
+    ]
+}


### PR DESCRIPTION
The `docker.network()` operation's documentation no longer matched the actual
API. Adapt it accordingly.

Additionally, fix network removal which passed an incorrect `command` to
`handle_docker`.
