### PR TITLE
CI: Prevent docs job from running on forks

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-22.04
+    if: github.repository == 'pyinfra-dev/pyinfra'
     steps:
       - name: Clone Source Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The job always fails due to the missing token and causes annoying notifications when rebasing `3.x` on a fork