### PR TITLE
Expand documentation for Connectors

### DIFF
--- a/docs/api/connectors.md
+++ b/docs/api/connectors.md
@@ -4,6 +4,12 @@
 
 ## Inventory Connector
 
+Inventory connectors can return one or more hosts each invocation of `make_names_data`.
+
+In the example below `make_names_data` is yielding a fixed hostname, data, groups tuple without processing. It could also be querying an API for hosts
+then looping over them, returning a dynamic hostname, data, groups list tuple based on what it gathers from the remote end (note in that case hosts
+have to be looped and yielded one at a time).
+
 ```py
 class InventoryConnector(BaseConnector):
     handles_execution = False
@@ -19,6 +25,13 @@ class InventoryConnector(BaseConnector):
         yield "@local", {}, ["@local"]
 ```
 
+To use the inventory connector call `pyinfra @[name of connector in pyinfra.connectors] [deployment script].py`
+
+The conector can also be run using `pyinfra @[name of connector in pyinfra.connectors]/[hostname] [deployment script].py`. If executed this way
+(inventory/data requested for a single host), `make_names_data(_=None)` should be updated to `make_names_data(name)` and the `name == None` case
+handled in code separately from `name` being a valid string.
+
+
 ## Executing Connector
 
 A connector that implements execution requires a few more methods:
@@ -29,6 +42,8 @@ class LocalConnector(BaseConnector):
 
     @staticmethod
     def make_names_data(_=None):
+        # Unlike InventoryConnector above, this connector can only return one host each invocation of make_names_data().
+
         ...  # see above
  
     def run_shell_command(
@@ -97,3 +112,8 @@ In order for pyinfra to gain knowledge about your connector, you need to add the
 # Value = module_path:class_name
 custom = 'pyinfra_custom_connector.connector:LoggingConnector'
 ```
+
+If modifying pyinfra directly, `pyinfra.connectors` should be added to `setup.py`.
+
+For quick and dirty testing of a new connector add the connect to `pyinfra/pyinfra-*.dist-info/entry_points.txt`.
+

--- a/docs/api/connectors.md
+++ b/docs/api/connectors.md
@@ -2,13 +2,20 @@
 
 [Connectors](../connectors) enable pyinfra to directly integrate with other tools and systems. Connectors are written as Python classes.
 
+Connectors come in three variations:
+
+ - Inventory only
+ - Execution only
+ - Inventory and Execution
+
+The last case just requires combining the two examples below and including any host/group gathering logic in `make_names_data`.
+
 ## Inventory Connector
 
 Inventory connectors can return one or more hosts each invocation of `make_names_data`.
 
-In the example below `make_names_data` is yielding a fixed hostname, data, groups tuple without processing. It could also be querying an API for hosts
-then looping over them, returning a dynamic hostname, data, groups list tuple based on what it gathers from the remote end (note in that case hosts
-have to be looped and yielded one at a time).
+In the example below `make_names_data` is yielding a hostname, data, groups tuple. As long as the final `yield` is a tuple though, the gathered data
+could be stored and processed in any data structure.
 
 ```py
 class InventoryConnector(BaseConnector):
@@ -22,7 +29,14 @@ class InventoryConnector(BaseConnector):
         Yields:
             tuple: (name, data, groups)
         """
-        yield "@local", {}, ["@local"]
+        # connect to api/parse files/process data here, resulting in a list of tuples;
+        gathered_hosts = [
+            ('@local', {}, ['@local']),
+            ('foundhost', {'ip': 198.51.100.4}, ['remote', 'example'])
+            ]
+
+        for loop_host in gathered_hosts:
+          yield gathered_hosts[0], gathered_hosts[1], gathered_hosts[2]
 ```
 
 To use the inventory connector call `pyinfra @[name of connector in pyinfra.connectors] [deployment script].py`
@@ -31,6 +45,26 @@ The conector can also be run using `pyinfra @[name of connector in pyinfra.conne
 (inventory/data requested for a single host), `make_names_data(_=None)` should be updated to `make_names_data(name)` and the `name == None` case
 handled in code separately from `name` being a valid string.
 
+Its worth being aware up front that due to `make_names_data` being a `staticmethod` it has no automatic access to the parent classes attributes.
+To work around this - eg to configure an API connector - configuration will have to happen outside the function and be imported in. Two examples
+(`getattr` and a function) are provided below.
+
+```py
+def load_settings():
+  settings = {}
+  # logic here
+  return settings
+
+class InventoryConnector(BaseConnector):
+  api_instance = external.ApiClient()
+  ...
+
+  @staticmethod
+  def make_names_data(_=None)
+    api_client = getattr(InventoryConnector, 'api_instance')
+    api_settings = load_settings()
+    ...
+```
 
 ## Executing Connector
 
@@ -114,6 +148,4 @@ custom = 'pyinfra_custom_connector.connector:LoggingConnector'
 ```
 
 If modifying pyinfra directly, `pyinfra.connectors` should be added to `setup.py`.
-
-For quick and dirty testing of a new connector add the connect to `pyinfra/pyinfra-*.dist-info/entry_points.txt`.
 

--- a/docs/api/connectors.md
+++ b/docs/api/connectors.md
@@ -41,7 +41,7 @@ class InventoryConnector(BaseConnector):
 
 To use the inventory connector call `pyinfra @[name of connector in pyinfra.connectors] [deployment script].py`
 
-The conector can also be run using `pyinfra @[name of connector in pyinfra.connectors]/[hostname] [deployment script].py`. If executed this way
+The connector can also be run using `pyinfra @[name of connector in pyinfra.connectors]/[hostname] [deployment script].py`. If executed this way
 (inventory/data requested for a single host), `make_names_data(_=None)` should be updated to `make_names_data(name)` and the `name == None` case
 handled in code separately from `name` being a valid string.
 


### PR DESCRIPTION
After quite some time spent trying to figure out how connectors work I've tried to provide updated documentation for the next person.
This changeset explains the different types of connectors in more detail and adds some additional information (mainly around `make_names_data` which wasn't clear to me at the start.

Relates to #1298