### PR TITLE
operations.util.packaging: Extend PkgInfo for winget

### DIFF
--- a/src/pyinfra/operations/util/packaging.py
+++ b/src/pyinfra/operations/util/packaging.py
@@ -15,12 +15,16 @@ from pyinfra.facts.rpm import RpmPackage
 from pyinfra.operations import files
 
 
+def default_inst_vers_format_fn(name: str, operator: str, version: str):
+    return "{name}{operator}{version}".format(name=name, operator=operator, version=version)
+
+
 class PkgInfo(NamedTuple):
     name: str
     version: str
     operator: str
     url: str
-    inst_vers_template: str = "{name}{operator}{version}"
+    inst_vers_format_fn: Callable = default_inst_vers_format_fn
     """
     The key packaging information needed: version, operator and url are optional.
     """
@@ -38,7 +42,7 @@ class PkgInfo(NamedTuple):
         """String that represents how a program can be installed.
 
         - If self.url exists, then url is always returned.
-        - If self.version exists, then inst_vers_template is used
+        - If self.version exists, then inst_vers_format_fn is used
         to create the string. The default template is '{name}{operator}{version}'.
         - Otherwise, self.name is returned.
 
@@ -49,12 +53,7 @@ class PkgInfo(NamedTuple):
             return shlex.quote(self.url)
 
         if self.version:
-            # assumes if version exists, then name and operator do
-            return self.inst_vers_template.format(
-                name=shlex.quote(self.name),
-                operator=shlex.quote(self.operator),
-                version=shlex.quote(self.version),
-            )
+            return shlex.quote(self.inst_vers_format_fn(self.name, self.operator, self.version))
         return shlex.quote(self.name)
 
     @classmethod

--- a/src/pyinfra/operations/util/packaging.py
+++ b/src/pyinfra/operations/util/packaging.py
@@ -20,6 +20,7 @@ class PkgInfo(NamedTuple):
     version: str
     operator: str
     url: str
+    inst_vers_template: str = "{name}{operator}{version}"
     """
     The key packaging information needed: version, operator and url are optional.
     """
@@ -34,13 +35,27 @@ class PkgInfo(NamedTuple):
 
     @property
     def inst_vers(self) -> str:
-        return (
-            self.url
-            if self.url != ""
-            else (
-                self.operator.join([self.name, self.version]) if self.version != "" else self.name
+        """String that represents how a program can be installed.
+
+        - If self.url exists, then url is always returned.
+        - If self.version exists, then inst_vers_template is used
+        to create the string. The default template is '{name}{operator}{version}'.
+        - Otherwise, self.name is returned.
+
+        Note, the result string will be quoted, so input is shell safe.
+        """
+
+        if self.url:
+            return shlex.quote(self.url)
+
+        if self.version:
+            # assumes if version exists, then name and operator do
+            return self.inst_vers_template.format(
+                name=shlex.quote(self.name),
+                operator=shlex.quote(self.operator),
+                version=shlex.quote(self.version),
             )
-        )
+        return shlex.quote(self.name)
 
     @classmethod
     def from_possible_pair(cls, s: str, join: str | None) -> PkgInfo:
@@ -194,7 +209,6 @@ def ensure_packages(
                         host.noop(f"package {pkg} is installed ({','.join(current_packages[pkg])})")
                     else:
                         host.noop(f"package {package.name} is installed")
-
     if present is False:
         for package in packages:
             has_package, expanded_packages = _has_package(
@@ -209,10 +223,10 @@ def ensure_packages(
 
     if diff_packages:
         command = install_command if present else uninstall_command
-        yield f"{command} {' '.join([shlex.quote(pkg) for pkg in diff_packages])}"
+        yield f"{command} {' '.join([pkg for pkg in diff_packages])}"
 
     if latest and upgrade_command and upgrade_packages:
-        yield f"{upgrade_command} {' '.join([shlex.quote(pkg) for pkg in upgrade_packages])}"
+        yield f"{upgrade_command} {' '.join([pkg for pkg in upgrade_packages])}"
 
 
 def ensure_rpm(state: State, host: Host, source: str, present: bool, package_manager_command: str):


### PR DESCRIPTION
## Background
I'm hoping to utilize the existing `ensure_packages` utility in `pyinfra-windows'. 

The utility currently makes some assumptions that don't work with `winget`. Namely, that all package managers support the following syntax:

```bash
apt install package1=version1 package2=version2

# does not work in winget
winget install package1=version1 package2=version2
```

You must do the following:
```bash
winget install package1 —version version1; winget install package2 —version version2;
```

This PR introduces `Pkginfo.inst_vers_template` to customize the creation `PkgInfo.inst_vers`.
The default template works from programs that support the  `{name}{operator}{version}` syntax. 

winget overides the template to do `'{name} {operator} {version};'.format("winget install Notepad++.Notepad++", "—version", "8.5")`

## Notes

This PR does change the `shlex.quote` behavior slightly, and I have left the failing tests for now.
Do you think this new quoting behavior is ok? 

```
# example failing test
--> COMMANDS OUTPUT:
[
    "pip install pyinfra==1.1 pytask another'>'1"
]
--> TEST WANTS:
[
    "pip install pyinfra==1.1 pytask 'another>1'"
]
```

If you don't want to support this here, I totally understand. I will duplicate some of the code. 

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
