### PR TITLE
Add GitTag fact and update repo operation to support tag checkout

### DIFF
--- a/pyinfra/facts/git.py
+++ b/pyinfra/facts/git.py
@@ -23,6 +23,16 @@ class GitBranch(GitFactBase):
         return re.sub(r"(heads|tags)/", r"", "\n".join(output))
 
 
+class GitTag(GitFactBase):
+    @override
+    def command(self, repo) -> str:
+        return "! test -d {0} || (cd {0} && git tag)".format(repo)
+
+    @override
+    def process(self, output):
+        return output
+
+
 class GitConfig(GitFactBase):
     default = dict
 

--- a/pyinfra/operations/git.py
+++ b/pyinfra/operations/git.py
@@ -9,7 +9,7 @@ import re
 from pyinfra import host
 from pyinfra.api import OperationError, operation
 from pyinfra.facts.files import Directory, File
-from pyinfra.facts.git import GitBranch, GitConfig, GitTrackingBranch
+from pyinfra.facts.git import GitBranch, GitConfig, GitTag, GitTrackingBranch
 
 from . import files, ssh
 from .util.files import chown, unix_path_join
@@ -144,10 +144,14 @@ def repo(
             git_commands.append("clone {0} .".format(src))
     # Ensuring existing repo
     else:
+        is_tag = False
         if branch and host.get_fact(GitBranch, repo=dest) != branch:
             git_commands.append("fetch")  # fetch to ensure we have the branch locally
             git_commands.append("checkout {0}".format(branch))
-        if pull:
+        if branch and branch in host.get_fact(GitTag, repo=dest):
+            git_commands.append("checkout {0}".format(branch))
+            is_tag = True
+        if pull and not is_tag:
             if rebase:
                 git_commands.append("pull --rebase")
             else:

--- a/tests/facts/git.GitTag/tag.json
+++ b/tests/facts/git.GitTag/tag.json
@@ -1,0 +1,13 @@
+{
+    "arg": "myrepo",
+    "command": "! test -d myrepo || (cd myrepo && git tag)",
+    "requires_command": "git",
+    "output": [
+        "v1.0.0",
+        "v1.0.1"
+    ],
+    "fact": [
+        "v1.0.0",
+        "v1.0.1"
+    ]
+}

--- a/tests/operations/git.repo/branch_pull.json
+++ b/tests/operations/git.repo/branch_pull.json
@@ -12,6 +12,10 @@
         },
         "git.GitBranch": {
             "repo=/home/myrepo": "master"
+        },
+        "git.GitTag": {
+            "repo=/home/myrepo": [
+            ]
         }
     },
     "commands": [


### PR DESCRIPTION
Introduced a new GitTag class to retrieve Git tags and modified the repo operation to handle branch and tag checkouts appropriately. Updated tests to reflect the addition of GitTag.

tested with 

```
from pyinfra.operations import git

headscale_admin_git_repo = "https://github.com/GoodiesHQ/headscale-admin"
headscale_admin_code_path = "/tmp/headscale_admin"
headscale_admin_git_branch = "v0.25.6"

# Set up headscale-admin GUI
git.repo(
    name="Clone Headscale-admin git repository",
    src=headscale_admin_git_repo,
    dest=headscale_admin_code_path,
    branch=headscale_admin_git_branch,
)
```

```
pyinfra @local 1340.py
```

Fix #1340 