### PR TITLE
files.move: new operation

### DIFF
--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -1069,6 +1069,34 @@ def template(
     )
 
 
+@operation()
+def move(src: str, dest: str, overwrite=False):
+    """
+    Move remote file/directory/link into remote directory
+
+    + src: remote file/directory to move
+    + dest: remote directory to move `src` into
+    + overwrite: whether to overwrite dest, if present
+    """
+
+    if host.get_fact(File, src) is None:
+        raise OperationError("src {0} does not exist".format(src))
+
+    if not host.get_fact(Directory, dest):
+        raise OperationError("dest {0} is not an existing directory".format(dest))
+
+    full_dest_path = os.path.join(dest, os.path.basename(src))
+    if host.get_fact(File, full_dest_path) is not None:
+        if overwrite:
+            yield StringCommand("rm", "-rf", QuoteString(full_dest_path))
+        else:
+            raise OperationError(
+                "dest {0} already exists and `overwrite` is unset".format(full_dest_path)
+            )
+
+    yield StringCommand("mv", QuoteString(src), QuoteString(dest))
+
+
 def _validate_path(path):
     try:
         return os.fspath(path)

--- a/tests/operations/files.move/directory.json
+++ b/tests/operations/files.move/directory.json
@@ -1,0 +1,19 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["tmp/testfile", "tmp2"],
+    "facts": {
+        "files.File": {
+            "path=tmp/testfile": false,
+            "path=tmp2/testfile": null
+        },
+        "files.Directory": {
+            "path=tmp/testfile": {
+                "mode": 700
+            },
+            "path=tmp2": {
+                "mode": 700
+            }
+        }
+    },
+    "commands": ["mv tmp/testfile tmp2"]
+}

--- a/tests/operations/files.move/invalid_dest.json
+++ b/tests/operations/files.move/invalid_dest.json
@@ -1,0 +1,18 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["tmp/testfile", "tmp2"],
+    "facts": {
+        "files.File": {
+            "path=tmp/testfile": {
+                "mode": 600
+            }
+        },
+        "files.Directory": {
+            "path=tmp2": null
+        }
+    },
+    "exception": {
+        "name": "OperationError",
+        "message": "dest tmp2 is not an existing directory"
+    }
+}

--- a/tests/operations/files.move/invalid_src.json
+++ b/tests/operations/files.move/invalid_src.json
@@ -1,0 +1,18 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["tmp/testfile", "tmp2"],
+    "facts": {
+        "files.File": {
+            "path=tmp/testfile": null
+        },
+        "files.Directory": {
+            "path=tmp2": {
+                "mode": 700
+            }
+        }
+    },
+    "exception": {
+        "name": "OperationError",
+        "message": "src tmp/testfile does not exist"
+    }
+}

--- a/tests/operations/files.move/link.json
+++ b/tests/operations/files.move/link.json
@@ -1,0 +1,21 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["tmp/testfile", "tmp2"],
+    "facts": {
+        "files.File": {
+            "path=tmp/testfile": false,
+            "path=tmp2/testfile": null
+        },
+        "files.Link": {
+            "path=tmp/testfile": {
+                "mode": 600
+            }
+        },
+        "files.Directory": {
+            "path=tmp2": {
+                "mode": 700
+            }
+        }
+    },
+    "commands": ["mv tmp/testfile tmp2"]
+}

--- a/tests/operations/files.move/no_conflict.json
+++ b/tests/operations/files.move/no_conflict.json
@@ -1,0 +1,18 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["tmp/testfile", "tmp2"],
+    "facts": {
+        "files.File": {
+            "path=tmp/testfile": {
+                "mode": 600
+            },
+            "path=tmp2/testfile": null
+        },
+        "files.Directory": {
+            "path=tmp2": {
+                "mode": 700
+            }
+        }
+    },
+    "commands": ["mv tmp/testfile tmp2"]
+}

--- a/tests/operations/files.move/no_overwrite.json
+++ b/tests/operations/files.move/no_overwrite.json
@@ -1,0 +1,23 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["tmp/testfile", "tmp2"],
+    "facts": {
+        "files.File": {
+            "path=tmp/testfile": {
+                "mode": 600
+            },
+            "path=tmp2/testfile": {
+                "mode": 600
+            }
+        },
+        "files.Directory": {
+            "path=tmp2": {
+                "mode": 700
+            }
+        }
+    },
+    "exception": {
+        "name": "OperationError",
+        "message": "dest tmp2/testfile already exists and `overwrite` is unset"
+    }
+}

--- a/tests/operations/files.move/overwrite.json
+++ b/tests/operations/files.move/overwrite.json
@@ -1,0 +1,21 @@
+{
+    "require_platform": ["Darwin", "Linux"],
+    "args": ["tmp/testfile", "tmp2"],
+    "kwargs": {"overwrite": true},
+    "facts": {
+        "files.File": {
+            "path=tmp/testfile": {
+                "mode": 600
+            },
+            "path=tmp2/testfile": {
+                "mode": 600
+            }
+        },
+        "files.Directory": {
+            "path=tmp2": {
+                "mode": 700
+            }
+        }
+    },
+    "commands": ["rm -rf tmp2/testfile", "mv tmp/testfile tmp2"]
+}


### PR DESCRIPTION
Proposing a fairly simple operation to use `mv` among remote files. Notice: it's not as smart. `mv t1 t2/t1` will try to create `t2/t1/t1`.