### PR TITLE
Fixed a typo with the volumes parameter to docker.prune operation.

### DIFF
--- a/pyinfra/operations/docker.py
+++ b/pyinfra/operations/docker.py
@@ -298,7 +298,7 @@ def network(
 @operation(is_idempotent=False)
 def prune(
     all=False,
-    volume=False,
+    volumes=False,
     filter="",
 ):
     """
@@ -335,6 +335,6 @@ def prune(
         resource="system",
         command="prune",
         all=all,
-        volume=volume,
+        volumes=volumes,
         filter=filter,
     )


### PR DESCRIPTION
Fixes a typo in the docker.prune operation that caused pyinfra to fail. Before the fix, the operation
```
docker.prune(
    name="Prune images",
    all=True
)
```
would fail with the trace
```
Traceback (most recent call last):
  File "/Users/mpilone/.local/pipx/venvs/pyinfra/lib/python3.13/site-packages/pyinfra_cli/util.py", line 65, in exec_file
    exec(PYTHON_CODES[filename], data)
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "deploy.py", line 11, in <module>
    docker.prune(
    ~~~~~~~~~~~~^
        name="Prune images",
        ^^^^^^^^^^^^^^^^^^^^
        all=True
        ^^^^^^^^
    )
    ^
  File "/Users/mpilone/.local/pipx/venvs/pyinfra/lib/python3.13/site-packages/pyinfra/api/operation.py", line 295, in decorated_func
    for _ in command_generator():
             ~~~~~~~~~~~~~~~~~^^
  File "/Users/mpilone/.local/pipx/venvs/pyinfra/lib/python3.13/site-packages/pyinfra/api/operation.py", line 282, in command_generator
    for command in func(*args, **kwargs):
                   ~~~~^^^^^^^^^^^^^^^^^
  File "/Users/mpilone/.local/pipx/venvs/pyinfra/lib/python3.13/site-packages/pyinfra/operations/docker.py", line 334, in prune
    yield handle_docker(
          ~~~~~~~~~~~~~^
        resource="system",
        ^^^^^^^^^^^^^^^^^^
    ...<3 lines>...
        filter=filter,
        ^^^^^^^^^^^^^^
    )
    ^
  File "/Users/mpilone/.local/pipx/venvs/pyinfra/lib/python3.13/site-packages/pyinfra/operations/util/docker.py", line 177, in handle_docker
    return docker_commands[resource][command](**kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/mpilone/.local/pipx/venvs/pyinfra/lib/python3.13/site-packages/pyinfra/operations/util/docker.py", line 69, in _prune_command
    if kwargs["volumes"]:
       ~~~~~~^^^^^^^^^^^
KeyError: 'volumes'
```

The issue was a typo where `volume` was used as the default argument but `volumes` was used later in the implementation and the documentation.