### PR TITLE
fix #1425 and #1427 to get the temp directory in a way that respects config.TEMP_DIR…

### DIFF
--- a/src/pyinfra/api/host.py
+++ b/src/pyinfra/api/host.py
@@ -313,7 +313,7 @@ class Host:
         )
 
     @memoize
-    def _get_temp_directory(self):
+    def get_temp_directory(self):
         temp_directory = self.state.config.TEMP_DIR
 
         if temp_directory is None:
@@ -339,7 +339,7 @@ class Host:
         Generate a temporary filename for this deploy.
         """
 
-        temp_directory = temp_directory or self._get_temp_directory()
+        temp_directory = temp_directory or self.get_temp_directory()
 
         if not hash_key:
             hash_key = str(uuid4())

--- a/src/pyinfra/api/host.py
+++ b/src/pyinfra/api/host.py
@@ -313,7 +313,7 @@ class Host:
         )
 
     @memoize
-    def get_temp_directory(self):
+    def _get_temp_directory(self):
         temp_directory = self.state.config.TEMP_DIR
 
         if temp_directory is None:
@@ -328,6 +328,10 @@ class Host:
 
         return temp_directory
 
+    def get_temp_dir_config(self):
+
+        return self.state.config.TEMP_DIR or self.state.config.DEFAULT_TEMP_DIR
+
     def get_temp_filename(
         self,
         hash_key: Optional[str] = None,
@@ -339,7 +343,7 @@ class Host:
         Generate a temporary filename for this deploy.
         """
 
-        temp_directory = temp_directory or self.get_temp_directory()
+        temp_directory = temp_directory or self._get_temp_directory()
 
         if not hash_key:
             hash_key = str(uuid4())

--- a/src/pyinfra/api/host.py
+++ b/src/pyinfra/api/host.py
@@ -329,7 +329,6 @@ class Host:
         return temp_directory
 
     def get_temp_dir_config(self):
-
         return self.state.config.TEMP_DIR or self.state.config.DEFAULT_TEMP_DIR
 
     def get_temp_filename(

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -28,7 +28,7 @@ SUDO_ASKPASS_COMMAND = r"""
 temp=$(mktemp "${{TMPDIR:={0}}}/pyinfra-sudo-askpass-XXXXXXXXXXXX")
 cat >"$temp"<<'__EOF__'
 #!/bin/sh
-printf '%s\n' "${0}"
+printf '%s\n' "${1}"
 __EOF__
 chmod 755 "$temp"
 echo "$temp"

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -265,7 +265,7 @@ def _ensure_sudo_askpass_set_for_host(host: "Host"):
     if host.connector_data.get("sudo_askpass_path"):
         return
     _, output = host.run_shell_command(
-        SUDO_ASKPASS_COMMAND.format(host.get_temp_directory(), SUDO_ASKPASS_ENV_VAR)
+        SUDO_ASKPASS_COMMAND.format(host.get_temp_dir_config(), SUDO_ASKPASS_ENV_VAR)
     )
     host.connector_data["sudo_askpass_path"] = shlex.quote(output.stdout_lines[0])
 

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -22,17 +22,17 @@ if TYPE_CHECKING:
 
 
 SUDO_ASKPASS_ENV_VAR = "PYINFRA_SUDO_PASSWORD"
+
+
 SUDO_ASKPASS_COMMAND = r"""
-temp=$(mktemp "${{TMPDIR:=/tmp}}/pyinfra-sudo-askpass-XXXXXXXXXXXX")
+temp=$(mktemp "${{TMPDIR:={0}}}/pyinfra-sudo-askpass-XXXXXXXXXXXX")
 cat >"$temp"<<'__EOF__'
 #!/bin/sh
 printf '%s\n' "${0}"
 __EOF__
 chmod 755 "$temp"
 echo "$temp"
-""".format(
-    SUDO_ASKPASS_ENV_VAR,
-)
+"""
 
 
 def run_local_process(
@@ -264,7 +264,9 @@ def extract_control_arguments(arguments: "ConnectorArguments") -> "ConnectorArgu
 def _ensure_sudo_askpass_set_for_host(host: "Host"):
     if host.connector_data.get("sudo_askpass_path"):
         return
-    _, output = host.run_shell_command(SUDO_ASKPASS_COMMAND)
+    _, output = host.run_shell_command(
+        SUDO_ASKPASS_COMMAND.format(host.get_temp_directory(), SUDO_ASKPASS_ENV_VAR)
+    )
     host.connector_data["sudo_askpass_path"] = shlex.quote(output.stdout_lines[0])
 
 

--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -1803,6 +1803,8 @@ def block(
     current = host.get_fact(Block, path=path, marker=marker, begin=begin, end=end)
     cmd = None
 
+    tmp_dir = host.get_temp_directory()
+
     # standard awk doesn't have an "in-place edit" option so we write to a tempfile and
     # if edits were successful move to dest i.e. we do: <out_prep> ... do some work ... <real_out>
     q_path = QuoteString(path)
@@ -1818,7 +1820,7 @@ def block(
         )
     )
     out_prep = StringCommand(
-        'OUT="$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)" && ',
+        f'OUT="$(TMPDIR={tmp_dir} mktemp -t pyinfra.XXXXXX)" && ',
         *mode_get,
         'OWNER="$(stat -c "%u:%g"',
         q_path,

--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -1803,7 +1803,7 @@ def block(
     current = host.get_fact(Block, path=path, marker=marker, begin=begin, end=end)
     cmd = None
 
-    tmp_dir = host.get_temp_directory()
+    tmp_dir = host.get_temp_dir_config()
 
     # standard awk doesn't have an "in-place edit" option so we write to a tempfile and
     # if edits were successful move to dest i.e. we do: <out_prep> ... do some work ... <real_out>

--- a/tests/operations/files.block/add_existing_block_different_content.json
+++ b/tests/operations/files.block/add_existing_block_different_content.json
@@ -1,6 +1,11 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
         "content": "should be this",
         "line": "before this",
@@ -8,10 +13,12 @@
     },
     "facts": {
         "files.Block": {
-            "begin=None, end=None, marker=None, path=/home/someone/something": ["previously was something else"]
+            "begin=None, end=None, marker=None, path=/home/someone/something": [
+                "previously was something else"
+            ]
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1; next} f' /home/someone/something \"should be this\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
+        "OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1; next} f' /home/someone/something \"should be this\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_existing_block_different_content_and_backup.json
+++ b/tests/operations/files.block/add_existing_block_different_content_and_backup.json
@@ -1,6 +1,11 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
         "content": "should be this",
         "line": "before this",
@@ -9,10 +14,12 @@
     },
     "facts": {
         "files.Block": {
-            "begin=None, end=None, marker=None, path=/home/someone/something": ["previously was something else"]
+            "begin=None, end=None, marker=None, path=/home/someone/something": [
+                "previously was something else"
+            ]
         }
     },
     "commands": [
-        "cp /home/someone/something /home/someone/something.a-timestamp && OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1; next} f' /home/someone/something \"should be this\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
+        "cp /home/someone/something /home/someone/something.a-timestamp && OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1; next} f' /home/someone/something \"should be this\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_existing_block_different_content_multiple_lines.json
+++ b/tests/operations/files.block/add_existing_block_different_content_multiple_lines.json
@@ -1,17 +1,28 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
-        "content": ["should be this", "and this", "and even this"],
+        "content": [
+            "should be this",
+            "and this",
+            "and even this"
+        ],
         "line": "before this",
         "before": true
     },
     "facts": {
         "files.Block": {
-            "begin=None, end=None, marker=None, path=/home/someone/something": ["previously was something else"]
+            "begin=None, end=None, marker=None, path=/home/someone/something": [
+                "previously was something else"
+            ]
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1; next} f' /home/someone/something \"should be this\nand this\nand even this\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
+        "OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {{f=1; x=ARGV[2]; ARGV[2]=\"\"}}/# BEGIN PYINFRA BLOCK/ {print; print x; f=0} /# END PYINFRA BLOCK/ {print; f=1; next} f' /home/someone/something \"should be this\nand this\nand even this\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_no_existing_block_and_no_line.json
+++ b/tests/operations/files.block/add_no_existing_block_and_no_line.json
@@ -1,6 +1,11 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
         "content": "please add this",
         "before": true,
@@ -12,6 +17,6 @@
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && ( awk '{{print}}'  -  /dev/null > \"$OUT\" <<PYINFRAHERE\n# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\nPYINFRAHERE\n )  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  /home/someone/something"
+        "OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && ( awk '{{print}}'  -  /dev/null > \"$OUT\" <<PYINFRAHERE\n# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\nPYINFRAHERE\n )  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_no_existing_block_line_provided.json
+++ b/tests/operations/files.block/add_no_existing_block_line_provided.json
@@ -1,6 +1,11 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
         "content": "please add this",
         "line": "before this",
@@ -12,6 +17,6 @@
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {x=ARGV[2]; ARGV[2]=\"\"}  f!=1 && /^.*before this.*$/ { print x; f=1} END {if (f==0) print x } { print }' /home/someone/something \"# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
+        "OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {x=ARGV[2]; ARGV[2]=\"\"}  f!=1 && /^.*before this.*$/ { print x; f=1} END {if (f==0) print x } { print }' /home/someone/something \"# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_no_existing_block_line_provided_escape_regex.json
+++ b/tests/operations/files.block/add_no_existing_block_line_provided_escape_regex.json
@@ -1,6 +1,11 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
         "content": "please add this",
         "line": "before this *",
@@ -13,6 +18,6 @@
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {x=ARGV[2]; ARGV[2]=\"\"}  f!=1 && /^.*before this \\*.*$/ { print x; f=1} END {if (f==0) print x } { print }' /home/someone/something \"# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
+        "OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk 'BEGIN {x=ARGV[2]; ARGV[2]=\"\"}  f!=1 && /^.*before this \\*.*$/ { print x; f=1} END {if (f==0) print x } { print }' /home/someone/something \"# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\" > \"$OUT\"  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/add_no_existing_file.json
+++ b/tests/operations/files.block/add_no_existing_file.json
@@ -1,6 +1,11 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
         "content": "please add this",
         "line": "after this",
@@ -12,6 +17,6 @@
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && ( awk '{{print}}' /dev/null  -  > \"$OUT\" <<PYINFRAHERE\n# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\nPYINFRAHERE\n )  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  /home/someone/something"
+        "OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && ( awk '{{print}}' /dev/null  -  > \"$OUT\" <<PYINFRAHERE\n# BEGIN PYINFRA BLOCK\nplease add this\n# END PYINFRA BLOCK\nPYINFRAHERE\n )  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/remove_but_content_not_none.json
+++ b/tests/operations/files.block/remove_but_content_not_none.json
@@ -1,16 +1,23 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
         "content": "please check this",
         "present": false
     },
     "facts": {
         "files.Block": {
-            "begin=None, end=None, marker=None, path=/home/someone/something": ["some existing content"]
+            "begin=None, end=None, marker=None, path=/home/someone/something": [
+                "some existing content"
+            ]
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk '/# BEGIN PYINFRA BLOCK/,/# END PYINFRA BLOCK/ {next} 1' /home/someone/something > $OUT  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
+        "OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk '/# BEGIN PYINFRA BLOCK/,/# END PYINFRA BLOCK/ {next} 1' /home/someone/something > $OUT  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
     ]
 }

--- a/tests/operations/files.block/remove_existing_block.json
+++ b/tests/operations/files.block/remove_existing_block.json
@@ -1,15 +1,22 @@
 {
-    "require_platform": ["Darwin", "Linux"],
-    "args": ["/home/someone/something"],
+    "require_platform": [
+        "Darwin",
+        "Linux"
+    ],
+    "args": [
+        "/home/someone/something"
+    ],
     "kwargs": {
         "present": false
     },
     "facts": {
         "files.Block": {
-            "begin=None, end=None, marker=None, path=/home/someone/something": ["existing content"]
+            "begin=None, end=None, marker=None, path=/home/someone/something": [
+                "existing content"
+            ]
         }
     },
     "commands": [
-        "OUT=\"$(TMPDIR=/tmp mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk '/# BEGIN PYINFRA BLOCK/,/# END PYINFRA BLOCK/ {next} 1' /home/someone/something > $OUT  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
+        "OUT=\"$(TMPDIR=_tempdir_ mktemp -t pyinfra.XXXXXX)\" &&  MODE=\"$(stat -c %a /home/someone/something 2>/dev/null || stat -f %Lp /home/someone/something 2>/dev/null)\" && OWNER=\"$(stat -c \"%u:%g\" /home/someone/something 2>/dev/null || stat -f \"%u:%g\" /home/someone/something 2>/dev/null || echo $(id -un):$(id -gn))\" && awk '/# BEGIN PYINFRA BLOCK/,/# END PYINFRA BLOCK/ {next} 1' /home/someone/something > $OUT  && mv \"$OUT\" /home/someone/something  && chown \"$OWNER\" /home/someone/something  && chmod \"$MODE\" /home/someone/something"
     ]
 }

--- a/tests/util.py
+++ b/tests/util.py
@@ -198,6 +198,9 @@ class FakeHost:
     ):
         return True
 
+    def get_temp_directory(*args, **kwargs):
+        return "_tempdir_"
+
     @staticmethod
     def _get_fact_key(fact_cls):
         return "{0}.{1}".format(fact_cls.__module__.split(".")[-1], fact_cls.__name__)

--- a/tests/util.py
+++ b/tests/util.py
@@ -198,7 +198,7 @@ class FakeHost:
     ):
         return True
 
-    def get_temp_directory(*args, **kwargs):
+    def get_temp_dir_config(*args, **kwargs):
         return "_tempdir_"
 
     @staticmethod


### PR DESCRIPTION
Use `host.get_temp_directory` instead of hard-coding `/tmp`.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
