### PR TITLE
facts.xbps.XbpsPackages: allow . in package names

### DIFF
--- a/pyinfra/facts/xbps.py
+++ b/pyinfra/facts/xbps.py
@@ -21,7 +21,7 @@ class XbpsPackages(FactBase):
 
     default = dict
 
-    regex = r"^.. ([a-zA-Z0-9_\-\+]+)\-([0-9a-z_\.]+)"
+    regex = r"^.. ([a-zA-Z0-9_\-\+\.]+)\-([0-9a-z\.]+_[0-9]+)"
 
     def command(self):
         return "xbps-query -l"

--- a/tests/facts/xbps.XbpsPackages/dot-in-package-name.json
+++ b/tests/facts/xbps.XbpsPackages/dot-in-package-name.json
@@ -1,0 +1,14 @@
+{
+    "command": "xbps-query -l",
+    "requires_command": "xbps-query",
+    "output": [
+        "ii python3-3.13.2_1                              Python programming language (3.13 series)",
+        "ii python3-jaraco.classes-3.4.0_2                Utility functions for Python class constructs (Python3)",
+        "ii python3-jaraco.context-6.0.1_2                Context managers by jaraco"
+    ],
+    "fact": {
+        "python3": ["3.13.2_1"],
+        "python3-jaraco.classes": ["3.4.0_2"],
+        "python3-jaraco.context": ["6.0.1_2"]
+    }
+}


### PR DESCRIPTION
Package names including dots `.` were split at the wrong location. Parts that included dots were counted as versions:

    {
        "python3": [
            "3.13.2_1",
            "jaraco.classes",
            "jaraco.context"
        ],
    }

This patch fixes the regex and adds a test for this case:

    {
        "python3": [
            "3.13.2_1"
        ],
        "python3-jaraco.classes": [
            "3.4.0_2"
        ],
        "python3-jaraco.context": [
            "6.0.1_2"
        ]
    }