### PR TITLE
update config from values from config.py (fix #1424)

### DIFF
--- a/pyinfra/api/config.py
+++ b/pyinfra/api/config.py
@@ -232,3 +232,8 @@ class Config(ConfigDefaults):
 
     def copy(self) -> "Config":
         return Config(**dict(self.get_current_state()))
+
+    def update(self, values: dict) -> None:
+        for key, value in values.items():
+            if key in ConfigDefaults.__dict__:
+                setattr(self, key, value)

--- a/pyinfra_cli/main.py
+++ b/pyinfra_cli/main.py
@@ -556,11 +556,8 @@ def _set_config(
     if state.cwd:
         config_filename = path.join(state.cwd, config_filename)
     if path.exists(config_filename):
-        exec_file(config_filename)
-
-    # Lock the current config, this allows us to restore this version after
-    # executing deploy files that may alter them.
-    config.lock_current_state()
+        values = exec_file(config_filename)
+        config.update(values)
 
     # Arg based config overrides
     if sudo:
@@ -582,6 +579,10 @@ def _set_config(
 
     if fail_percent is not None:
         config.FAIL_PERCENT = fail_percent
+
+    # Lock the current config, this allows us to restore this version after
+    # executing deploy files that may alter them.
+    config.lock_current_state()
 
     return config
 


### PR DESCRIPTION
also lock _after_ applying CLI over-rides.

The current code only takes values defined in `config.py` if they are variables for which we have a default: this as assumed to be the intended limitation. If not, `update` can be simplified accordingly.

Intended to fix #1424 

- [ x] Pull request is based on the default branch (`3.x` at this time)
- [x ] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x ] Tests pass (see `scripts/dev-test.sh`)
- [ x] Type checking & code style passes (see `scripts/dev-lint.sh`)
