### PR TITLE
Add flatpak remote support

### DIFF
--- a/pyinfra/operations/flatpak.py
+++ b/pyinfra/operations/flatpak.py
@@ -12,12 +12,14 @@ from pyinfra.facts.flatpak import FlatpakPackages
 @operation()
 def packages(
     packages: str | list[str] | None = None,
+    remote: str | None = None,
     present=True,
 ):
     """
     Install/remove a flatpak package
 
     + packages: List of packages
+    + remote: Source to install the application or runtime from
     + present: whether the package should be installed
 
     **Examples:**
@@ -28,6 +30,13 @@ def packages(
         flatpak.package(
             name="Install vlc",
             packages="org.videolan.VLC",
+        )
+
+        # Install vlc flatpak from flathub
+        flatpak.package(
+            name="Install vlc",
+            packages="org.videolan.VLC",
+            remote="flathub",
         )
 
         # Install multiple flatpaks
@@ -55,6 +64,12 @@ def packages(
     install_packages = []
     remove_packages = []
 
+    if remote is None:
+        remote = ""
+    else:
+        # ensure we have a space between the remote and packages
+        remote = remote.strip() + " "
+
     for package in packages:
         # it's installed
         if package in flatpak_packages:
@@ -73,7 +88,7 @@ def packages(
                 host.noop(f"flatpak package {package} is not installed")
 
     if install_packages:
-        yield " ".join(["flatpak", "install", "--noninteractive"] + install_packages)
+        yield f"flatpak install --noninteractive {remote}{' '.join(install_packages)}"
 
     if remove_packages:
-        yield " ".join(["flatpak", "uninstall", "--noninteractive"] + remove_packages)
+        yield f"flatpak uninstall --noninteractive {' '.join(remove_packages)}"


### PR DESCRIPTION
When trying to automate the setup of a new fedora workstation install, the flatpak.packages operation failed since it did not handle the presence of multiple remotes to install from (flathub and fedora).

I have added the ability to set a remote to install from to the operation flatpak.packages

This resolves https://github.com/pyinfra-dev/pyinfra/issues/1346

This is the first time I'm contributing on GitHub, so please tell me if there is anything I've missed.

Before `pyinfra @local flatpak.packages org.libreoffice.LibreOffice -yvv` failed,
But now with `pyinfra @local flatpak.packages org.libreoffice.LibreOffice remote=flathub -yvv` it installs properly.

(Note: This is the same pull request as before, it closed the old one since I renamed the branch)