### PR TITLE
Add inventory processing note and reference it

### DIFF
--- a/docs/examples/data_multiple_environments.md
+++ b/docs/examples/data_multiple_environments.md
@@ -33,3 +33,6 @@ git_branch = 'master'
 env = 'staging'
 git_branch = 'develop'
 ```
+
+For more information on inventory files, see :doc:`inventory-data`.
+

--- a/docs/inventory-data.rst
+++ b/docs/inventory-data.rst
@@ -33,6 +33,13 @@ If you save this file as ``inventory.py``, you can then use it when executing py
 
     All the hosts are added to a group with the name of the inventory file (eg any hosts defined in ``inventories/production.py`` belong to group ``production``).
 
+.. admonition:: inventories/
+    :class: note
+
+    Files in the ``inventories/`` directory are not automatically joined during inventory processesing, rather this directory is a convention when wanting
+    to store multiple related inventories. Code can be imported from files under ``inventories/`` in to the main ``inventory.py`` if desired.
+
+
 Host Data
 ~~~~~~~~~
 


### PR DESCRIPTION
I thought the contents of inventories would be processed automatically but that isn't the case. To clear things up I've added a warning to inventory-data and added a reference to that page from the example docs.