### PR TITLE
Parse test spec files with PyYAML instead of json

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ TEST_REQUIRES = (
     "flake8==7.1.1",
     "flake8-black==0.3.6",
     "flake8-isort==6.1.1",
+    "pyyaml==6.0.2",
     # Typing
     "mypy",
     "types-cryptography",

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -8,7 +8,7 @@ from pyinfra.api import StringCommand
 from pyinfra.api.facts import ShortFactBase
 from pyinfra_cli.util import json_encode
 
-from .util import JsonTest, get_command_string
+from .util import YamlTest, get_command_string
 
 # show full diff on json
 TestCase.maxDiff = None
@@ -31,11 +31,11 @@ def make_fact_tests(folder_name):
     module = import_module("pyinfra.facts.{0}".format(module_name))
     fact = getattr(module, fact_name)()
 
-    class TestTests(TestCase, metaclass=JsonTest):
-        jsontest_files = path.join("tests", "facts", folder_name)
-        jsontest_prefix = "test_{0}_".format(fact.name)
+    class TestTests(TestCase, metaclass=YamlTest):
+        yaml_test_dir = path.join("tests", "facts", folder_name)
+        yaml_test_prefix = "test_{0}_".format(fact.name)
 
-        def jsontest_function(self, test_name, test_data, fact=fact):
+        def yaml_test_function(self, test_name, test_data, fact=fact):
             short_fact = None
 
             if isinstance(fact, ShortFactBase):
@@ -46,7 +46,9 @@ def make_fact_tests(folder_name):
             command = _make_command(fact.command, test_args)
 
             if "command" in test_data:
-                assert get_command_string(StringCommand(command)) == test_data["command"]
+                assert (
+                    get_command_string(StringCommand(command)) == test_data["command"]
+                )
             else:
                 warnings.warn(
                     'No command set for test: {0} (got "{1}")'.format(

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -6,11 +6,23 @@ from os import listdir, path
 from unittest import TestCase
 from unittest.mock import patch
 
-from pyinfra.api import FileDownloadCommand, FileUploadCommand, FunctionCommand, StringCommand
+from pyinfra.api import (
+    FileDownloadCommand,
+    FileUploadCommand,
+    FunctionCommand,
+    StringCommand,
+)
 from pyinfra.context import ctx_host, ctx_state
 from pyinfra_cli.util import json_encode
 
-from .util import FakeState, JsonTest, create_host, get_command_string, parse_value, patch_files
+from .util import (
+    FakeState,
+    YamlTest,
+    create_host,
+    get_command_string,
+    parse_value,
+    patch_files,
+)
 
 PLATFORM_NAME = platform.system()
 
@@ -31,7 +43,9 @@ def parse_commands(commands):
 
         elif isinstance(command, FunctionCommand):
             func_name = (
-                command.function if command.function == "__func__" else command.function.__name__
+                command.function
+                if command.function == "__func__"
+                else command.function.__name__
             )
             json_command = [
                 func_name,
@@ -92,16 +106,16 @@ def make_operation_tests(arg):
     # Generate a test class
     @patch("pyinfra.operations.files.get_timestamp", lambda: "a-timestamp")
     @patch("pyinfra.operations.util.files.get_timestamp", lambda: "a-timestamp")
-    class TestTests(TestCase, metaclass=JsonTest):
-        jsontest_files = path.join("tests", "operations", arg)
-        jsontest_prefix = "test_{0}_{1}_".format(module_name, op_name)
+    class TestTests(TestCase, metaclass=YamlTest):
+        yaml_test_dir = path.join("tests", "operations", arg)
+        yaml_test_prefix = "test_{0}_{1}_".format(module_name, op_name)
 
         @classmethod
         def setUpClass(cls):
             # Create a global fake state that attach to context state
             cls.state = FakeState()
 
-        def jsontest_function(self, test_name, test_data):
+        def yaml_test_function(self, test_name, test_data):
             if (
                 "require_platform" in test_data
                 and PLATFORM_NAME not in test_data["require_platform"]
@@ -127,7 +141,9 @@ def make_operation_tests(arg):
                             if allowed_exception:
                                 allowed_exception_names = allowed_exception.get("names")
                                 if not allowed_exception_names:
-                                    allowed_exception_names = [allowed_exception["name"]]
+                                    allowed_exception_names = [
+                                        allowed_exception["name"]
+                                    ]
 
                                 if e.__class__.__name__ not in allowed_exception_names:
                                     print("Wrong exception raised!")
@@ -146,7 +162,9 @@ def make_operation_tests(arg):
                 if noop_description is not None:
                     assert host.noop_description == noop_description
                 else:
-                    assert host.noop_description is not None, "no noop description was set"
+                    assert host.noop_description is not None, (
+                        "no noop description was set"
+                    )
                     warnings.warn(
                         'No noop_description set for test: {0} (got "{1}")'.format(
                             op_test_name,

--- a/tests/util.py
+++ b/tests/util.py
@@ -197,9 +197,9 @@ class FakeHost:
         real_args = getfullargspec(fact_cls.command).args
 
         for key in kwargs.keys():
-            assert (
-                key in real_args
-            ), f"Argument {key} is not a real argument in the `{fact_cls}.command` method"
+            assert key in real_args, (
+                f"Argument {key} is not a real argument in the `{fact_cls}.command` method"
+            )
 
     def get_fact(self, fact_cls, *args, **kwargs):
         fact_key = self._get_fact_key(fact_cls)
@@ -363,7 +363,9 @@ class patch_files:
 
         for child in child_dirs:
             full_child = path.join(dirname, child)
-            for recursive_return in self.walk(full_child, topdown, onerror, followlinks):
+            for recursive_return in self.walk(
+                full_child, topdown, onerror, followlinks
+            ):
                 yield recursive_return
 
 
@@ -382,32 +384,28 @@ def create_host(name=None, facts=None, data=None):
     return FakeHost(name, facts=real_facts, data=data)
 
 
-class JsonTest(type):
+class YamlTest(type):
     def __new__(cls, name, bases, attrs):
-        # Get the JSON files
-        files = listdir(attrs["jsontest_files"])
-        files = [f for f in files if f.endswith(".json")]
+        test_suffixes = {".yaml", ".yml", ".json"}
 
-        test_prefix = attrs.get("jsontest_prefix", "test_")
+        tests_dir = Path(attrs["yaml_test_dir"])
 
-        def gen_test(test_name, filename):
+        test_files = [f for f in tests_dir.iterdir() if f.suffix in test_suffixes]
+
+        test_prefix = attrs.get("yaml_test_prefix", "test_")
+
+        def gen_test(test_name, test_file):
             def test(self):
-                test_data = json.loads(
-                    open(
-                        path.join(attrs["jsontest_files"], filename),
-                        encoding="utf-8",
-                    ).read(),
-                )
-                self.jsontest_function(test_name, test_data)
+                test_data = json.loads(test_file.open(encoding="utf-8").read())
+                self.yaml_test_function(test_name, test_data)
 
             return test
 
-        # Loop them and create class methods to call the jsontest_function
-        for filename in files:
-            test_name = filename[:-5]
-
+        # Loop them and create class methods to call the yaml_test_function
+        for test_file in test_files:
+            test_name = test_file.stem
             # Attach the method
             method_name = "{0}{1}".format(test_prefix, test_name)
-            attrs[method_name] = gen_test(test_name, filename)
+            attrs[method_name] = gen_test(test_name, test_file)
 
         return type.__new__(cls, name, bases, attrs)


### PR DESCRIPTION
YAML is a strict superset of JSON, so all the tests should still be parsed the same way, but allowing YAML in tests introduces additional flexibility (multiline strings, comments, etc.) that JSON can't provide.