### PR TITLE
files.line, crontab.crontab: actually delete lines when present=False

### DIFF
--- a/pyinfra/operations/crontab.py
+++ b/pyinfra/operations/crontab.py
@@ -6,7 +6,7 @@ from pyinfra import host
 from pyinfra.api import StringCommand, operation
 from pyinfra.api.util import try_int
 from pyinfra.facts.crontab import Crontab, CrontabFile
-from pyinfra.operations.util.files import sed_replace
+from pyinfra.operations.util.files import sed_delete, sed_replace
 
 
 @operation()
@@ -111,7 +111,7 @@ def crontab(
     # Don't want the cron and it does exist? Remove the line
     if not present and exists:
         edit_commands.append(
-            sed_replace(
+            sed_delete(
                 temp_filename,
                 existing_crontab_match,
                 "",

--- a/pyinfra/operations/files.py
+++ b/pyinfra/operations/files.py
@@ -56,7 +56,14 @@ from pyinfra.facts.files import (
 from pyinfra.facts.server import Date, Which
 
 from .util import files as file_utils
-from .util.files import adjust_regex, ensure_mode_int, get_timestamp, sed_replace, unix_path_join
+from .util.files import (
+    adjust_regex,
+    ensure_mode_int,
+    get_timestamp,
+    sed_delete,
+    sed_replace,
+    unix_path_join,
+)
 
 
 @operation()
@@ -427,9 +434,9 @@ def line(
         else:
             host.noop('line "{0}" exists in {1}'.format(replace or line, path))
 
-    # Line(s) exists and we want to remove them, replace with nothing
+    # Line(s) exists and we want to remove them
     elif present_lines and not present:
-        yield sed_replace(
+        yield sed_delete(
             path,
             match_line,
             "",

--- a/tests/operations/apt.repo/remove.json
+++ b/tests/operations/apt.repo/remove.json
@@ -16,6 +16,6 @@
         }
     },
     "commands": [
-        "sed -i.a-timestamp 's/^.*deb http:\\/\\/archive\\.canonical\\.com\\/ubuntu hardy partner.*$//' /etc/apt/sources.list && rm -f /etc/apt/sources.list.a-timestamp"
+        "sed -i.a-timestamp '/^.*deb http:\\/\\/archive\\.canonical\\.com\\/ubuntu hardy partner.*$/d' /etc/apt/sources.list && rm -f /etc/apt/sources.list.a-timestamp"
     ]
 }

--- a/tests/operations/bsdinit.service/disabled.json
+++ b/tests/operations/bsdinit.service/disabled.json
@@ -15,6 +15,6 @@
         }
     },
     "commands": [
-        "sed -i.a-timestamp 's/^nginx_enable=.*$//' /etc/rc.conf.local && rm -f /etc/rc.conf.local.a-timestamp"
+        "sed -i.a-timestamp '/^nginx_enable=.*$/d' /etc/rc.conf.local && rm -f /etc/rc.conf.local.a-timestamp"
     ]
 }

--- a/tests/operations/crontab.crontab/remove.json
+++ b/tests/operations/crontab.crontab/remove.json
@@ -19,7 +19,7 @@
     },
     "commands": [
         "crontab -l  > _tempfile_",
-        "sed -i.a-timestamp 's/.*this_is_a_command.*//' _tempfile_ && rm -f _tempfile_.a-timestamp",
+        "sed -i.a-timestamp '/.*this_is_a_command.*/d' _tempfile_ && rm -f _tempfile_.a-timestamp",
         "crontab  _tempfile_"
     ]
 }


### PR DESCRIPTION
* operations/utils/files.py: Add sed_delete().
Factor out common code from sed_replace and sed_delete into _sed_command(). Add _set_delete_builder() and _sed_replace_builder() to build the actual sed expression.

* operations/files.py line(): use sed_delete().
* operations/crontab.py crontab(): use sed_delete().

* tests/operations/apt.repo/remove.json, tests/operations/bsdinit.service/disabled.json,
tests/operations/crontab.crontab.remove.json: adjust expected commands.

Fixes #1376

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [N/A] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
