### PR TITLE
Change recommended installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Why pyinfra? Design features include:
 
 ## Quickstart
 
-Install pyinfra with `pip`:
+Install pyinfra with [`uv`](https://docs.astral.sh/uv/):
 
 ```
-pip install pyinfra
+uv tool install pyinfra
 ```
 
 Now you can execute commands on hosts via SSH:

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,11 +1,11 @@
 Getting Started
 ===============
 
-This guide should help describe the basics of deploying stuff with pyinfra. Start by installing pyinfra with ``pip`` (see :doc:`full install instructions <./install>`):
+This guide should help describe the basics of deploying stuff with pyinfra. Start by installing pyinfra with `uv <https://docs.astral.sh/uv/>`_ (see :doc:`full install instructions <./install>`):
 
 .. code:: bash
 
-    pip install pyinfra
+    uv tool install pyinfra
 
 To do something with pyinfra you need two things:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,7 +26,49 @@ orphan: true
 
 ## Installation Method
 
-### Using pip (Recommended)
+### Using uv (Recommended)
+
+First install [uv](https://docs.astral.sh/uv/getting-started/installation/) if you haven't already.
+
+Now you can install pyinfra as a tool, or add it to your project's dependencies.
+
+#### Installing pyinfra as a tool
+
+   ```sh
+   # install pyinfra
+   uv tool install pyinfra
+   
+   # verify installation
+   pyinfra --version
+   ```
+
+#### Adding pyinfra to your project dependencies
+
+   ```sh
+   # add pyinfra to your project dependencies
+   uv add pyinfra
+   
+   # verify installation
+   uv run pyinfra --version
+   ```
+
+### Using pipx
+
+First install [pipx](https://pipx.pypa.io/stable/installation/) if you haven't already.
+
+#### Install pyinfra
+
+   ```sh
+   pipx install pyinfra
+   ```
+
+#### Verify Installation
+
+   ```sh
+   pyinfra --version
+   ```
+
+### Using pip
 
 #### Create a Virtual Environment (Best Practice)
 


### PR DESCRIPTION
This PR changes the recommended installation method from `pip` to [`uv`](https://docs.astral.sh/uv/) and adds pipx and leaves pip as alternative installation methods.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
