### PR TITLE
fix: lastlog is always null

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -439,8 +439,7 @@ class Users(FactBase):
 
         for i in `cat /etc/passwd | cut -d: -f1`; do
             ENTRY=`grep ^$i: /etc/passwd`;
-            LASTLOG_RAW=`(lastlog -u $i 2> /dev/null || lastlogin $i 2> /dev/null)`;
-            LASTLOG=`echo $LASTLOG_RAW | grep ^$i | tr -s ' '`;
+            LASTLOG=`(((lastlog -u $i || lastlogin $i) 2> /dev/null) | grep ^$i | tr -s ' ')`;
             PASSWORD=`grep ^$i: /etc/shadow | cut -d: -f2`;
             echo "$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG|$PASSWORD";
         done

--- a/tests/facts/server.Users/mixed.json
+++ b/tests/facts/server.Users/mixed.json
@@ -8,7 +8,7 @@
         "freebsd:*:1001:1001:FreeBSD:/home/freebsd:/bin/sh|freebsd|freebsd|freebsd pts/0 10.1.10.10 Thu Aug 31 05:37:58 2023|$bsdpw$",
         "freebsdnologin:*:1001:1001:FreeBSD NoLogin:/home/freebsdnologin:/bin/sh|freebsdnologin|freebsdnologin||"
     ],
-    "command": "for i in `cat /etc/passwd | cut -d: -f1`; do\n            ENTRY=`grep ^$i: /etc/passwd`;\n            LASTLOG_RAW=`(lastlog -u $i 2> /dev/null || lastlogin $i 2> /dev/null)`;\n            LASTLOG=`echo $LASTLOG_RAW | grep ^$i | tr -s ' '`;\n            PASSWORD=`grep ^$i: /etc/shadow | cut -d: -f2`;\n            echo \"$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG|$PASSWORD\";\n        done",
+    "command": "for i in `cat /etc/passwd | cut -d: -f1`; do\n            ENTRY=`grep ^$i: /etc/passwd`;\n            LASTLOG=`(((lastlog -u $i || lastlogin $i) 2> /dev/null) | grep ^$i | tr -s ' ')`;\n            PASSWORD=`grep ^$i: /etc/shadow | cut -d: -f2`;\n            echo \"$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG|$PASSWORD\";\n        done",
     "fact": {
         "root": {
             "home": "/root",


### PR DESCRIPTION
Just did some evaluating of pyinfra recently, and noticed that the lastlog information when using the server.Users fact was empty on my Ubuntu and RHEL servers.

Going through the logic, it seems that due to a change introduced in #1015, the functionality for non-FreeBSD based systems broke.

I changed the LASTLOG and LASTLOG_RAW to be a oneliner that should preserve the functionality introduced in the aforementioned PR, and also fixes the issue (at least on the systems I have tested).

I have tested this on:
16.04.3 LTS (Xenial Xerus)
18.04.6 LTS (Bionic Beaver)
20.04.6 LTS (Focal Fossa)
22.04.4 LTS (Jammy Jellyfish)
24.04.1 LTS (Noble Numbat)
Red Hat Enterprise Linux 8.9 (Ootpa)
Red Hat Enterprise Linux 9.5 (Plow)

Before the change, all systems returned:
"lastlog": null,
"login_time": null,

And after the change, they return values as expected:
"lastlog": "Tue Dec 3 09:28:02 +0000 2024",
"login_time": "2024-12-03T09:28:02+00:00",

I also did a quick test on FreeBSD 14.1, and everything seemed to work as expected there also after the change.

The issue is related to the header that is shown when using lastlog:
```
[testuser@test01 pyinfra]$ LASTLOG_RAW=`(lastlog -u testuser 2> /dev/null || lastlogin testuser 2> /dev/null)`
[testuser@test01 pyinfra]$ echo $LASTLOG_RAW
Username Port From Latest testuser pts/1 10.10.99.30 Mon Jan 13 12:57:59 +0100 2025
```

And after the change it shows this:
```
[testuser@test01 pyinfra]$ LASTLOG=`(((lastlog -u testuser || lastlogin testuser) 2> /dev/null) | grep ^testuser | tr -s ' ')`
[testuser@test01 pyinfra]$ echo $LASTLOG
testuser pts/1 10.10.99.30 Mon Jan 13 12:57:59 +0100 2025
```