### PR TITLE
Return repoid in _parse_yum_or_zypper_repositories

### DIFF
--- a/pyinfra/facts/dnf.py
+++ b/pyinfra/facts/dnf.py
@@ -16,11 +16,15 @@ class DnfRepositories(FactBase):
 
         [
             {
-                "name": "CentOS-$releasever - Apps",
-                "baseurl": "http://mirror.centos.org/$contentdir/$releasever/Apps/$basearch/os/",
-                "gpgcheck": "1",
+                "repoid": "baseos",
+                "name": "AlmaLinux $releasever - BaseOS",
+                "mirrorlist": "https://mirrors.almalinux.org/mirrorlist/$releasever/baseos",
                 "enabled": "1",
-                "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+                "gpgcheck": "1",
+                "countme": "1",
+                "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9",
+                "metadata_expire": "86400",
+                "enabled_metadata": "1"
             },
         ]
     """

--- a/pyinfra/facts/util/packaging.py
+++ b/pyinfra/facts/util/packaging.py
@@ -32,6 +32,7 @@ def _parse_yum_or_zypper_repositories(output):
                 repos.append(current_repo)
                 current_repo = {}
 
+            current_repo["repoid"] = line[1:-1]
             current_repo["name"] = line[1:-1]
 
         if current_repo and "=" in line:

--- a/pyinfra/facts/yum.py
+++ b/pyinfra/facts/yum.py
@@ -16,11 +16,15 @@ class YumRepositories(FactBase):
 
         [
             {
-                "name": "CentOS-$releasever - Apps",
-                "baseurl": "http://mirror.centos.org/$contentdir/$releasever/Apps/$basearch/os/",
-                "gpgcheck": "1",
+                "repoid": "baseos",
+                "name": "AlmaLinux $releasever - BaseOS",
+                "mirrorlist": "https://mirrors.almalinux.org/mirrorlist/$releasever/baseos",
                 "enabled": "1",
-                "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial",
+                "gpgcheck": "1",
+                "countme": "1",
+                "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux-9",
+                "metadata_expire": "86400",
+                "enabled_metadata": "1"
             },
         ]
     """

--- a/pyinfra/facts/zypper.py
+++ b/pyinfra/facts/zypper.py
@@ -16,11 +16,11 @@ class ZypperRepositories(FactBase):
 
         [
             {
+                "repoid": "repo-oss",
                 "name": "Main Repository",
                 "enabled": "1",
-                "autorefresh": "0",
-                "baseurl": "http://download.opensuse.org/distribution/leap/$releasever/repo/oss/",
-                "type": "rpm-md",
+                "autorefresh": "1",
+                "baseurl": "http://download.opensuse.org/distribution/leap/$releasever/repo/oss/"
             },
         ]
     """

--- a/tests/facts/dnf.DnfRepositories/repos-with-spaces.json
+++ b/tests/facts/dnf.DnfRepositories/repos-with-spaces.json
@@ -7,6 +7,7 @@
     ],
     "fact": [
         {
+            "repoid": "rhel-atomic-7-cdk-3.6-source-rpms",
             "name": "Red Hat Container Development Kit 3.6 /(Source RPMs)"
         }
     ]

--- a/tests/facts/dnf.DnfRepositories/repos.json
+++ b/tests/facts/dnf.DnfRepositories/repos.json
@@ -10,10 +10,12 @@
     ],
     "fact": [
         {
+            "repoid": "somerepo",
             "name": "somerepo",
             "baseurl": "abc"
         },
         {
+            "repoid": "anotherrepo",
             "name": "anotherrepo"
         }
     ]

--- a/tests/facts/yum.YumRepositories/repos.json
+++ b/tests/facts/yum.YumRepositories/repos.json
@@ -10,6 +10,7 @@
     ],
     "fact": [
         {
+            "repoid": "somerepo",
             "name": "somerepo",
             "baseurl": "abc"
         }

--- a/tests/facts/zypper.ZypperRepositories/repos.json
+++ b/tests/facts/zypper.ZypperRepositories/repos.json
@@ -10,6 +10,7 @@
     ],
     "fact": [
         {
+            "repoid": "somerepo",
             "name": "somerepo",
             "baseurl": "abc"
         }


### PR DESCRIPTION
This PR modifies `parse_yum_repositories` and `parse_zypper_repositories` to return `repoid` alongside other metadata. For backwards compatibility, `name` is still set to the repoid, unless overwritten. Closes #1408

This PR also refreshes the examples used in the docs (sourced from openSUSE Leap 15.6 and AlmaLinux 9.6) (AlmaLinux was chosen because other distros have way too long URLs and Flake8 didn't like it)

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
