### PR TITLE
operations/crontab: replace print with logger.debug

### DIFF
--- a/pyinfra/operations/crontab.py
+++ b/pyinfra/operations/crontab.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import shlex
 
-from pyinfra import host
-from pyinfra.api import StringCommand, operation
+from pyinfra import logger
+from pyinfra.api.command import StringCommand
+from pyinfra.api.operation import operation
 from pyinfra.api.util import try_int
+from pyinfra.context import host
 from pyinfra.facts.crontab import Crontab, CrontabFile
 from pyinfra.operations.util.files import sed_delete, sed_replace
-
-from pyinfra import logger
 
 
 @operation()

--- a/pyinfra/operations/crontab.py
+++ b/pyinfra/operations/crontab.py
@@ -8,6 +8,8 @@ from pyinfra.api.util import try_int
 from pyinfra.facts.crontab import Crontab, CrontabFile
 from pyinfra.operations.util.files import sed_delete, sed_replace
 
+from pyinfra import logger
+
 
 @operation()
 def crontab(
@@ -121,7 +123,7 @@ def crontab(
 
     # Want the cron but it doesn't exist? Append the line
     elif present and not exists:
-        print("present", present, "exists", exists)
+        logger.debug(f"present: {present}, exists: {exists}")
         if ctb:  # append a blank line if cron entries already exist
             edit_commands.append("echo '' >> {0}".format(temp_filename))
         if cron_name:


### PR DESCRIPTION
Replaces a `print` statement in crontab operation with `logger.debug`.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [ ] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
