### PR TITLE
operations/postgres: fix quoting of locale parameters

### DIFF
--- a/pyinfra/operations/postgres.py
+++ b/pyinfra/operations/postgres.py
@@ -249,8 +249,8 @@ def database(
             ("OWNER", '"{0}"'.format(owner) if owner else owner),
             ("TEMPLATE", template),
             ("ENCODING", encoding),
-            ("LC_COLLATE", lc_collate),
-            ("LC_CTYPE", lc_ctype),
+            ("LC_COLLATE", "'{0}'".format(lc_collate) if lc_collate else lc_collate),
+            ("LC_CTYPE", "'{0}'".format(lc_ctype) if lc_ctype else lc_ctype),
             ("TABLESPACE", tablespace),
             ("CONNECTION LIMIT", connection_limit),
         ):

--- a/tests/operations/postgresql.database/add_database_locales.json
+++ b/tests/operations/postgresql.database/add_database_locales.json
@@ -1,0 +1,16 @@
+{
+    "args": ["somedb"],
+    "kwargs": {
+        "encoding": "utf8",
+        "lc_collate": "C",
+        "lc_ctype": "C"
+    },
+    "facts" :{
+        "postgres.PostgresDatabases": {
+            "psql_database=None, psql_host=None, psql_password=None, psql_port=None, psql_user=None": {}
+        }
+    },
+    "commands": [
+        "psql -Ac 'CREATE DATABASE \"somedb\" ENCODING utf8 LC_COLLATE '\"'\"'C'\"'\"' LC_CTYPE '\"'\"'C'\"'\"''"
+    ]
+}


### PR DESCRIPTION
As [reported on Matrix](https://matrix.to/#/!dPvLqxqwbQZYeQrNnu:matrix.org/$MIrE5_JPXE6opmhxxOdITtCwTLMvvQExFL3Tq_p1bVs?via=beeper.com&via=matrix.org&via=t2bot.io), the `postgres.database` operation currently fails if the `lc_collate` or `lc_ctype` parameters are passed: these values must be passed as single-quoted strings in the SQL statement. This PR adds a fix and test case for this.

The workaround for now is to pass the single quotes on the python side (by passing `lc_collate="'C'"`) and the PR will break that workaround, but I don't think it's worth making the quoting logic idempotent. Happy to add it if we think it's worth the added complexity.

Manually tested against a postgres:17 container, with `postgres.database("test", encoding="utf8", template="template0", lc_collate="C", lc_ctype="C")`:

- the latest release fails and PG logs the following error: `ERROR:  invalid LC_COLLATE locale name: "c"`
- this branch succeeds and PG logs: `STATEMENT:  CREATE DATABASE "test2" TEMPLATE template0 ENCODING utf8 LC_COLLATE C LC_CTYPE C`