### PR TITLE
Treat `mounted` state as an active systemd unit

### DIFF
--- a/pyinfra/facts/systemd.py
+++ b/pyinfra/facts/systemd.py
@@ -64,7 +64,7 @@ class SystemdStatus(FactBase[Dict[str, bool]]):
     default = dict
 
     state_key = "SubState"
-    state_values = ["running", "waiting", "exited", "listening"]
+    state_values = ["running", "waiting", "exited", "listening", "mounted"]
 
     @override
     def command(

--- a/tests/facts/systemd.SystemdStatus/services.json
+++ b/tests/facts/systemd.SystemdStatus/services.json
@@ -12,12 +12,16 @@
         "SubState=dead",
         "",
         "Id=ebtables.timer",
-        "SubState=exited"
+        "SubState=exited",
+        "",
+        "Id=mnt-foo.mount",
+        "SubState=mounted"
     ],
     "fact":  {
         "lvm2-activation.service": false,
         "lvm2-lvmetad.service": true,
         "lvm2-lvmpolld.service": false,
-        "ebtables.timer": true
+        "ebtables.timer": true,
+        "mnt-foo.mount": true
     }
 }


### PR DESCRIPTION
This is important for mount units, which usually settle to either `mounted` or `dead`.

Fixes #1362.