### PR TITLE
enable -h as shorthand for --help

### DIFF
--- a/pyinfra_cli/main.py
+++ b/pyinfra_cli/main.py
@@ -49,7 +49,10 @@ def _print_support(ctx, param, value):
     ctx.exit()
 
 
-@click.command()
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument("inventory", nargs=1, type=click.Path(exists=False))
 @click.argument("operations", nargs=-1, required=True, type=click.Path(exists=False))
 @click.option(


### PR DESCRIPTION
This is a tiny improvement that enables the CLI switch `-h` as shorthand for `--help`.

I often find myself trying `-h`, failing and then remembering that specific tools only offer `--help`. `-h` is commonly available from CLI tools, argparse has it a default, etc. Thus, it would be nice if pyinfra would allow it too.