### PR TITLE
Make pyinfra compatible with `uv`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,21 @@
+[project]
+name = "pyinfra"
+# delegate handling of these to setup.py/setup.cfg
+dynamic = [
+    "authors",
+    "classifiers",
+    "dependencies",
+    "description",
+    "entry-points",
+    "license",
+    "optional-dependencies",
+    "readme",
+    "requires-python",
+    "scripts",
+    "urls",
+    "version",
+]
+
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
[uv](https://docs.astral.sh/uv/#projects) is a super fast package/project manager. 
Some nice things about using are
- it's managing the project's virtual env automatically, so you don't need to remember to activate it etc (https://docs.pyinfra.com/en/3.x/contributing.html#dev-setup)
- it's super easy to swap out any versions simply via `uv run` arguments (rather than modifying `setup.py` and recreating venv manually), this even applies to python versions

That said, the change is sort of orthogonal to uv, in the sense that `pyproject.toml` is a more modern way of describing projects. Ideally everything from `setup.py` which doesn't need to be dynamic should be in it, at the moment feels like everything could be moved except perhaps `get_version_from_changelog`. But for now limiting the scope of PR and just forwarding to `setup.py` via `dynamic` property.

--------- 

`uv` requires `pyproject.toml`, so previously trying to use `uv` against pyinfra resulted in:

```
$ uv run --extra dev mypy -p pyinfra
error: No `project` table found in: `/pyinfra/pyproject.toml`
```

After adding minimal `[project]` section to `pyproject.toml`, `uv` commands run succesfully.

Testing: to make sure the change doesn't introduce any visible changes to the package:

- built wheels on current `3.x` branch and on my branch via `python3 setup.py bdist_wheel`
- unpacked via `unzip`
- compared recursively via `diff -bur dist_old/ dist_new/`

This results in exact match, i.e. all package metadata is unchanged as expected.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
