### PR TITLE
facts: server.Mounts: fix whitespaces and escaped characters

### DIFF
--- a/tests/facts/server.Mounts/mounts.json
+++ b/tests/facts/server.Mounts/mounts.json
@@ -1,39 +1,44 @@
 {
-    "command": "mount",
+    "command": "cat /proc/self/mountinfo",
     "output": [
-        "/dev/sda1 on /boot type ext2 (rw,relatime,block_validity,barrier,user_xattr,acl)",
-        "/dev/disk1s4 on /private/var/vm (apfs, local, noexec, journaled, noatime, nobrowse)",
-        "map thing on / type something ()"
+        "2 1 0:26 / / ro,noatime - ext4 /dev/sdb1 rw",
+        "33 29 8:1 / /boot rw,relatime - vfat /dev/sda1 rw,lazytime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,utf8,errors=remount-ro",
+        "408 35 0:352 / /mnt/overlay/overlay,dir\\040with\\040spaces\\040and\\040\\134backslashes ro,relatime shared:27 - overlay none ro,lowerdir=lower\\054dir,upperdir=upper\\054dir,workdir=work\\054dir"
     ],
     "fact": {
+        "/": {
+            "device": "/dev/sdb1",
+            "type": "ext4",
+            "options": [
+                "ro",
+                "noatime"
+            ]
+        },
         "/boot": {
             "device": "/dev/sda1",
-            "type": "ext2",
+            "type": "vfat",
             "options": [
                 "rw",
                 "relatime",
-                "block_validity",
-                "barrier",
-                "user_xattr",
-                "acl"
+                "lazytime",
+                "fmask=0022",
+                "dmask=0022",
+                "codepage=437",
+                "iocharset=iso8859-1",
+                "shortname=mixed",
+                "utf8",
+                "errors=remount-ro"
             ]
         },
-        "/private/var/vm": {
-            "device": "/dev/disk1s4",
-            "type": "apfs",
+        "/mnt/overlay/overlay,dir with spaces and \\backslashes": {
+            "device": "none",
+            "type": "overlay",
             "options": [
-                "local",
-                "noexec",
-                "journaled",
-                "noatime",
-                "nobrowse"
-            ]
-        },
-        "/": {
-            "device": "map thing",
-            "type": "something",
-            "options": [
-                ""
+                "ro",
+                "relatime",
+                "lowerdir=lower,dir",
+                "upperdir=upper,dir",
+                "workdir=work,dir"
             ]
         }
     }


### PR DESCRIPTION
The `mount` command can not be parsed unambigiously. Whitespaces in paths and `,` in option lists are not escaped. See the new tests for examples the old code can not handle.

This patch switches to reading from `/proc/self/mountinfo` instead (see man 5 proc for documentation) where strings are properly escaped.

While `/proc/self/mountinfo` provides a lot more details, these are ignored to keep compatibility with the old type. If there is a need, the missing fields can be easily added.

@Fizzadar 461d8ec5c8556e6c2db6b9803e7a62085dea628f introduced handling "map devices". I'm not sure what they are. I'd love to see a line from `/proc/self/mountinfo`, so we can test against that.