### PR TITLE
ssh: Add support for ServerAliveInterval

### DIFF
--- a/pyinfra/connectors/sshuserclient/client.py
+++ b/pyinfra/connectors/sshuserclient/client.py
@@ -183,6 +183,13 @@ class SSHClient(ParamikoClient):
         if _pyinfra_ssh_forward_agent is not None:
             forward_agent = _pyinfra_ssh_forward_agent
 
+        keep_alive = config.get("keep_alive")
+
+        if keep_alive:
+            transport = self.get_transport()
+            assert transport is not None, "No transport"
+            transport.set_keepalive(keep_alive)
+
         if forward_agent:
             transport = self.get_transport()
             assert transport is not None, "No transport"
@@ -239,6 +246,9 @@ class SSHClient(ParamikoClient):
 
         if "port" in host_config:
             cfg["port"] = int(host_config["port"])
+
+        if "serveraliveinterval" in host_config:
+            cfg["keep_alive"] = int(host_config["serveraliveinterval"])
 
         if "proxycommand" in host_config:
             cfg["sock"] = ProxyCommand(host_config["proxycommand"])


### PR DESCRIPTION
I have some tasks running in pyinfra that are particularly long. This is within my expectations, but the problem is that paramiko raises EOFError for all the other hosts that are waiting their turn to run the next step.

After looking a bit I realize paramiko doesn't support `SeverAliveInterval` from ssh/config, but has a call `transport.set_keepalive` doing the same thing.

This PR adds the parsing for `ServerAliveInterval` from ssh/config and sets appropriately the keepalive on the transport.