### PR TITLE
Add support for enabling OpenRC service on a specific runlevel

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -78,7 +78,7 @@ pytest -m end_to_end_docker
 
 ## Documentation
 
-Documentation changes should be made in the [pyinfra git repository](https://github.com/pyinfra-dev/pyinfa) - the repository `docs.pyinfra.com` should
+Documentation changes should be made in the [pyinfra git repository](https://github.com/pyinfra-dev/pyinfra) - the repository `docs.pyinfra.com` should
 not be changed, it contains build artifacts.
 
 ### Generate Documentation

--- a/pyinfra/operations/openrc.py
+++ b/pyinfra/operations/openrc.py
@@ -48,10 +48,16 @@ def service(
         openrc_enabled = host.get_fact(OpenrcEnabled, runlevel=runlevel)
         is_enabled = openrc_enabled.get(service, False)
 
-        if enabled and not is_enabled:
-            yield "rc-update add {0}".format(service)
-            openrc_enabled[service] = True
+        if enabled is True:
+            if not is_enabled:
+                yield "rc-update add {0}".format(service)
+                openrc_enabled[service] = True
+            else:
+                host.noop("service {0} is enabled".format(service))
 
-        if not enabled and is_enabled:
-            yield "rc-update del {0}".format(service)
-            openrc_enabled[service] = False
+        if enabled is False:
+            if is_enabled:
+                yield "rc-update del {0}".format(service)
+                openrc_enabled[service] = False
+            else:
+                host.noop("service {0} is disabled".format(service))

--- a/pyinfra/operations/openrc.py
+++ b/pyinfra/operations/openrc.py
@@ -50,14 +50,14 @@ def service(
 
         if enabled is True:
             if not is_enabled:
-                yield "rc-update add {0}".format(service)
+                yield "rc-update add {0} {1}".format(service, runlevel)
                 openrc_enabled[service] = True
             else:
                 host.noop("service {0} is enabled".format(service))
 
         if enabled is False:
             if is_enabled:
-                yield "rc-update del {0}".format(service)
+                yield "rc-update del {0} {1}".format(service, runlevel)
                 openrc_enabled[service] = False
             else:
                 host.noop("service {0} is disabled".format(service))

--- a/tests/operations/openrc.service/disable.json
+++ b/tests/operations/openrc.service/disable.json
@@ -16,6 +16,6 @@
         }
     },
     "commands": [
-        "rc-update del nginx"
+        "rc-update del nginx default"
     ]
 }

--- a/tests/operations/openrc.service/disable_noop.json
+++ b/tests/operations/openrc.service/disable_noop.json
@@ -1,0 +1,20 @@
+{
+    "args": ["nginx"],
+    "kwargs": {
+        "enabled": false
+    },
+    "facts": {
+        "openrc.OpenrcStatus": {
+            "runlevel=default": {
+                "nginx": true
+            }
+        },
+        "openrc.OpenrcEnabled": {
+            "runlevel=default": {
+                "nginx": false
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "service nginx is disabled"
+}

--- a/tests/operations/openrc.service/disable_runlevel.json
+++ b/tests/operations/openrc.service/disable_runlevel.json
@@ -1,0 +1,22 @@
+{
+    "args": ["nftables"],
+    "kwargs": {
+        "runlevel": "boot",
+        "enabled": false
+    },
+    "facts": {
+        "openrc.OpenrcStatus": {
+            "runlevel=boot": {
+                "nftables": true
+            }
+        },
+        "openrc.OpenrcEnabled": {
+            "runlevel=boot": {
+                "nftables": true
+            }
+        }
+    },
+    "commands": [
+        "rc-update del nftables boot"
+    ]
+}

--- a/tests/operations/openrc.service/enable.json
+++ b/tests/operations/openrc.service/enable.json
@@ -16,6 +16,6 @@
         }
     },
     "commands": [
-        "rc-update add nginx"
+        "rc-update add nginx default"
     ]
 }

--- a/tests/operations/openrc.service/enable_noop.json
+++ b/tests/operations/openrc.service/enable_noop.json
@@ -1,0 +1,20 @@
+{
+    "args": ["nginx"],
+    "kwargs": {
+        "enabled": true
+    },
+    "facts": {
+        "openrc.OpenrcStatus": {
+            "runlevel=default": {
+                "nginx": true
+            }
+        },
+        "openrc.OpenrcEnabled": {
+            "runlevel=default": {
+                "nginx": true
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "service nginx is enabled"
+}

--- a/tests/operations/openrc.service/enable_runlevel.json
+++ b/tests/operations/openrc.service/enable_runlevel.json
@@ -1,0 +1,22 @@
+{
+    "args": ["nftables"],
+    "kwargs": {
+        "runlevel": "boot",
+        "enabled": true
+    },
+    "facts": {
+        "openrc.OpenrcStatus": {
+            "runlevel=boot": {
+                "nftables": true
+            }
+        },
+        "openrc.OpenrcEnabled": {
+            "runlevel=boot": {
+                "nftables": false
+            }
+        }
+    },
+    "commands": [
+        "rc-update add nftables boot"
+    ]
+}


### PR DESCRIPTION
<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)

Hello and thank you for your work on this project :)
I find the design to be very clear and well-thought, making it easy to engage with contributing.

I want to use pyinfra to enable a nftables service on the boot runlevel with OpenRC. I noticed that the openrc.service operation would always trigger a change on every run even though the service was never really enabled on this runlevel. This is because the change was always happening on the default runlevel, ignoring the configuration.

I would like to propose these changes:
- A noop message for when a service is already enabled/disabled to help with troubleshooting.
- Support for enabled/disabling services on a specific runlevel, as expected from the documentation.

I did not find it necessary to update the openrc.service documentation.
I also fixed a small typo in a link in the contributing documentation.