### PR TITLE
facts/server: support negative value in sysctl

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -459,7 +459,7 @@ class Sysctl(FactBase):
                 key = key.strip()
                 values = values.strip()
 
-                if re.match(r"^[a-zA-Z0-9_\.\s]+$", values):
+                if re.match(r"^[a-zA-Z0-9_\-\.\s]+$", values):
                     values = [try_int(item.strip()) for item in values.split()]
 
                     if len(values) == 1:

--- a/tests/facts/server.Sysctl/sysctl_linux.json
+++ b/tests/facts/server.Sysctl/sysctl_linux.json
@@ -1,11 +1,13 @@
 {
     "command": "sysctl -a",
     "output": [
+        "net.ipv4.tcp_adv_win_scale = -2",
         "vm.nr_hugepages_mempolicy = 0",
         "nope what",
         "vm.nr_overcommit_hugepages = 0"
     ],
     "fact": {
+        "net.ipv4.tcp_adv_win_scale": -2,
         "vm.nr_hugepages_mempolicy": 0,
         "vm.nr_overcommit_hugepages": 0
     }


### PR DESCRIPTION
<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)

Some sysctl value can be negative, for example `net.ipv4.tcp_adv_win_scale = -2`

Current facts/server/Sysctl parse -2 as string, but operations/server/Sysctl parse it as int