### PR TITLE
Fixing a few warnings

### DIFF
--- a/pyinfra/operations/opkg.py
+++ b/pyinfra/operations/opkg.py
@@ -1,10 +1,10 @@
 """
-    Manage packages on OpenWrt using opkg
-        + ``update`` - update local copy of package information
-        + ``packages`` -  install and remove packages
+Manage packages on OpenWrt using opkg
+    + ``update`` - update local copy of package information
+    + ``packages`` -  install and remove packages
 
-    see https://openwrt.org/docs/guide-user/additional-software/opkg
-    OpenWrt recommends against upgrading all packages  thus there is no ``opkg.upgrade`` function
+see https://openwrt.org/docs/guide-user/additional-software/opkg
+OpenWrt recommends against upgrading all packages  thus there is no ``opkg.upgrade`` function
 """
 
 from typing import List, Union

--- a/tests/facts/deb.DebPackage/whitespace.json
+++ b/tests/facts/deb.DebPackage/whitespace.json
@@ -1,5 +1,7 @@
 {
     "arg": "/root/tivsm-api64.amd64.deb",
+    "command": "! test -e /root/tivsm-api64.amd64.deb && (dpkg -s /root/tivsm-api64.amd64.deb 2>/dev/null || true) || dpkg -I /root/tivsm-api64.amd64.deb",
+    "requires_command": "dpkg",
     "output": [
       " new Debian package, version 2.0.",
       " size 73275616 bytes: control archive=1079 bytes.",

--- a/tests/facts/zfs.Datasets/datasets.yaml
+++ b/tests/facts/zfs.Datasets/datasets.yaml
@@ -1,4 +1,5 @@
 command: zfs get -H all
+requires_command: zfs
 output: |
   tank	type	filesystem	-
   tank	size	2.71T	-

--- a/tests/facts/zfs.Filesystems/filesystems.yaml
+++ b/tests/facts/zfs.Filesystems/filesystems.yaml
@@ -1,4 +1,5 @@
 command: zfs get -H all
+requires_command: zfs
 output: |
   tank	type	filesystem	-
   tank	size	2.71T	-

--- a/tests/facts/zfs.Pools/pools.yaml
+++ b/tests/facts/zfs.Pools/pools.yaml
@@ -1,4 +1,5 @@
 command: zpool get -H all
+requires_command: zpool
 output: |
   tank	compression	lz4	-
   tank	ashift	12	local

--- a/tests/facts/zfs.Snapshots/snapshots.yaml
+++ b/tests/facts/zfs.Snapshots/snapshots.yaml
@@ -1,4 +1,5 @@
 command: zfs get -H all
+requires_command: zfs
 output: |
   tank	type	filesystem	-
   tank	size	2.71T	-

--- a/tests/facts/zfs.Volumes/volumes.yaml
+++ b/tests/facts/zfs.Volumes/volumes.yaml
@@ -1,4 +1,5 @@
 command: zfs get -H all
+requires_command: zfs
 output: |
   tank	type	filesystem	-
   tank	size	2.71T	-

--- a/tests/operations/git.config/add_existing_multi_value.json
+++ b/tests/operations/git.config/add_existing_multi_value.json
@@ -10,5 +10,6 @@
             }
         }
     },
-    "commands": []
+    "commands": [],
+    "noop_description": "git config key is set to value"
 }


### PR DESCRIPTION
- refactor: update opkg documentation and add requires_command to ZFS and Git tests
- Improved formatting of the opkg management documentation.
- Added `requires_command` field to various ZFS dataset, filesystem, pool, snapshot, and volume test configurations.
- Updated Git config test to include a `noop_description` for clarity.