### PR TITLE
server.sysctl: handle 0 integer values correctly

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -437,7 +437,7 @@ def sysctl(
     existing_sysctls = host.get_fact(Sysctl, keys=[key])
     existing_value = existing_sysctls.get(key)
 
-    if not existing_value or existing_value != value:
+    if existing_value != value:
         yield "sysctl {0}='{1}'".format(key, string_value)
     else:
         host.noop("sysctl {0} is set to {1}".format(key, string_value))

--- a/tests/operations/server.sysctl/set_noop_zero_int.json
+++ b/tests/operations/server.sysctl/set_noop_zero_int.json
@@ -1,0 +1,12 @@
+{
+    "args": ["kern.max-files", 0],
+    "facts": {
+        "server.Sysctl": {
+            "keys=['kern.max-files']": {
+                "kern.max-files": 0
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "sysctl kern.max-files is set to 0"
+}


### PR DESCRIPTION
Previously, sysctl operations would incorrectly trigger changes when checking against zero values since `not 0` is `True` in python.

This drops checking the `existing_value` and relies on the comparison against the desired value instead.

Added test case verifying correct noop behavior when sysctl value is 0.