### PR TITLE
Fix files.put(mode=True) (#1137) and update files.put docstring for similar mismatched type comparison issue

### DIFF
--- a/pyinfra/api/util.py
+++ b/pyinfra/api/util.py
@@ -425,7 +425,7 @@ def get_path_permissions_mode(pathname: str):
     """
 
     mode_octal = oct(stat(pathname).st_mode)
-    return mode_octal[-3:]
+    return int(mode_octal[-3:])
 
 
 def raise_if_bad_type(

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -805,7 +805,9 @@ def put(
 
     ``mode``:
         When set to ``True`` the permissions of the local file are applied to the
-        remote file after the upload is complete.
+        remote file after the upload is complete.  If set to an octal value with
+        digits for at least user, group, and other, either as an ``int`` or
+        ``str``, those permissions will be used.
 
     ``create_remote_dir``:
         If the remote directory does not exist it will be created using the same
@@ -815,6 +817,11 @@ def put(
     Note:
         This operation is not suitable for large files as it may involve copying
         the file before uploading it.
+
+        Currently, if the mode argument is anything other than a ``bool`` or a full
+        octal permission set and the remote file exists, the operation will always
+        behave as if the remote file does not match the specified permissions and
+        requires a change.
 
     **Examples:**
 

--- a/tests/operations/files.put/no_change_same_mode_as_local.json
+++ b/tests/operations/files.put/no_change_same_mode_as_local.json
@@ -1,0 +1,29 @@
+{
+    "args": ["somefile.txt", "/home/somefile.txt"],
+    "kwargs": {
+        "mode": true
+    },
+    "local_files": {
+        "files": {
+            "somefile.txt": {
+                "mode": 644
+            }
+        },
+        "dirs": {}
+    },
+    "facts": {
+        "files.File": {
+            "path=/home/somefile.txt": {
+                "mode": 644
+            }
+        },
+        "files.Directory": {
+            "path=/home": true
+        },
+        "files.Sha1File": {
+            "path=/home/somefile.txt": "ac2cd59a622114712b5b21081763c54bf0caacb8"
+        }
+    },
+    "commands": [],
+    "noop_description": "file /home/somefile.txt is already uploaded"
+}


### PR DESCRIPTION
Addresses the type mismatch issue causing issue #1137 and documents related type mismatch pitfalls for the ``mode`` argument to ``files.put()``.
