### PR TITLE
[ADD] ops/server.user: allow to add user to more secondary groups 

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -764,6 +764,7 @@ def user(
     shell: str | None = None,
     group: str | None = None,
     groups: list[str] | None = None,
+    append=False,
     public_keys: str | list[str] | None = None,
     delete_keys=False,
     ensure_home=True,
@@ -783,6 +784,7 @@ def user(
     + shell: the users shell
     + group: the users primary group
     + groups: the users secondary groups
+    + append: whether to add `user` to `groups`, w/o losing membership of other groups
     + public_keys: list of public keys to attach to this user, ``home`` must be specified
     + delete_keys: whether to remove any keys not specified in ``public_keys``
     + ensure_home: whether to ensure the ``home`` directory exists
@@ -929,6 +931,8 @@ def user(
 
         # Check secondary groups, if defined
         if groups and set(existing_user["groups"]) != set(groups):
+            if append:
+                args.append("-a")
             args.append("-G {0}".format(",".join(groups)))
 
         if comment and existing_user["comment"] != comment:

--- a/tests/operations/server.user/append_secondary_groups.json
+++ b/tests/operations/server.user/append_secondary_groups.json
@@ -1,0 +1,36 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "group": "somegroup",
+        "groups": [
+            "group3", "group4"
+        ],
+        "append": true
+    },
+    "facts": {
+        "server.Os": "Linux",
+        "server.Users": {
+            "someuser": {
+                "home": "/home/someuser",
+                "group": "somegroup",
+                "groups": [
+                    "group1", "group2"
+                ]
+            }
+        },
+        "files.Directory": {
+            "path=/home/someuser": {
+                "user": "someuser",
+                "group": "somegroup"
+            },
+            "path=/home/someotheruser": {
+                "user": "someuser",
+                "group": "somegroup"
+            }
+        },
+        "server.Groups": {}
+    },
+    "commands": [
+        "usermod -a -G group3,group4 someuser"
+    ]
+}


### PR DESCRIPTION
It is often necessary to add a user to a secondary group, without dropping it from other secondary groups it already belonged to. `usermod` provides a `-a` flag dedicated to this very need. This commit allows to leverage that flag via `pyinfra`.

In fact, in `pyinfra` this is even more necessary as facts are collected and never updated, making so that:

```python
from pyinfra import host
from pyinfra.facts.server import Users
from pyinfra.operations import server

server.group(
    name="create main group",
    group="user",
)

server.group(
    name="create secondary group 1",
    group="extra_group1",
)

server.user(
    name="create user `user`",
    user="user",
    groups=["extra_group1"],
)

server.group(
    name="create secondary group 2",
    group="extra_group2",
)

server.user(
    name="Add user to extra group 2",
    user="user",
    groups=[
        *host.get_fact(Users).get("user", {}).get("groups", []),
        "extra_group2",
    ],
)
```

* yields `usermod -G extra_group1,extra_group2 user` if `user` was member of `extra_group1` before the task started, or
* yields `usermod -G extra_group2 user`, if it was not part of the task

Notice that it does not matter whether the user `user` was added to the `extra_group1` group by `pyinfra`.