### PR TITLE
Allow specifying custom tempdir for files.download

### DIFF
--- a/pyinfra/api/host.py
+++ b/pyinfra/api/host.py
@@ -328,12 +328,18 @@ class Host:
 
         return temp_directory
 
-    def get_temp_filename(self, hash_key: Optional[str] = None, hash_filename: bool = True):
+    def get_temp_filename(
+        self,
+        hash_key: Optional[str] = None,
+        hash_filename: bool = True,
+        *,
+        temp_directory: Optional[str] = None,
+    ):
         """
         Generate a temporary filename for this deploy.
         """
 
-        temp_directory = self._get_temp_directory()
+        temp_directory = temp_directory or self._get_temp_directory()
 
         if not hash_key:
             hash_key = str(uuid4())

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -75,6 +75,7 @@ def download(
     headers: dict[str, str] | None = None,
     insecure=False,
     proxy: str | None = None,
+    temp_dir: str | Path | None = None,
 ):
     """
     Download files from remote locations using ``curl`` or ``wget``.
@@ -93,6 +94,7 @@ def download(
     + headers: optional dictionary of headers to set for the HTTP request
     + insecure: disable SSL verification for the HTTP request
     + proxy: simple HTTP proxy through which we can download files, form `http://<yourproxy>:<port>`
+    + temp_dir: use this custom temporary directory during the download
 
     **Example:**
 
@@ -148,7 +150,9 @@ def download(
 
     # If we download, always do user/group/mode as SSH user may be different
     if download:
-        temp_file = host.get_temp_filename(dest)
+        temp_file = host.get_temp_filename(
+            dest, temp_directory=str(temp_dir) if temp_dir is not None else None
+        )
 
         curl_args: list[Union[str, StringCommand]] = ["-sSLf"]
         wget_args: list[Union[str, StringCommand]] = ["-q"]

--- a/tests/util.py
+++ b/tests/util.py
@@ -184,7 +184,7 @@ class FakeHost:
     def noop(self, description):
         self.noop_description = description
 
-    def get_temp_filename(*args):
+    def get_temp_filename(*args, **kwargs):
         return "_tempfile_"
 
     @staticmethod


### PR DESCRIPTION
This introduces a new argument to the `files.download` operation: `temp_dir`, which allows the user to specify a custom temporary directory for downloading into.

I know that `TEMP_DIR` exists as an (undocumented) config option, but since `Host._get_temp_directory` is memoized, it's not feasible to set this option only for certain operations.

My use case is downloading very large files (> 100 GB) into specific volumes on the server, which are backed by different filesystems and have some constraints regarding free space. The default of downloading everything into `/tmp` (or whatever) doesn't work because it would fill up the root partition before the download even finishes, but setting `TEMP_DIR` to different directories throughout a single deploy is also not really possible without resorting to hacks, afaics.

To allow customizing the temporary directory, `Host.get_temp_filename` also gained a (keyword-only, optional) new argument `temp_directory`.