### PR TITLE
[IMP] files.file: amend <touch> flag meaning

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -1204,7 +1204,7 @@ def file(
     user: str | None = None,
     group: str | None = None,
     mode: int | str | None = None,
-    touch=False,
+    touch=True,
     create_remote_dir=True,
     force=False,
     force_backup=True,
@@ -1268,6 +1268,9 @@ def file(
         return
 
     if info is None:  # create
+        if not touch:
+            raise OperationError("File {0} does not exist and `touch` is unset".format(path))
+
         if create_remote_dir:
             yield from _create_remote_dir(path, user, group)
 
@@ -1281,12 +1284,8 @@ def file(
     else:  # update
         changed = False
 
-        if touch:
-            changed = True
-            yield StringCommand("touch", QuoteString(path))
-
         # Check mode
-        if mode and (not info or info["mode"] != mode):
+        if mode and info["mode"] != mode:
             yield file_utils.chmod(path, mode)
             changed = True
 

--- a/tests/operations/files.file/touch.json
+++ b/tests/operations/files.file/touch.json
@@ -1,18 +1,15 @@
 {
     "args": ["testfile"],
     "kwargs": {
-        "touch": true
+        "touch": false
     },
     "facts": {
         "files.File": {
-            "path=testfile": {
-                "mode": 600
-            }
+            "path=testfile": null
         }
     },
-    "commands": [
-        "touch testfile"
-    ],
-    "idempotent": false,
-    "disable_idempotent_warning_reason": "touch operations are always executed"
+    "exception": {
+        "name": "OperationError",
+        "message": "File testfile does not exist and `touch` is unset"
+    }
 }


### PR DESCRIPTION
As it stands, the `<touch>` flag of `files.file` is useless: it only controls whether a `touch <path>` command is issued when the `<path>` file already exists, which results in a no-op, in both cases.

Since `<assume_present>` was removed in dfa69b66fe8ebf9c02accb1d3f6ec4905f11476d, it may make sense to have `<touch>` control whether the operation is allowed to create an empty file, if one is not found. And, raise if the file is not found and the flag is unset: the usecase is that one may want to only change ownership/permissions of an existing file, without accidentally creating an empty placeholder for it.

A small unrelated change to the condition to set the mode is also included.