### PR TITLE
setup.py: remove unnecessary setuptools (runtime) dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ INSTALL_REQUIRES = (
     "click>2",
     "jinja2>2,<4",
     "python-dateutil>2,<3",
-    "setuptools",
     "pywinrm",
     "typeguard",
     "distro>=1.6,<2",
@@ -55,7 +54,6 @@ TEST_REQUIRES = (
     "types-paramiko",
     "types-python-dateutil",
     "types-PyYAML",
-    "types-setuptools",
 )
 
 DOCS_REQUIRES = (


### PR DESCRIPTION
setuptools should only be necessary for building package, but not for using it

It was introduced ~9 years ago in this commit https://github.com/pyinfra-dev/pyinfra/commit/be47be5474481d5629ac890f7e45e4048282d80e , likely for `pkg_resources`, but pyinfra migrated off it since due to deprecation

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [ ] Tests pass (see `scripts/dev-test.sh`)
- [ ] Type checking & code style passes (see `scripts/dev-lint.sh`)
