### PR TITLE
facts.server, operations.server: Make Mount fact and operation portable

### DIFF
--- a/pyinfra/operations/server.py
+++ b/pyinfra/operations/server.py
@@ -5,7 +5,6 @@ Linux/BSD.
 
 from __future__ import annotations
 
-import platform
 from io import StringIO
 from itertools import filterfalse, tee
 from os import path
@@ -21,6 +20,7 @@ from pyinfra.facts.server import (
     Groups,
     Home,
     Hostname,
+    Kernel,
     KernelModules,
     Locales,
     Mounts,
@@ -336,7 +336,7 @@ def mount(
         mounted_options = mounts[path]["options"]
         needed_options = set(options) - set(mounted_options)
         if needed_options:
-            if platform.system() == "FreeBSD":
+            if host.get_fact(Kernel).strip() == "FreeBSD":
                 fs_type = mounts[path]["type"]
                 device = mounts[path]["device"]
 

--- a/tests/facts/server.Mounts/mounts.json
+++ b/tests/facts/server.Mounts/mounts.json
@@ -5,6 +5,9 @@
         "33 29 8:1 / /boot rw,relatime - vfat /dev/sda1 rw,lazytime,fmask=0022,dmask=0022,codepage=437,iocharset=iso8859-1,shortname=mixed,utf8,errors=remount-ro",
         "408 35 0:352 / /mnt/overlay/overlay,dir\\040with\\040spaces\\040and\\040\\134backslashes ro,relatime shared:27 - overlay none ro,lowerdir=lower\\054dir,upperdir=upper\\054dir,workdir=work\\054dir"
     ],
+    "facts": {
+        "server.Kernel": "Linux"
+    },
     "fact": {
         "/": {
             "device": "/dev/sdb1",

--- a/tests/operations/server.mount/remount_options.json
+++ b/tests/operations/server.mount/remount_options.json
@@ -4,6 +4,7 @@
         "options": ["rw", "noatime"]
     },
     "facts": {
+        "server.Kernel": "Linux",
         "server.Mounts": {
             "/data": {
                 "options": ["rw"]

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -111,7 +111,7 @@ def make_operation_tests(arg):
             op_test_name = "{0}/{1}.json".format(arg, test_name)
 
             # Create a host with this tests facts and attach to context host
-            host = create_host(facts=test_data.get("facts", {}))
+            host = create_host(self.state, facts=test_data.get("facts", {}))
 
             allowed_exception = test_data.get("exception")
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -171,7 +171,8 @@ class FakeHost:
     current_deploy_kwargs = None
     current_deploy_data = None
 
-    def __init__(self, name, facts, data):
+    def __init__(self, state, name, facts, data):
+        self.state = state
         self.name = name
         self.fact = FakeFacts(facts)
         self.data = data
@@ -368,7 +369,7 @@ class patch_files:
                 yield recursive_return
 
 
-def create_host(name=None, facts=None, data=None):
+def create_host(state, name=None, facts=None, data=None):
     """
     Creates a FakeHost object with attached fact data.
     """
@@ -380,7 +381,7 @@ def create_host(name=None, facts=None, data=None):
     for name, fact_data in facts.items():
         real_facts[name] = fact_data
 
-    return FakeHost(name, facts=real_facts, data=data)
+    return FakeHost(state, name, facts=real_facts, data=data)
 
 
 class YamlTest(type):


### PR DESCRIPTION
Using `platform.system(...)` is not a good idea because it runs on the local machine and we need to take into account the operating system of the remote machine.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [X] Pull request is based on the default branch (`3.x` at this time)
- [ ] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [ ] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
