### PR TITLE
Fix user addition/modification operations for FreeBSD.

### DIFF
--- a/pyinfra/facts/server.py
+++ b/pyinfra/facts/server.py
@@ -526,10 +526,10 @@ class Users(FactBase):
         for i in `cat /etc/passwd | cut -d: -f1`; do
             ENTRY=`grep ^$i: /etc/passwd`;
             LASTLOG=`(((lastlog -u $i || lastlogin $i) 2> /dev/null) | grep ^$i | tr -s ' ')`;
-            PASSWORD=`grep ^$i: /etc/shadow | cut -d: -f2`;
+            PASSWORD=`(grep ^$i: /etc/shadow || grep ^$i: /etc/master.passwd) 2> /dev/null | cut -d: -f2`;
             echo "$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG|$PASSWORD";
         done
-    """.strip()
+    """.strip() # noqa
 
     default = dict
 

--- a/tests/facts/server.Users/mixed.json
+++ b/tests/facts/server.Users/mixed.json
@@ -8,7 +8,7 @@
         "freebsd:*:1001:1001:FreeBSD:/home/freebsd:/bin/sh|freebsd|freebsd|freebsd pts/0 10.1.10.10 Thu Aug 31 05:37:58 2023|$bsdpw$",
         "freebsdnologin:*:1001:1001:FreeBSD NoLogin:/home/freebsdnologin:/bin/sh|freebsdnologin|freebsdnologin||"
     ],
-    "command": "for i in `cat /etc/passwd | cut -d: -f1`; do\n            ENTRY=`grep ^$i: /etc/passwd`;\n            LASTLOG=`(((lastlog -u $i || lastlogin $i) 2> /dev/null) | grep ^$i | tr -s ' ')`;\n            PASSWORD=`grep ^$i: /etc/shadow | cut -d: -f2`;\n            echo \"$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG|$PASSWORD\";\n        done",
+    "command": "for i in `cat /etc/passwd | cut -d: -f1`; do\n            ENTRY=`grep ^$i: /etc/passwd`;\n            LASTLOG=`(((lastlog -u $i || lastlogin $i) 2> /dev/null) | grep ^$i | tr -s ' ')`;\n            PASSWORD=`(grep ^$i: /etc/shadow || grep ^$i: /etc/master.passwd) 2> /dev/null | cut -d: -f2`;\n            echo \"$ENTRY|`id -gn $i`|`id -Gn $i`|$LASTLOG|$PASSWORD\";\n        done",
     "fact": {
         "root": {
             "home": "/root",

--- a/tests/operations/server.user/add.freebsd.json
+++ b/tests/operations/server.user/add.freebsd.json
@@ -12,15 +12,15 @@
         "password": "$somecryptedpassword$"
     },
     "facts": {
-        "server.Os": "Linux",
+        "server.Os": "FreeBSD",
         "server.Users": {},
         "server.Groups": {},
         "files.Directory": {
             "path=homedir": null
-        },
+        }
     },
     "commands": [
-        "useradd -d homedir -s shellbin -g mygroup -G secondary_group,another -r --uid 1000 -c 'Full Name' -m -p '$somecryptedpassword$' someuser",
+        "echo '$somecryptedpassword$' | pw useradd -n someuser -H 0 -d homedir -s shellbin -g mygroup -G secondary_group,another -u 1000 -c 'Full Name' -m",
         "mkdir -p homedir",
         "chown someuser:mygroup homedir"
     ]

--- a/tests/operations/server.user/add_group_exists.freebsd.json
+++ b/tests/operations/server.user/add_group_exists.freebsd.json
@@ -1,0 +1,18 @@
+{
+    "args": ["someuser"],
+    "facts": {
+        "server.Users": {},
+        "server.Groups": [
+            "someuser"
+        ],
+        "files.Directory": {
+            "path=/home/someuser": null
+        },
+        "server.Os": "FreeBSD"
+    },
+    "commands": [
+        "pw useradd -n someuser -d /home/someuser -g someuser",
+        "mkdir -p /home/someuser",
+        "chown someuser:someuser /home/someuser"
+    ]
+}

--- a/tests/operations/server.user/add_home_is_link.freebsd.json
+++ b/tests/operations/server.user/add_home_is_link.freebsd.json
@@ -1,0 +1,20 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "home": "homedir"
+    },
+    "facts": {
+        "server.Os": "FreeBSD",
+        "server.Users": {},
+        "server.Groups": {},
+        "files.Directory": {
+            "path=homedir": false
+        },
+        "files.Link": {
+            "path=homedir": true
+        }
+    },
+    "commands": [
+        "pw useradd -n someuser -d homedir"
+    ]
+}

--- a/tests/operations/server.user/add_non_unique.freebsd.json
+++ b/tests/operations/server.user/add_non_unique.freebsd.json
@@ -1,0 +1,15 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "unique": false,
+        "ensure_home": false
+    },
+    "facts": {
+        "server.Os": "FreeBSD",
+        "server.Users": {},
+        "server.Groups": {}
+    },
+    "commands": [
+        "pw useradd -n someuser -d /home/someuser -o"
+    ]
+}

--- a/tests/operations/server.user/append_secondary_groups.freebsd.json
+++ b/tests/operations/server.user/append_secondary_groups.freebsd.json
@@ -1,0 +1,36 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "group": "somegroup",
+        "groups": [
+            "group3", "group4"
+        ],
+        "append": true
+    },
+    "facts": {
+        "server.Os": "FreeBSD",
+        "server.Users": {
+            "someuser": {
+                "home": "/home/someuser",
+                "group": "somegroup",
+                "groups": [
+                    "group1", "group2"
+                ]
+            }
+        },
+        "files.Directory": {
+            "path=/home/someuser": {
+                "user": "someuser",
+                "group": "somegroup"
+            },
+            "path=/home/someotheruser": {
+                "user": "someuser",
+                "group": "somegroup"
+            }
+        },
+        "server.Groups": {}
+    },
+    "commands": [
+        "pw usermod -n someuser -a -G group3,group4"
+    ]
+}

--- a/tests/operations/server.user/edit.freebsd.json
+++ b/tests/operations/server.user/edit.freebsd.json
@@ -1,0 +1,39 @@
+{
+    "args": ["someuser"],
+    "kwargs": {
+        "shell": "/bin/false",
+        "group": "somegroup",
+        "groups": ["group1", "group2", "group3"],
+        "home": "/home/someotheruser",
+        "comment": "New Full Name"
+    },
+    "facts": {
+        "server.Os": "FreeBSD",
+        "server.Users": {
+            "someuser": {
+                "comment": "Full Name",
+                "home": "/home/someuser",
+                "shell": "/bin/bash",
+                "group": "nowt",
+                "groups": [
+                    "group1", "group2"
+                ],
+                "password": "$somepw$"
+            }
+        },
+        "files.Directory": {
+            "path=/home/someuser": {
+                "user": "someuser",
+                "group": "somegroup"
+            },
+            "path=/home/someotheruser": {
+                "user": "someuser",
+                "group": "somegroup"
+            }
+        },
+        "server.Groups": {}
+    },
+    "commands": [
+        "pw usermod -n someuser -d /home/someotheruser -s /bin/false -g somegroup -G group1,group2,group3 -c 'New Full Name'"
+    ]
+}


### PR DESCRIPTION
- The user addition/modification operations for FreeBSD were not correct. This patch fixes all issues I found (see man page https://man.freebsd.org/cgi/man.cgi?pw(8))

- On FreeBSD `/etc/shadow` does not exist, the file is called `/etc/master.passwd`.
The line for that is 6 characters too long to pass the flake8 linter. But adding newlines here will become rather messy in my opinion. Any thoughts?

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
