### PR TITLE
Add a note to the docs about using `_inner` when calling operations from other operations

### DIFF
--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -33,8 +33,7 @@ yield FunctionCommand(function, args_list, kwargs_dict)
 yield StringCommand("echo", "Shell!", _sudo=True)
 ```
 
-Operations can also call other operations using ``yield from`` syntax:
-
+Operations can also call other operations using ``yield from <operation>._inner`` syntax.
 ```py
 yield from files.file._inner(
     path="/some/file",


### PR DESCRIPTION
While this behavior is shown in the example, it is not explicit that this is a requirement.