### PR TITLE
Resolve Python Logger warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15,windows-2022, windows-2025]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: [3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/pyinfra_cli/inventory.py
+++ b/pyinfra_cli/inventory.py
@@ -172,7 +172,7 @@ def make_inventory(
         # The inventory is either an inventory file or a (list of) hosts
         return make_inventory_from_files(inventory, override_data, cwd, group_data_directories)
     elif inventory_func is None:
-        logger.warn(
+        logger.warning(
             f"{inventory} is neither an inventory file, a (list of) hosts or connectors "
             "nor refers to a python module"
         )


### PR DESCRIPTION
# PR Summary
This small PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```