### PR TITLE
operations/crontab: fix replace containing newline, add test

### DIFF
--- a/pyinfra/operations/crontab.py
+++ b/pyinfra/operations/crontab.py
@@ -157,7 +157,7 @@ def crontab(
             ),
         ):
             if not exists_name and cron_name:
-                new_crontab_line = f"{name_comment}\n{new_crontab_line}"
+                new_crontab_line = f"{name_comment}\\n{new_crontab_line}"
             edit_commands.append(
                 sed_replace(
                     temp_filename,

--- a/tests/operations/crontab.crontab/edit_existing_with_newline.json
+++ b/tests/operations/crontab.crontab/edit_existing_with_newline.json
@@ -1,0 +1,26 @@
+{
+    "args": ["command_to_be"],
+    "kwargs": {
+        "month": 1,
+        "cron_name": "name of cron"
+    },
+    "facts": {
+        "crontab.Crontab": {
+            "user=None": {
+                "command_to_be": {
+                    "minute": "*",
+                    "hour": "*",
+                    "month": "*",
+                    "day_of_week": "*",
+                    "day_of_month": "*",
+                    "comments": []
+                }
+            }
+        }
+    },
+    "commands": [
+        "crontab -l  > _tempfile_",
+        "sed -i.a-timestamp 's/.*command_to_be.*/# pyinfra-name=name of cron\\n* * * 1 * command_to_be/' _tempfile_ && rm -f _tempfile_.a-timestamp",
+        "crontab  _tempfile_"
+    ]
+}


### PR DESCRIPTION
This replace is triggered e.g. when replacing an (pre-)existing crontab line without name to one maintained by pyinfra, this time with a pyinfra-name.

The sed replace command contains a newline character that should stay as a '\n' and not an actual newline, as sed does not support a multi-line script.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
