### PR TITLE
Pr1/3 : add GPG key management operations and facts

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -3,6 +3,7 @@ extend-exclude = [
     "tests/facts/apt.SimulateOperationWillChange/upgrade.json",
     "tests/facts/opkg.OpkgPackages/opkg_packages.json",
     "tests/words.txt",
+    "tests/facts/gpg.GpgKeyrings/*.json",  # GPG keyring test files contain hex key IDs
 ]
 
 [default]

--- a/src/pyinfra/facts/gpg.py
+++ b/src/pyinfra/facts/gpg.py
@@ -148,3 +148,71 @@ class GpgSecretKeys(GpgFactBase):
         return ("gpg --list-secret-keys --with-colons --keyring {0} --no-default-keyring").format(
             keyring,
         )
+
+
+class GpgKeyrings(GpgFactBase):
+    """
+    Returns information on all GPG keyrings found in specified directories.
+
+    .. code:: python
+
+        {
+            "/etc/apt/keyrings/docker.gpg": {
+                "format": "gpg",
+                "keys": {...}  # Same format as GpgKeys fact
+            }
+        }
+    """
+
+    @override
+    def command(self, directories):
+        if isinstance(directories, str):
+            directories = [directories]
+
+        search_locations = " ".join(f'"{d}"' for d in directories)
+
+        # Generate a command that finds keyrings and lists their keys
+        # We'll use a shell script that outputs keyring path followed by key info
+        return (
+            f"for keyring in $(find {search_locations} -type f \\( -name '*.gpg' "
+            f"-o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do "
+            f'echo "KEYRING:$keyring"; '
+            f'if [[ "$keyring" == *.asc ]]; then '
+            f'gpg --with-colons "$keyring" 2>/dev/null || true; '
+            f"else "
+            f'gpg --list-keys --with-colons --keyring "$keyring" --no-default-keyring 2>/dev/null || true; '  # noqa: E501
+            f"fi; done"
+        )
+
+    @override
+    def process(self, output):
+        keyrings = {}
+        current_keyring = None
+        current_output: list[str] = []
+
+        for line in output:
+            line = line.strip()
+            if not line:
+                continue
+
+            if line.startswith("KEYRING:"):
+                # Process previous keyring if exists
+                if current_keyring and current_output:
+                    keyring_format = current_keyring.split(".")[-1].lower()
+                    keys = super().process(current_output)
+                    keyrings[current_keyring] = {"format": keyring_format, "keys": keys}
+
+                # Start new keyring
+                current_keyring = line[8:]  # Remove "KEYRING:" prefix
+                current_output = []
+            else:
+                # Accumulate GPG output for current keyring
+                current_output.append(line)
+
+        # Process final keyring
+        if current_keyring and current_output:
+            keyring_format = current_keyring.split(".")[-1].lower()
+            keys = super().process(current_output)
+            keyrings[current_keyring] = {"format": keyring_format, "keys": keys}
+
+        return keyrings

--- a/src/pyinfra/facts/gpg.py
+++ b/src/pyinfra/facts/gpg.py
@@ -171,17 +171,15 @@ class GpgKeyrings(GpgFactBase):
 
         search_locations = " ".join(f'"{d}"' for d in directories)
 
-        # Generate a command that finds keyrings and lists their keys
-        # We'll use a shell script that outputs keyring path followed by key info
+        # Two separate find+exec calls to avoid bash-specific syntax:
+        # - binary keyrings (.gpg, .kbx) use --keyring / --no-default-keyring
+        # - armored keyrings (.asc) are passed directly to gpg
         return (
-            f"for keyring in $(find {search_locations} -type f \\( -name '*.gpg' "
-            f"-o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do "
-            f'echo "KEYRING:$keyring"; '
-            f'if [[ "$keyring" == *.asc ]]; then '
-            f'gpg --with-colons "$keyring" 2>/dev/null || true; '
-            f"else "
-            f'gpg --list-keys --with-colons --keyring "$keyring" --no-default-keyring 2>/dev/null || true; '  # noqa: E501
-            f"fi; done"
+            f"find {search_locations} -type f \\( -name '*.gpg' -o -name '*.kbx' \\) 2>/dev/null"
+            f' -exec sh -c \'echo "KEYRING:$1";'
+            f' gpg --list-keys --with-colons --keyring "$1" --no-default-keyring 2>/dev/null || true\' _ {{}} \\; ;'
+            f" find {search_locations} -type f -name '*.asc' 2>/dev/null"
+            f' -exec sh -c \'echo "KEYRING:$1"; gpg --with-colons "$1" 2>/dev/null || true\' _ {{}} \\;'
         )
 
     @override

--- a/src/pyinfra/operations/gpg.py
+++ b/src/pyinfra/operations/gpg.py
@@ -75,12 +75,19 @@ def _install_key_from_keyserver(keyserver: str, keyid: str | list[str], dest: st
 
 
 def _matches_keyid(existing_key_id: str, clean_key: str) -> bool:
-    """Check if existing_key_id matches a cleaned (no 0x prefix, uppercase) key ID."""
+    """Check if existing_key_id matches a cleaned (no 0x prefix, uppercase) key ID.
+
+    Supports all common GPG key ID forms:
+    - Short 8-char ID:   clean_key is a suffix of existing_key_id  (existing.endswith)
+    - Long 16-char ID:   exact match
+    - Full fingerprint:  clean_key ends with existing_key_id        (clean.endswith)
+    """
     existing_upper = existing_key_id.upper()
     return (
         clean_key == existing_upper
         or existing_upper.endswith(clean_key)
         or existing_upper.startswith(clean_key)
+        or clean_key.endswith(existing_upper)  # full fingerprint → short key ID
     )
 
 

--- a/src/pyinfra/operations/gpg.py
+++ b/src/pyinfra/operations/gpg.py
@@ -45,7 +45,7 @@ def _install_key_from_keyserver(keyserver: str, keyid: str | list[str], dest: st
     joined = " ".join(keyid)
 
     # Create temporary GPG home directory
-    temp_dir = f"/tmp/pyinfra-gpg-{host.get_temp_filename('')[-8:]}"
+    temp_dir = host.get_temp_filename(f"gpg-keyserver-{joined}")
 
     yield from files.directory._inner(
         path=temp_dir,

--- a/src/pyinfra/operations/gpg.py
+++ b/src/pyinfra/operations/gpg.py
@@ -74,6 +74,16 @@ def _install_key_from_keyserver(keyserver: str, keyid: str | list[str], dest: st
     )
 
 
+def _matches_keyid(existing_key_id: str, clean_key: str) -> bool:
+    """Check if existing_key_id matches a cleaned (no 0x prefix, uppercase) key ID."""
+    existing_upper = existing_key_id.upper()
+    return (
+        clean_key == existing_upper
+        or existing_upper.endswith(clean_key)
+        or existing_upper.startswith(clean_key)
+    )
+
+
 def _remove_key_from_keyrings(keyid: str | list[str], working_dirs: list[str]):
     """Remove specific keys from all keyrings in specified directories."""
     if isinstance(keyid, str):
@@ -83,31 +93,42 @@ def _remove_key_from_keyrings(keyid: str | list[str], working_dirs: list[str]):
     keyrings_info = host.get_fact(GpgKeyrings, directories=working_dirs)
 
     for keyring_path, keyring_data in keyrings_info.items():
-        # Get the keys from the GpgKeyrings fact data
+        keyring_format = keyring_data.get("format", "gpg")
         keys_in_keyring = keyring_data.get("keys", {})
 
-        # Check if any of the target keys exist in this keyring
-        keys_to_remove = []
+        # Collect fingerprints of matching keys to remove
+        fingerprints_to_remove = []
         for kid in keyid:
-            # Handle different key ID formats (short, long, with/without 0x prefix)
             clean_key = kid.replace("0x", "").replace("0X", "").upper()
+            for existing_key_id, key_info in keys_in_keyring.items():
+                if _matches_keyid(existing_key_id, clean_key):
+                    fingerprint = key_info.get("fingerprint", existing_key_id)
+                    if fingerprint not in fingerprints_to_remove:
+                        fingerprints_to_remove.append(fingerprint)
 
-            # Check for exact match or if the key ID is a suffix/prefix of any key
-            # in the keyring
-            for existing_key_id in keys_in_keyring.keys():
-                if (
-                    clean_key == existing_key_id.upper()
-                    or existing_key_id.upper().endswith(clean_key)
-                    or existing_key_id.upper().startswith(clean_key)
-                ):
-                    keys_to_remove.append(existing_key_id)
+        if not fingerprints_to_remove:
+            continue
 
-        if keys_to_remove:
-            # Remove the entire keyring file if any target keys are found
-            # This is the safest approach for keyring management
-            yield from files.file._inner(
-                path=keyring_path,
-                present=False,
+        if keyring_format == "asc":
+            # .asc (armored) files cannot be edited in-place.
+            # If only some keys match, we cannot selectively remove them.
+            if len(fingerprints_to_remove) < len(keys_in_keyring):
+                raise OperationError(
+                    f"Cannot remove individual keys from armored keyring {keyring_path!r}: "
+                    "the file contains other keys and cannot be edited in-place. "
+                    "Remove the file explicitly with present=False and no keyid."
+                )
+            yield from files.file._inner(path=keyring_path, present=False)
+        else:
+            # .gpg / .kbx: delete keys individually, then remove file if now empty
+            fingerprints_joined = " ".join(fingerprints_to_remove)
+            yield (
+                f'gpg --batch --yes --no-default-keyring --keyring "{keyring_path}"'
+                f" --delete-keys {fingerprints_joined}"
+            )
+            yield (
+                f'gpg --batch --no-default-keyring --keyring "{keyring_path}"'
+                f' --list-keys 2>/dev/null | grep -q "^pub" || rm -f "{keyring_path}"'
             )
 
 
@@ -119,32 +140,47 @@ def _remove_key_from_keyring(keyid: str | list[str], dest: str):
     # Check if the destination keyring exists and contains the target keys
     keyrings_info = host.get_fact(GpgKeyrings, directories=[str(PurePosixPath(dest).parent)])
 
-    if dest in keyrings_info:
-        keyring_data = keyrings_info[dest]
-        keys_in_keyring = keyring_data.get("keys", {})
+    if dest not in keyrings_info:
+        return
 
-        # Check if any of the target keys exist in this keyring
-        keys_found = False
-        for kid in keyid:
-            clean_key = kid.replace("0x", "").replace("0X", "").upper()
-            for existing_key_id in keys_in_keyring.keys():
-                # Check for exact match, suffix (short key ID), or prefix match
-                if (
-                    clean_key == existing_key_id.upper()
-                    or existing_key_id.upper().endswith(clean_key)
-                    or existing_key_id.upper().startswith(clean_key)
-                ):
-                    keys_found = True
-                    break
-            if keys_found:
-                break
+    keyring_data = keyrings_info[dest]
+    keyring_format = keyring_data.get("format", "gpg")
+    keys_in_keyring = keyring_data.get("keys", {})
 
-        if keys_found:
-            # Remove the entire keyring file - safest approach for keyring management
-            yield from files.file._inner(
-                path=dest,
-                present=False,
+    # Collect fingerprints of matching keys to remove
+    fingerprints_to_remove = []
+    for kid in keyid:
+        clean_key = kid.replace("0x", "").replace("0X", "").upper()
+        for existing_key_id, key_info in keys_in_keyring.items():
+            if _matches_keyid(existing_key_id, clean_key):
+                fingerprint = key_info.get("fingerprint", existing_key_id)
+                if fingerprint not in fingerprints_to_remove:
+                    fingerprints_to_remove.append(fingerprint)
+
+    if not fingerprints_to_remove:
+        return
+
+    if keyring_format == "asc":
+        # .asc (armored) files cannot be edited in-place.
+        # If only some keys match, we cannot selectively remove them.
+        if len(fingerprints_to_remove) < len(keys_in_keyring):
+            raise OperationError(
+                f"Cannot remove individual keys from armored keyring {dest!r}: "
+                "the file contains other keys and cannot be edited in-place. "
+                "Remove the file explicitly with present=False and no keyid."
             )
+        yield from files.file._inner(path=dest, present=False)
+    else:
+        # .gpg / .kbx: delete keys individually, then remove file if now empty
+        fingerprints_joined = " ".join(fingerprints_to_remove)
+        yield (
+            f'gpg --batch --yes --no-default-keyring --keyring "{dest}"'
+            f" --delete-keys {fingerprints_joined}"
+        )
+        yield (
+            f'gpg --batch --no-default-keyring --keyring "{dest}"'
+            f' --list-keys 2>/dev/null | grep -q "^pub" || rm -f "{dest}"'
+        )
 
 
 def _remove_keyring_file(dest: str):

--- a/src/pyinfra/operations/gpg.py
+++ b/src/pyinfra/operations/gpg.py
@@ -1,0 +1,327 @@
+"""
+Manage GPG keys and keyrings.
+"""
+
+from pathlib import PurePosixPath
+from urllib.parse import urlparse
+
+from pyinfra import host
+from pyinfra.api import OperationError, operation
+from pyinfra.facts.gpg import GpgKeyrings
+
+from . import files
+
+
+@operation()
+def key(
+    src: str | None = None,
+    dest: str | None = None,
+    keyserver: str | None = None,
+    keyid: str | list[str] | None = None,
+    dearmor: bool = True,
+    mode: str = "0644",
+    present: bool = True,
+    working_dirs: list[str] | None = None,
+):
+    """
+    Install or remove GPG keys from various sources.
+
+    Args:
+        src: filename or URL to a key (ASCII .asc or binary .gpg)
+        dest: destination path for the key file (required for installation, optional for removal)
+        keyserver: keyserver URL for fetching keys by ID
+        keyid: key ID or list of key IDs (required with keyserver, optional for removal)
+        dearmor: whether to convert ASCII armored keys to binary format
+        mode: file permissions for the installed key
+        present: whether the key should be present (True) or absent (False)
+        working_dirs: dirs to search for existing keyrings (required for removal without dest)
+                When False: if dest is provided, removes from specific keyring;
+                           if dest is None, removes from keyrings found in working_dirs;
+                           if keyid is provided, removes specific key(s);
+                           if keyid is None, removes entire keyring file(s)
+
+    Examples:
+        gpg.key(
+            name="Install Docker GPG key",
+            src="https://download.docker.com/linux/debian/gpg",
+            dest="/etc/apt/keyrings/docker.gpg",
+        )
+
+        gpg.key(
+            name="Remove old GPG key file",
+            dest="/etc/apt/keyrings/old-key.gpg",
+            present=False,
+        )
+
+        gpg.key(
+            name="Remove specific key by ID",
+            dest="/etc/apt/keyrings/vendor.gpg",
+            keyid="0xABCDEF12",
+            present=False,
+        )
+
+        gpg.key(
+            name="Remove key from specific directories",
+            keyid="0xCOMPROMISED123",
+            present=False,
+            working_dirs=["/etc/apt/keyrings", "/usr/share/keyrings"],
+        )
+
+        gpg.key(
+            name="Fetch keys from keyserver",
+            keyserver="hkps://keyserver.ubuntu.com",
+            keyid=["0xD88E42B4", "0x7EA0A9C3"],
+            dest="/etc/apt/keyrings/vendor.gpg",
+        )
+    """
+
+    # Validate parameters based on operation type
+    if present is True:
+        # For installation, dest is required
+        if not dest:
+            raise OperationError("`dest` must be provided for installation")
+    elif present is False:
+        # For removal, either dest or (keyid and working_dirs) must be provided
+        if not dest and not (keyid and working_dirs):
+            raise OperationError(
+                "For removal, either `dest` or both `keyid` and `working_dirs` must be provided"
+            )
+
+    # For removal, handle different scenarios
+    if present is False:
+        if not dest and keyid:
+            # Remove key(s) from all keyrings found in specified directories
+            if isinstance(keyid, str):
+                keyid = [keyid]
+
+            if not working_dirs:
+                raise OperationError(
+                    "`working_dirs` must be provided when removing keys without `dest`"
+                )
+
+            # Use the GpgKeyrings fact to find all keyrings in specified directories
+            keyrings_info = host.get_fact(GpgKeyrings, directories=working_dirs)
+
+            for keyring_path, keyring_data in keyrings_info.items():
+                # Get the keys from the GpgKeyrings fact data
+                keys_in_keyring = keyring_data.get("keys", {})
+
+                # Check if any of the target keys exist in this keyring
+                keys_to_remove = []
+                for kid in keyid:
+                    # Handle different key ID formats (short, long, with/without 0x prefix)
+                    clean_key = kid.replace("0x", "").replace("0X", "").upper()
+
+                    # Check for exact match or if the key ID is a suffix/prefix of any key
+                    # in the keyring
+                    for existing_key_id in keys_in_keyring.keys():
+                        if (
+                            clean_key == existing_key_id.upper()
+                            or existing_key_id.upper().endswith(clean_key)
+                            or existing_key_id.upper().startswith(clean_key)
+                        ):
+                            keys_to_remove.append(existing_key_id)
+
+                if keys_to_remove:
+                    # Remove the entire keyring file if any target keys are found
+                    # This is the safest approach for keyring management
+                    yield from files.file._inner(
+                        path=keyring_path,
+                        present=False,
+                    )
+
+            return
+
+        elif dest and keyid:
+            # Remove specific key(s) from a specific keyring file
+            if isinstance(keyid, str):
+                keyid = [keyid]
+
+            # Check if the destination keyring exists and contains the target keys
+            keyrings_info = host.get_fact(
+                GpgKeyrings, directories=[str(PurePosixPath(dest).parent)]
+            )
+
+            if dest in keyrings_info:
+                keyring_data = keyrings_info[dest]
+                keys_in_keyring = keyring_data.get("keys", {})
+
+                # Check if any of the target keys exist in this keyring
+                keys_found = False
+                for kid in keyid:
+                    clean_key = kid.replace("0x", "").replace("0X", "").upper()
+                    for existing_key_id in keys_in_keyring.keys():
+                        # Check for exact match, suffix (short key ID), or prefix match
+                        if (
+                            clean_key == existing_key_id.upper()
+                            or existing_key_id.upper().endswith(clean_key)
+                            or existing_key_id.upper().startswith(clean_key)
+                        ):
+                            keys_found = True
+                            break
+                    if keys_found:
+                        break
+
+                if keys_found:
+                    # Remove the entire keyring file - safest approach for keyring management
+                    yield from files.file._inner(
+                        path=dest,
+                        present=False,
+                    )
+            return
+
+        elif dest and not keyid:
+            # Remove entire keyring file
+            yield from files.file._inner(
+                path=dest,
+                present=False,
+            )
+            return
+
+        else:
+            raise OperationError("Invalid parameters for removal operation")
+
+    # For installation, validate required parameters
+    if not src and not keyserver:
+        raise OperationError("Either `src` or `keyserver` must be provided for installation")
+
+    if keyserver and not keyid:
+        raise OperationError("`keyid` must be provided with `keyserver`")
+
+    if keyid and not keyserver and not src:
+        raise OperationError(
+            "When using `keyid` for installation, either `keyserver` or `src` must be provided"
+        )
+
+    # For installation (present=True), ensure destination directory exists
+    if dest is None:
+        raise OperationError("dest is required for installation")
+
+    dest_dir = str(PurePosixPath(dest).parent)
+    yield from files.directory._inner(
+        path=dest_dir,
+        mode="0755",
+        present=True,
+    )
+
+    # --- src branch: install a key from URL or local file ---
+    if src:
+        if urlparse(src).scheme in ("http", "https"):
+            # Remote source: download first, then process
+            temp_file = host.get_temp_filename(src)
+
+            yield from files.download._inner(
+                src=src,
+                dest=temp_file,
+            )
+
+            # Install the key and clean up temp file
+            yield from _install_key_file(temp_file, dest, dearmor, mode)
+
+            # Clean up temp file using pyinfra
+            yield from files.file._inner(
+                path=temp_file,
+                present=False,
+            )
+        else:
+            # Local file: install directly
+            yield from _install_key_file(src, dest, dearmor, mode)
+
+    # --- keyserver branch: fetch keys by ID ---
+    if keyserver:
+        if keyid is None:
+            raise OperationError("`keyid` must be provided with `keyserver`")
+
+        if isinstance(keyid, str):
+            keyid = [keyid]
+
+        joined = " ".join(keyid)
+
+        # Create temporary GPG home directory
+        temp_dir = f"/tmp/pyinfra-gpg-{host.get_temp_filename('')[-8:]}"
+
+        yield from files.directory._inner(
+            path=temp_dir,
+            mode="0700",  # GPG directories should be more restrictive
+            present=True,
+        )
+
+        # Export GNUPGHOME and fetch keys
+        yield f'export GNUPGHOME="{temp_dir}" && gpg --batch --keyserver "{keyserver}" --recv-keys {joined}'  # noqa: E501
+
+        # Export keys to destination - always use direct binary export
+        # gpg --export produces binary format by default, no dearmoring needed
+        yield (f'export GNUPGHOME="{temp_dir}" && gpg --batch --export {joined} > "{dest}"')
+
+        # Clean up temporary directory
+        yield from files.directory._inner(
+            path=temp_dir,
+            present=False,
+        )
+
+        # Set proper permissions
+        yield from files.file._inner(
+            path=dest,
+            mode=mode,
+            present=True,
+        )
+
+
+@operation()
+def dearmor(src: str, dest: str, mode: str = "0644"):
+    """
+    Convert ASCII armored GPG key to binary format.
+
+    Args:
+        src: source ASCII armored key file
+        dest: destination binary key file
+        mode: file permissions for the output file
+
+    Example:
+        gpg.dearmor(
+            name="Convert key to binary",
+            src="/tmp/key.asc",
+            dest="/etc/apt/keyrings/key.gpg",
+        )
+    """
+
+    # Ensure destination directory exists
+    dest_dir = str(PurePosixPath(dest).parent)
+    yield from files.directory._inner(
+        path=dest_dir,
+        mode="0755",
+        present=True,
+    )
+
+    yield f'gpg --batch --dearmor -o "{dest}" "{src}"'
+
+    # Set proper permissions
+    yield from files.file._inner(
+        path=dest,
+        mode=mode,
+        present=True,
+    )
+
+
+def _install_key_file(src_file: str, dest_path: str, dearmor: bool, mode: str):
+    """
+    Helper function to install a GPG key file, dearmoring if necessary.
+    """
+    if dearmor:
+        # Check if it's an ASCII armored key and handle accordingly
+        # Note: Could be enhanced using GpgKey fact
+        yield (
+            f'if grep -q "BEGIN PGP PUBLIC KEY BLOCK" "{src_file}"; then '
+            f'gpg --batch --dearmor -o "{dest_path}" "{src_file}"; '
+            f'else cp "{src_file}" "{dest_path}"; fi'
+        )
+    else:
+        # Simple copy for binary keys or when dearmoring is disabled
+        yield f'cp "{src_file}" "{dest_path}"'
+
+    # Set proper permissions
+    yield from files.file._inner(
+        path=dest_path,
+        mode=mode,
+        present=True,
+    )

--- a/src/pyinfra/operations/gpg.py
+++ b/src/pyinfra/operations/gpg.py
@@ -12,6 +12,177 @@ from pyinfra.facts.gpg import GpgKeyrings
 from . import files
 
 
+def _install_key_from_src(src: str, dest: str, dearmor: bool, mode: str):
+    """Install a GPG key from a file or URL."""
+    if urlparse(src).scheme in ("http", "https"):
+        # Remote source: download first, then process
+        temp_file = host.get_temp_filename(src)
+
+        yield from files.download._inner(
+            src=src,
+            dest=temp_file,
+        )
+
+        # Install the key and clean up temp file
+        yield from _install_key_file(temp_file, dest, dearmor, mode)
+
+        # Clean up temp file using pyinfra
+        yield from files.file._inner(
+            path=temp_file,
+            present=False,
+        )
+    else:
+        # Local file: install directly
+        yield from _install_key_file(src, dest, dearmor, mode)
+
+
+def _install_key_from_keyserver(keyserver: str, keyid: str | list[str], dest: str, mode: str):
+    """Install GPG keys from a keyserver."""
+    if isinstance(keyid, str):
+        keyid = [keyid]
+
+    joined = " ".join(keyid)
+
+    # Create temporary GPG home directory
+    temp_dir = f"/tmp/pyinfra-gpg-{host.get_temp_filename('')[-8:]}"
+
+    yield from files.directory._inner(
+        path=temp_dir,
+        mode="0700",  # GPG directories should be more restrictive
+        present=True,
+    )
+
+    # Export GNUPGHOME and fetch keys
+    yield f'export GNUPGHOME="{temp_dir}" && gpg --batch --keyserver "{keyserver}" --recv-keys {joined}'  # noqa: E501
+
+    # Export keys to destination - always use direct binary export
+    # gpg --export produces binary format by default, no dearmoring needed
+    yield (f'export GNUPGHOME="{temp_dir}" && gpg --batch --export {joined} > "{dest}"')
+
+    # Clean up temporary directory
+    yield from files.directory._inner(
+        path=temp_dir,
+        present=False,
+    )
+
+    # Set proper permissions
+    yield from files.file._inner(
+        path=dest,
+        mode=mode,
+        present=True,
+    )
+
+
+def _remove_key_from_keyrings(keyid: str | list[str], working_dirs: list[str]):
+    """Remove specific keys from all keyrings in specified directories."""
+    if isinstance(keyid, str):
+        keyid = [keyid]
+
+    # Use the GpgKeyrings fact to find all keyrings in specified directories
+    keyrings_info = host.get_fact(GpgKeyrings, directories=working_dirs)
+
+    for keyring_path, keyring_data in keyrings_info.items():
+        # Get the keys from the GpgKeyrings fact data
+        keys_in_keyring = keyring_data.get("keys", {})
+
+        # Check if any of the target keys exist in this keyring
+        keys_to_remove = []
+        for kid in keyid:
+            # Handle different key ID formats (short, long, with/without 0x prefix)
+            clean_key = kid.replace("0x", "").replace("0X", "").upper()
+
+            # Check for exact match or if the key ID is a suffix/prefix of any key
+            # in the keyring
+            for existing_key_id in keys_in_keyring.keys():
+                if (
+                    clean_key == existing_key_id.upper()
+                    or existing_key_id.upper().endswith(clean_key)
+                    or existing_key_id.upper().startswith(clean_key)
+                ):
+                    keys_to_remove.append(existing_key_id)
+
+        if keys_to_remove:
+            # Remove the entire keyring file if any target keys are found
+            # This is the safest approach for keyring management
+            yield from files.file._inner(
+                path=keyring_path,
+                present=False,
+            )
+
+
+def _remove_key_from_keyring(keyid: str | list[str], dest: str):
+    """Remove specific keys from a specific keyring file."""
+    if isinstance(keyid, str):
+        keyid = [keyid]
+
+    # Check if the destination keyring exists and contains the target keys
+    keyrings_info = host.get_fact(GpgKeyrings, directories=[str(PurePosixPath(dest).parent)])
+
+    if dest in keyrings_info:
+        keyring_data = keyrings_info[dest]
+        keys_in_keyring = keyring_data.get("keys", {})
+
+        # Check if any of the target keys exist in this keyring
+        keys_found = False
+        for kid in keyid:
+            clean_key = kid.replace("0x", "").replace("0X", "").upper()
+            for existing_key_id in keys_in_keyring.keys():
+                # Check for exact match, suffix (short key ID), or prefix match
+                if (
+                    clean_key == existing_key_id.upper()
+                    or existing_key_id.upper().endswith(clean_key)
+                    or existing_key_id.upper().startswith(clean_key)
+                ):
+                    keys_found = True
+                    break
+            if keys_found:
+                break
+
+        if keys_found:
+            # Remove the entire keyring file - safest approach for keyring management
+            yield from files.file._inner(
+                path=dest,
+                present=False,
+            )
+
+
+def _remove_keyring_file(dest: str):
+    """Remove an entire keyring file."""
+    yield from files.file._inner(
+        path=dest,
+        present=False,
+    )
+
+
+def _validate_installation_params(
+    src: str | None, keyserver: str | None, keyid: str | list[str] | None, dest: str | None
+):
+    """Validate parameters for key installation."""
+    if not src and not keyserver:
+        raise OperationError("Either `src` or `keyserver` must be provided for installation")
+
+    if keyserver and not keyid:
+        raise OperationError("`keyid` must be provided with `keyserver`")
+
+    if keyid and not keyserver and not src:
+        raise OperationError(
+            "When using `keyid` for installation, either `keyserver` or `src` must be provided"
+        )
+
+    if dest is None:
+        raise OperationError("`dest` must be provided for installation")
+
+
+def _validate_removal_params(
+    dest: str | None, keyid: str | list[str] | None, working_dirs: list[str] | None
+):
+    """Validate parameters for key removal."""
+    if not dest and not (keyid and working_dirs):
+        raise OperationError(
+            "For removal, either `dest` or both `keyid` and `working_dirs` must be provided"
+        )
+
+
 @operation()
 def key(
     src: str | None = None,
@@ -75,128 +246,38 @@ def key(
         )
     """
 
-    # Validate parameters based on operation type
-    if present is True:
-        # For installation, dest is required
-        if not dest:
-            raise OperationError("`dest` must be provided for installation")
-    elif present is False:
-        # For removal, either dest or (keyid and working_dirs) must be provided
-        if not dest and not (keyid and working_dirs):
-            raise OperationError(
-                "For removal, either `dest` or both `keyid` and `working_dirs` must be provided"
-            )
-
-    # For removal, handle different scenarios
+    # Handle removal operations
     if present is False:
+        _validate_removal_params(dest, keyid, working_dirs)
+
         if not dest and keyid:
             # Remove key(s) from all keyrings found in specified directories
-            if isinstance(keyid, str):
-                keyid = [keyid]
-
             if not working_dirs:
                 raise OperationError(
                     "`working_dirs` must be provided when removing keys without `dest`"
                 )
-
-            # Use the GpgKeyrings fact to find all keyrings in specified directories
-            keyrings_info = host.get_fact(GpgKeyrings, directories=working_dirs)
-
-            for keyring_path, keyring_data in keyrings_info.items():
-                # Get the keys from the GpgKeyrings fact data
-                keys_in_keyring = keyring_data.get("keys", {})
-
-                # Check if any of the target keys exist in this keyring
-                keys_to_remove = []
-                for kid in keyid:
-                    # Handle different key ID formats (short, long, with/without 0x prefix)
-                    clean_key = kid.replace("0x", "").replace("0X", "").upper()
-
-                    # Check for exact match or if the key ID is a suffix/prefix of any key
-                    # in the keyring
-                    for existing_key_id in keys_in_keyring.keys():
-                        if (
-                            clean_key == existing_key_id.upper()
-                            or existing_key_id.upper().endswith(clean_key)
-                            or existing_key_id.upper().startswith(clean_key)
-                        ):
-                            keys_to_remove.append(existing_key_id)
-
-                if keys_to_remove:
-                    # Remove the entire keyring file if any target keys are found
-                    # This is the safest approach for keyring management
-                    yield from files.file._inner(
-                        path=keyring_path,
-                        present=False,
-                    )
-
-            return
+            yield from _remove_key_from_keyrings(keyid, working_dirs)
 
         elif dest and keyid:
             # Remove specific key(s) from a specific keyring file
-            if isinstance(keyid, str):
-                keyid = [keyid]
-
-            # Check if the destination keyring exists and contains the target keys
-            keyrings_info = host.get_fact(
-                GpgKeyrings, directories=[str(PurePosixPath(dest).parent)]
-            )
-
-            if dest in keyrings_info:
-                keyring_data = keyrings_info[dest]
-                keys_in_keyring = keyring_data.get("keys", {})
-
-                # Check if any of the target keys exist in this keyring
-                keys_found = False
-                for kid in keyid:
-                    clean_key = kid.replace("0x", "").replace("0X", "").upper()
-                    for existing_key_id in keys_in_keyring.keys():
-                        # Check for exact match, suffix (short key ID), or prefix match
-                        if (
-                            clean_key == existing_key_id.upper()
-                            or existing_key_id.upper().endswith(clean_key)
-                            or existing_key_id.upper().startswith(clean_key)
-                        ):
-                            keys_found = True
-                            break
-                    if keys_found:
-                        break
-
-                if keys_found:
-                    # Remove the entire keyring file - safest approach for keyring management
-                    yield from files.file._inner(
-                        path=dest,
-                        present=False,
-                    )
-            return
+            yield from _remove_key_from_keyring(keyid, dest)
 
         elif dest and not keyid:
             # Remove entire keyring file
-            yield from files.file._inner(
-                path=dest,
-                present=False,
-            )
-            return
+            yield from _remove_keyring_file(dest)
 
         else:
             raise OperationError("Invalid parameters for removal operation")
 
-    # For installation, validate required parameters
-    if not src and not keyserver:
-        raise OperationError("Either `src` or `keyserver` must be provided for installation")
+        return
 
-    if keyserver and not keyid:
-        raise OperationError("`keyid` must be provided with `keyserver`")
+    # Handle installation operations
+    _validate_installation_params(src, keyserver, keyid, dest)
 
-    if keyid and not keyserver and not src:
-        raise OperationError(
-            "When using `keyid` for installation, either `keyserver` or `src` must be provided"
-        )
+    # After validation, we know dest is not None for installation
+    assert dest is not None, "dest should not be None after validation"
 
-    # For installation (present=True), ensure destination directory exists
-    if dest is None:
-        raise OperationError("dest is required for installation")
-
+    # Ensure destination directory exists
     dest_dir = str(PurePosixPath(dest).parent)
     yield from files.directory._inner(
         path=dest_dir,
@@ -204,67 +285,14 @@ def key(
         present=True,
     )
 
-    # --- src branch: install a key from URL or local file ---
+    # Install from source (file or URL)
     if src:
-        if urlparse(src).scheme in ("http", "https"):
-            # Remote source: download first, then process
-            temp_file = host.get_temp_filename(src)
+        yield from _install_key_from_src(src, dest, dearmor, mode)
 
-            yield from files.download._inner(
-                src=src,
-                dest=temp_file,
-            )
-
-            # Install the key and clean up temp file
-            yield from _install_key_file(temp_file, dest, dearmor, mode)
-
-            # Clean up temp file using pyinfra
-            yield from files.file._inner(
-                path=temp_file,
-                present=False,
-            )
-        else:
-            # Local file: install directly
-            yield from _install_key_file(src, dest, dearmor, mode)
-
-    # --- keyserver branch: fetch keys by ID ---
+    # Install from keyserver
     if keyserver:
-        if keyid is None:
-            raise OperationError("`keyid` must be provided with `keyserver`")
-
-        if isinstance(keyid, str):
-            keyid = [keyid]
-
-        joined = " ".join(keyid)
-
-        # Create temporary GPG home directory
-        temp_dir = f"/tmp/pyinfra-gpg-{host.get_temp_filename('')[-8:]}"
-
-        yield from files.directory._inner(
-            path=temp_dir,
-            mode="0700",  # GPG directories should be more restrictive
-            present=True,
-        )
-
-        # Export GNUPGHOME and fetch keys
-        yield f'export GNUPGHOME="{temp_dir}" && gpg --batch --keyserver "{keyserver}" --recv-keys {joined}'  # noqa: E501
-
-        # Export keys to destination - always use direct binary export
-        # gpg --export produces binary format by default, no dearmoring needed
-        yield (f'export GNUPGHOME="{temp_dir}" && gpg --batch --export {joined} > "{dest}"')
-
-        # Clean up temporary directory
-        yield from files.directory._inner(
-            path=temp_dir,
-            present=False,
-        )
-
-        # Set proper permissions
-        yield from files.file._inner(
-            path=dest,
-            mode=mode,
-            present=True,
-        )
+        assert keyid is not None, "keyid should not be None after validation"
+        yield from _install_key_from_keyserver(keyserver, keyid, dest, mode)
 
 
 @operation()

--- a/src/pyinfra/operations/gpg.py
+++ b/src/pyinfra/operations/gpg.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from pyinfra import host
 from pyinfra.api import OperationError, operation
 from pyinfra.facts.gpg import GpgKeyrings
+from pyinfra.facts import files as file_facts
 
 from . import files
 
@@ -276,6 +277,64 @@ def key(
 
     # After validation, we know dest is not None for installation
     assert dest is not None, "dest should not be None after validation"
+
+    # Check if key already exists (for idempotence)
+    if keyid:
+        # If we have keyid(s), check if they exist in the destination keyring
+        try:
+            dest_dir = str(PurePosixPath(dest).parent)
+            keyring_fact = host.get_fact(GpgKeyrings, [dest_dir])
+
+            # keyring_fact contains keyring paths as keys
+            # Check if our destination keyring exists in the fact
+            keyring_info = keyring_fact.get(dest)
+
+            if keyring_info:
+                existing_keys = keyring_info["keys"]
+                keyids_to_check = keyid if isinstance(keyid, list) else [keyid]
+
+                # Check if all requested keys already exist
+                all_keys_exist = True
+                for kid in keyids_to_check:
+                    # Remove 0x prefix if present for comparison
+                    clean_keyid = kid.replace("0x", "").replace("0X", "").upper()
+                    key_exists = any(
+                        clean_keyid in existing_key_id.upper()
+                        or existing_key_id.upper().endswith(clean_keyid)
+                        for existing_key_id in existing_keys.keys()
+                    )
+                    if not key_exists:
+                        all_keys_exist = False
+                        break
+
+                if all_keys_exist:
+                    # All keys already exist, ensure file permissions are correct
+                    yield from files.file._inner(
+                        path=dest,
+                        mode=mode,
+                        present=True,
+                    )
+                    host.noop(f"GPG keys {keyid} already exist in {dest}")
+                    return
+        except (KeyError, AttributeError):
+            # Fact not available or incomplete, proceed with installation
+            pass
+    else:
+        # If no keyid specified, check if destination file exists (for file/URL sources)
+        try:
+            file_fact = host.get_fact(file_facts.File, dest)
+            if file_fact:
+                # File exists, ensure permissions are correct
+                yield from files.file._inner(
+                    path=dest,
+                    mode=mode,
+                    present=True,
+                )
+                host.noop(f"GPG keyring {dest} already exists")
+                return
+        except (KeyError, AttributeError):
+            # Fact not available, proceed with installation
+            pass
 
     # Ensure destination directory exists
     dest_dir = str(PurePosixPath(dest).parent)

--- a/tests/facts/gpg.GpgKeyrings/asc_only.json
+++ b/tests/facts/gpg.GpgKeyrings/asc_only.json
@@ -1,0 +1,59 @@
+{
+    "command": "for keyring in $(find \"/etc/apt/trusted.gpg.d\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "requires_command": "gpg",
+    "arg": ["/etc/apt/trusted.gpg.d"],
+    "output": [
+        "KEYRING:/etc/apt/trusted.gpg.d/debian-archive-bookworm-automatic.asc",
+        "pub:-:4096:1:B7C5D7D6350947F8:1663251644:::-:::scSC::::::23::0:",
+        "fpr:::::::::4D64390375060AA4D3E84D8FB7C5D7D6350947F8:",
+        "uid:-::::1663251644::7B1EFED0F7198D8488DD53F0E95BB93FC4D0A10C::Debian Stable Release Key (12/bookworm) <debian-release@lists.debian.org>::::::::::0:",
+        "sub:-:4096:1:16E0B0B5FC11C3A7:1663251644:::-:::e::::::23:",
+        "fpr:::::::::CFD35E5D1F5CBDE15AE59C5E16E0B0B5FC11C3A7:",
+        "KEYRING:/etc/apt/trusted.gpg.d/debian-archive-bookworm-stable.asc",
+        "pub:-:4096:1:4F368D5D67269BAC:1663251677:::-:::scSC::::::23::0:",
+        "fpr:::::::::80E46CDDD2798E51FB74F84E4F368D5D67269BAC:",
+        "uid:-::::1663251677::BB28BDBA35F9A1A92F44E4C96A9E86FC66F9D4E6::Debian Archive Automatic Signing Key (12/bookworm) <ftpmaster@debian.org>::::::::::0:",
+        "sub:-:4096:1:D7AB25251C0A3EE3:1663251677:::-:::e::::::23:",
+        "fpr:::::::::C5691F97B9C30A5CF0A3B1F9D7AB25251C0A3EE3:"
+    ],
+    "fact": {
+        "/etc/apt/trusted.gpg.d/debian-archive-bookworm-automatic.asc": {
+            "format": "asc",
+            "keys": {
+                "B7C5D7D6350947F8": {
+                    "validity": "-",
+                    "length": 4096,
+                    "subkeys": {
+                        "16E0B0B5FC11C3A7": {
+                            "validity": "-",
+                            "length": 4096,
+                            "fingerprint": "CFD35E5D1F5CBDE15AE59C5E16E0B0B5FC11C3A7"
+                        }
+                    },
+                    "fingerprint": "4D64390375060AA4D3E84D8FB7C5D7D6350947F8",
+                    "uid_hash": "7B1EFED0F7198D8488DD53F0E95BB93FC4D0A10C",
+                    "uid": "Debian Stable Release Key (12/bookworm) <debian-release@lists.debian.org>"
+                }
+            }
+        },
+        "/etc/apt/trusted.gpg.d/debian-archive-bookworm-stable.asc": {
+            "format": "asc",
+            "keys": {
+                "4F368D5D67269BAC": {
+                    "validity": "-",
+                    "length": 4096,
+                    "subkeys": {
+                        "D7AB25251C0A3EE3": {
+                            "validity": "-",
+                            "length": 4096,
+                            "fingerprint": "C5691F97B9C30A5CF0A3B1F9D7AB25251C0A3EE3"
+                        }
+                    },
+                    "fingerprint": "80E46CDDD2798E51FB74F84E4F368D5D67269BAC",
+                    "uid_hash": "BB28BDBA35F9A1A92F44E4C96A9E86FC66F9D4E6",
+                    "uid": "Debian Archive Automatic Signing Key (12/bookworm) <ftpmaster@debian.org>"
+                }
+            }
+        }
+    }
+}

--- a/tests/facts/gpg.GpgKeyrings/asc_only.json
+++ b/tests/facts/gpg.GpgKeyrings/asc_only.json
@@ -1,7 +1,9 @@
 {
-    "command": "for keyring in $(find \"/etc/apt/trusted.gpg.d\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "command": "find \"/etc/apt/trusted.gpg.d\" -type f \\( -name '*.gpg' -o -name '*.kbx' \\) 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --list-keys --with-colons --keyring \"$1\" --no-default-keyring 2>/dev/null || true' _ {} \\; ; find \"/etc/apt/trusted.gpg.d\" -type f -name '*.asc' 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --with-colons \"$1\" 2>/dev/null || true' _ {} \\;",
     "requires_command": "gpg",
-    "arg": ["/etc/apt/trusted.gpg.d"],
+    "arg": [
+        "/etc/apt/trusted.gpg.d"
+    ],
     "output": [
         "KEYRING:/etc/apt/trusted.gpg.d/debian-archive-bookworm-automatic.asc",
         "pub:-:4096:1:B7C5D7D6350947F8:1663251644:::-:::scSC::::::23::0:",

--- a/tests/facts/gpg.GpgKeyrings/custom_directory.json
+++ b/tests/facts/gpg.GpgKeyrings/custom_directory.json
@@ -1,7 +1,9 @@
 {
-    "command": "for keyring in $(find \"/custom/keyring/path\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "command": "find \"/custom/keyring/path\" -type f \\( -name '*.gpg' -o -name '*.kbx' \\) 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --list-keys --with-colons --keyring \"$1\" --no-default-keyring 2>/dev/null || true' _ {} \\; ; find \"/custom/keyring/path\" -type f -name '*.asc' 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --with-colons \"$1\" 2>/dev/null || true' _ {} \\;",
     "requires_command": "gpg",
-    "arg": ["/custom/keyring/path"],
+    "arg": [
+        "/custom/keyring/path"
+    ],
     "output": [
         "KEYRING:/custom/keyring/path/custom.asc",
         "pub:-:4096:1:9A3B3C4D5E6F7890:1622505600:::-:::scSC::::::23::0:",

--- a/tests/facts/gpg.GpgKeyrings/custom_directory.json
+++ b/tests/facts/gpg.GpgKeyrings/custom_directory.json
@@ -1,0 +1,26 @@
+{
+    "command": "for keyring in $(find \"/custom/keyring/path\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "requires_command": "gpg",
+    "arg": ["/custom/keyring/path"],
+    "output": [
+        "KEYRING:/custom/keyring/path/custom.asc",
+        "pub:-:4096:1:9A3B3C4D5E6F7890:1622505600:::-:::scSC::::::23::0:",
+        "fpr:::::::::1234567890ABCDEF1234567890ABCDEF12345678:",
+        "uid:-::::1622505600::::Custom Key <custom@example.com>::::::::::0:"
+    ],
+    "fact": {
+        "/custom/keyring/path/custom.asc": {
+            "format": "asc",
+            "keys": {
+                "9A3B3C4D5E6F7890": {
+                    "validity": "-",
+                    "length": 4096,
+                    "subkeys": {},
+                    "fingerprint": "1234567890ABCDEF1234567890ABCDEF12345678",
+                    "uid_hash": "",
+                    "uid": "Custom Key <custom@example.com>"
+                }
+            }
+        }
+    }
+}

--- a/tests/facts/gpg.GpgKeyrings/default.json
+++ b/tests/facts/gpg.GpgKeyrings/default.json
@@ -1,0 +1,42 @@
+{
+    "command": "for keyring in $(find \"/etc/apt/trusted.gpg.d\" \"/etc/apt/keyrings\" \"/usr/share/keyrings\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "requires_command": "gpg",
+    "arg": [["/etc/apt/trusted.gpg.d", "/etc/apt/keyrings", "/usr/share/keyrings"]],
+    "output": [
+        "KEYRING:/etc/apt/keyrings/docker.gpg",
+        "tru:t:1:1601454628:0:3:1:5",
+        "pub:-:4096:1:ABCD1234EFGH5678:1336770936:::-:::scSC::::::23::0:",
+        "fpr:::::::::ABCD1234EFGH5678IJKL9012MNOP3456QRST7890:",
+        "uid:-::::1336770936::ABC123DEF456::Docker Release (CE deb) <docker@docker.com>::::::::::0:",
+        "KEYRING:/etc/apt/trusted.gpg.d/ubuntu-keyring.asc",
+        "pub:-:4096:1:1234ABCD5678EFGH:1336774248:::-:::scSC::::::23::0:",
+        "uid:-::::1336774248::::Ubuntu Archive Signing Key <ubuntu-archive@lists.ubuntu.com>::::::::::0:"
+    ],
+    "fact": {
+        "/etc/apt/keyrings/docker.gpg": {
+            "format": "gpg",
+            "keys": {
+                "ABCD1234EFGH5678": {
+                    "validity": "-",
+                    "length": 4096,
+                    "subkeys": {},
+                    "fingerprint": "ABCD1234EFGH5678IJKL9012MNOP3456QRST7890",
+                    "uid_hash": "ABC123DEF456",
+                    "uid": "Docker Release (CE deb) <docker@docker.com>"
+                }
+            }
+        },
+        "/etc/apt/trusted.gpg.d/ubuntu-keyring.asc": {
+            "format": "asc",
+            "keys": {
+                "1234ABCD5678EFGH": {
+                    "validity": "-",
+                    "length": 4096,
+                    "subkeys": {},
+                    "uid_hash": "",
+                    "uid": "Ubuntu Archive Signing Key <ubuntu-archive@lists.ubuntu.com>"
+                }
+            }
+        }
+    }
+}

--- a/tests/facts/gpg.GpgKeyrings/default.json
+++ b/tests/facts/gpg.GpgKeyrings/default.json
@@ -1,7 +1,13 @@
 {
-    "command": "for keyring in $(find \"/etc/apt/trusted.gpg.d\" \"/etc/apt/keyrings\" \"/usr/share/keyrings\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "command": "find \"/etc/apt/trusted.gpg.d\" \"/etc/apt/keyrings\" \"/usr/share/keyrings\" -type f \\( -name '*.gpg' -o -name '*.kbx' \\) 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --list-keys --with-colons --keyring \"$1\" --no-default-keyring 2>/dev/null || true' _ {} \\; ; find \"/etc/apt/trusted.gpg.d\" \"/etc/apt/keyrings\" \"/usr/share/keyrings\" -type f -name '*.asc' 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --with-colons \"$1\" 2>/dev/null || true' _ {} \\;",
     "requires_command": "gpg",
-    "arg": [["/etc/apt/trusted.gpg.d", "/etc/apt/keyrings", "/usr/share/keyrings"]],
+    "arg": [
+        [
+            "/etc/apt/trusted.gpg.d",
+            "/etc/apt/keyrings",
+            "/usr/share/keyrings"
+        ]
+    ],
     "output": [
         "KEYRING:/etc/apt/keyrings/docker.gpg",
         "tru:t:1:1601454628:0:3:1:5",

--- a/tests/facts/gpg.GpgKeyrings/empty_directory.json
+++ b/tests/facts/gpg.GpgKeyrings/empty_directory.json
@@ -1,0 +1,7 @@
+{
+    "command": "for keyring in $(find \"/empty/directory\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "requires_command": "gpg",
+    "arg": ["/empty/directory"],
+    "output": [],
+    "fact": {}
+}

--- a/tests/facts/gpg.GpgKeyrings/empty_directory.json
+++ b/tests/facts/gpg.GpgKeyrings/empty_directory.json
@@ -1,7 +1,9 @@
 {
-    "command": "for keyring in $(find \"/empty/directory\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "command": "find \"/empty/directory\" -type f \\( -name '*.gpg' -o -name '*.kbx' \\) 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --list-keys --with-colons --keyring \"$1\" --no-default-keyring 2>/dev/null || true' _ {} \\; ; find \"/empty/directory\" -type f -name '*.asc' 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --with-colons \"$1\" 2>/dev/null || true' _ {} \\;",
     "requires_command": "gpg",
-    "arg": ["/empty/directory"],
+    "arg": [
+        "/empty/directory"
+    ],
     "output": [],
     "fact": {}
 }

--- a/tests/facts/gpg.GpgKeyrings/mixed_formats.json
+++ b/tests/facts/gpg.GpgKeyrings/mixed_formats.json
@@ -1,7 +1,9 @@
 {
-    "command": "for keyring in $(find \"/etc/apt/trusted.gpg.d\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "command": "find \"/etc/apt/trusted.gpg.d\" -type f \\( -name '*.gpg' -o -name '*.kbx' \\) 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --list-keys --with-colons --keyring \"$1\" --no-default-keyring 2>/dev/null || true' _ {} \\; ; find \"/etc/apt/trusted.gpg.d\" -type f -name '*.asc' 2>/dev/null -exec sh -c 'echo \"KEYRING:$1\"; gpg --with-colons \"$1\" 2>/dev/null || true' _ {} \\;",
     "requires_command": "gpg",
-    "arg": ["/etc/apt/trusted.gpg.d"],
+    "arg": [
+        "/etc/apt/trusted.gpg.d"
+    ],
     "output": [
         "KEYRING:/etc/apt/trusted.gpg.d/debian-archive.gpg",
         "tru:t:1:1601454628:0:3:1:5",

--- a/tests/facts/gpg.GpgKeyrings/mixed_formats.json
+++ b/tests/facts/gpg.GpgKeyrings/mixed_formats.json
@@ -1,0 +1,62 @@
+{
+    "command": "for keyring in $(find \"/etc/apt/trusted.gpg.d\" -type f \\( -name '*.gpg' -o -name '*.asc' -o -name '*.kbx' \\) 2>/dev/null); do echo \"KEYRING:$keyring\"; if [[ \"$keyring\" == *.asc ]]; then gpg --with-colons \"$keyring\" 2>/dev/null || true; else gpg --list-keys --with-colons --keyring \"$keyring\" --no-default-keyring 2>/dev/null || true; fi; done",
+    "requires_command": "gpg",
+    "arg": ["/etc/apt/trusted.gpg.d"],
+    "output": [
+        "KEYRING:/etc/apt/trusted.gpg.d/debian-archive.gpg",
+        "tru:t:1:1601454628:0:3:1:5",
+        "pub:-:4096:1:73A4F27B8DD47936:1663251644:::-:::scSC::::::23::0:",
+        "fpr:::::::::4D64390375060AA4D3E84D8F73A4F27B8DD47936:",
+        "uid:-::::1663251644::7B1EFED0F7198D8488DD53F0E95BB93FC4D0A10C::Debian Archive Automatic Signing Key (11/bullseye) <ftpmaster@debian.org>::::::::::0:",
+        "KEYRING:/etc/apt/trusted.gpg.d/ubuntu-keyring.asc",
+        "pub:-:4096:1:1E9377A2BA9EF27F:1336770936:::-:::scSC::::::23::0:",
+        "fpr:::::::::790BC7277767219C42C86F931E9377A2BA9EF27F:",
+        "uid:-::::1336770936::::Ubuntu Archive Signing Key <ubuntu-archive@lists.ubuntu.com>::::::::::0:",
+        "KEYRING:/etc/apt/trusted.gpg.d/docker.kbx",
+        "tru:t:1:1601454628:0:3:1:5",
+        "pub:-:4096:1:9DC858229FC7DD38:1498167007:::-:::scSC::::::23::0:",
+        "fpr:::::::::9DC858229FC7DD38B3088BD89DC858229FC7DD38:",
+        "uid:-::::1498167007::::Docker Release (CE deb) <docker@docker.com>::::::::::0:"
+    ],
+    "fact": {
+        "/etc/apt/trusted.gpg.d/debian-archive.gpg": {
+            "format": "gpg",
+            "keys": {
+                "73A4F27B8DD47936": {
+                    "validity": "-",
+                    "length": 4096,
+                    "subkeys": {},
+                    "fingerprint": "4D64390375060AA4D3E84D8F73A4F27B8DD47936",
+                    "uid_hash": "7B1EFED0F7198D8488DD53F0E95BB93FC4D0A10C",
+                    "uid": "Debian Archive Automatic Signing Key (11/bullseye) <ftpmaster@debian.org>"
+                }
+            }
+        },
+        "/etc/apt/trusted.gpg.d/ubuntu-keyring.asc": {
+            "format": "asc",
+            "keys": {
+                "1E9377A2BA9EF27F": {
+                    "validity": "-",
+                    "length": 4096,
+                    "subkeys": {},
+                    "fingerprint": "790BC7277767219C42C86F931E9377A2BA9EF27F",
+                    "uid_hash": "",
+                    "uid": "Ubuntu Archive Signing Key <ubuntu-archive@lists.ubuntu.com>"
+                }
+            }
+        },
+        "/etc/apt/trusted.gpg.d/docker.kbx": {
+            "format": "kbx",
+            "keys": {
+                "9DC858229FC7DD38": {
+                    "validity": "-",
+                    "length": 4096,
+                    "subkeys": {},
+                    "fingerprint": "9DC858229FC7DD38B3088BD89DC858229FC7DD38",
+                    "uid_hash": "",
+                    "uid": "Docker Release (CE deb) <docker@docker.com>"
+                }
+            }
+        }
+    }
+}

--- a/tests/operations/gpg.dearmor/basic.json
+++ b/tests/operations/gpg.dearmor/basic.json
@@ -1,0 +1,22 @@
+{
+    "args": [],
+    "kwargs": {
+        "src": "/tmp/test.asc",
+        "dest": "/tmp/test.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/tmp": {
+                "mode": 755
+            }
+        },
+        "files.File": {
+            "path=/tmp/test.gpg": null
+        }
+    },
+    "commands": [
+        "gpg --batch --dearmor -o \"/tmp/test.gpg\" \"/tmp/test.asc\"",
+        "touch /tmp/test.gpg",
+        "chmod 644 /tmp/test.gpg"
+    ]
+}

--- a/tests/operations/gpg.dearmor/custom_mode.json
+++ b/tests/operations/gpg.dearmor/custom_mode.json
@@ -1,0 +1,24 @@
+{
+    "args": [],
+    "kwargs": {
+        "src": "/tmp/key.asc",
+        "dest": "/etc/apt/keyrings/key.gpg",
+        "mode": "0600"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/key.gpg": null
+        }
+    },
+    "commands": [
+        "mkdir -p /etc/apt/keyrings",
+        "chmod 755 /etc/apt/keyrings",
+        "gpg --batch --dearmor -o \"/etc/apt/keyrings/key.gpg\" \"/tmp/key.asc\"",
+        "mkdir -p /etc/apt/keyrings",
+        "touch /etc/apt/keyrings/key.gpg",
+        "chmod 600 /etc/apt/keyrings/key.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/custom_mode.json
+++ b/tests/operations/gpg.key/custom_mode.json
@@ -1,0 +1,24 @@
+{
+    "args": [],
+    "kwargs": {
+        "src": "/tmp/local-key.asc",
+        "dest": "/etc/apt/keyrings/test.gpg",
+        "mode": "0600"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/test.gpg": null
+        }
+    },
+    "commands": [
+        "mkdir -p /etc/apt/keyrings",
+        "chmod 755 /etc/apt/keyrings",
+        "if grep -q \"BEGIN PGP PUBLIC KEY BLOCK\" \"/tmp/local-key.asc\"; then gpg --batch --dearmor -o \"/etc/apt/keyrings/test.gpg\" \"/tmp/local-key.asc\"; else cp \"/tmp/local-key.asc\" \"/etc/apt/keyrings/test.gpg\"; fi",
+        "mkdir -p /etc/apt/keyrings",
+        "touch /etc/apt/keyrings/test.gpg",
+        "chmod 600 /etc/apt/keyrings/test.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/keyserver_multiple.json
+++ b/tests/operations/gpg.key/keyserver_multiple.json
@@ -8,7 +8,7 @@
     "facts": {
         "files.Directory": {
             "path=/etc/apt/keyrings": null,
-            "path=/tmp/pyinfra-gpg-empfile_": null
+            "path=_tempfile_": null
         },
         "files.File": {
             "path=/etc/apt/keyrings/vendor.gpg": null
@@ -17,10 +17,10 @@
     "commands": [
         "mkdir -p /etc/apt/keyrings",
         "chmod 755 /etc/apt/keyrings",
-        "mkdir -p /tmp/pyinfra-gpg-empfile_",
-        "chmod 700 /tmp/pyinfra-gpg-empfile_",
-        "export GNUPGHOME=\"/tmp/pyinfra-gpg-empfile_\" && gpg --batch --keyserver \"hkps://keyserver.ubuntu.com\" --recv-keys 0xD88E42B4 0x7EA0A9C3",
-        "export GNUPGHOME=\"/tmp/pyinfra-gpg-empfile_\" && gpg --batch --export 0xD88E42B4 0x7EA0A9C3 > \"/etc/apt/keyrings/vendor.gpg\"",
+        "mkdir -p _tempfile_",
+        "chmod 700 _tempfile_",
+        "export GNUPGHOME=\"_tempfile_\" && gpg --batch --keyserver \"hkps://keyserver.ubuntu.com\" --recv-keys 0xD88E42B4 0x7EA0A9C3",
+        "export GNUPGHOME=\"_tempfile_\" && gpg --batch --export 0xD88E42B4 0x7EA0A9C3 > \"/etc/apt/keyrings/vendor.gpg\"",
         "mkdir -p /etc/apt/keyrings",
         "touch /etc/apt/keyrings/vendor.gpg",
         "chmod 644 /etc/apt/keyrings/vendor.gpg"

--- a/tests/operations/gpg.key/keyserver_multiple.json
+++ b/tests/operations/gpg.key/keyserver_multiple.json
@@ -1,0 +1,28 @@
+{
+    "args": [],
+    "kwargs": {
+        "keyserver": "hkps://keyserver.ubuntu.com",
+        "keyid": ["0xD88E42B4", "0x7EA0A9C3"],
+        "dest": "/etc/apt/keyrings/vendor.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": null,
+            "path=/tmp/pyinfra-gpg-empfile_": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": null
+        }
+    },
+    "commands": [
+        "mkdir -p /etc/apt/keyrings",
+        "chmod 755 /etc/apt/keyrings",
+        "mkdir -p /tmp/pyinfra-gpg-empfile_",
+        "chmod 700 /tmp/pyinfra-gpg-empfile_",
+        "export GNUPGHOME=\"/tmp/pyinfra-gpg-empfile_\" && gpg --batch --keyserver \"hkps://keyserver.ubuntu.com\" --recv-keys 0xD88E42B4 0x7EA0A9C3",
+        "export GNUPGHOME=\"/tmp/pyinfra-gpg-empfile_\" && gpg --batch --export 0xD88E42B4 0x7EA0A9C3 > \"/etc/apt/keyrings/vendor.gpg\"",
+        "mkdir -p /etc/apt/keyrings",
+        "touch /etc/apt/keyrings/vendor.gpg",
+        "chmod 644 /etc/apt/keyrings/vendor.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/keyserver_no_keyid.json
+++ b/tests/operations/gpg.key/keyserver_no_keyid.json
@@ -1,0 +1,12 @@
+{
+    "args": [],
+    "kwargs": {
+        "keyserver": "hkps://keyserver.ubuntu.com",
+        "dest": "/etc/apt/keyrings/test.gpg"
+    },
+    "exception": {
+        "names": ["OperationError"],
+        "message": "`keyid` must be provided with `keyserver`"
+    },
+    "facts": {}
+}

--- a/tests/operations/gpg.key/keyserver_single.json
+++ b/tests/operations/gpg.key/keyserver_single.json
@@ -1,0 +1,28 @@
+{
+    "args": [],
+    "kwargs": {
+        "keyserver": "hkps://keyserver.ubuntu.com",
+        "keyid": ["0xD88E42B4"],
+        "dest": "/etc/apt/keyrings/vendor.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": null,
+            "path=/tmp/pyinfra-gpg-empfile_": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": null
+        }
+    },
+    "commands": [
+        "mkdir -p /etc/apt/keyrings",
+        "chmod 755 /etc/apt/keyrings",
+        "mkdir -p /tmp/pyinfra-gpg-empfile_",
+        "chmod 700 /tmp/pyinfra-gpg-empfile_",
+        "export GNUPGHOME=\"/tmp/pyinfra-gpg-empfile_\" && gpg --batch --keyserver \"hkps://keyserver.ubuntu.com\" --recv-keys 0xD88E42B4",
+        "export GNUPGHOME=\"/tmp/pyinfra-gpg-empfile_\" && gpg --batch --export 0xD88E42B4 > \"/etc/apt/keyrings/vendor.gpg\"",
+        "mkdir -p /etc/apt/keyrings",
+        "touch /etc/apt/keyrings/vendor.gpg",
+        "chmod 644 /etc/apt/keyrings/vendor.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/keyserver_single.json
+++ b/tests/operations/gpg.key/keyserver_single.json
@@ -8,7 +8,7 @@
     "facts": {
         "files.Directory": {
             "path=/etc/apt/keyrings": null,
-            "path=/tmp/pyinfra-gpg-empfile_": null
+            "path=_tempfile_": null
         },
         "files.File": {
             "path=/etc/apt/keyrings/vendor.gpg": null
@@ -17,10 +17,10 @@
     "commands": [
         "mkdir -p /etc/apt/keyrings",
         "chmod 755 /etc/apt/keyrings",
-        "mkdir -p /tmp/pyinfra-gpg-empfile_",
-        "chmod 700 /tmp/pyinfra-gpg-empfile_",
-        "export GNUPGHOME=\"/tmp/pyinfra-gpg-empfile_\" && gpg --batch --keyserver \"hkps://keyserver.ubuntu.com\" --recv-keys 0xD88E42B4",
-        "export GNUPGHOME=\"/tmp/pyinfra-gpg-empfile_\" && gpg --batch --export 0xD88E42B4 > \"/etc/apt/keyrings/vendor.gpg\"",
+        "mkdir -p _tempfile_",
+        "chmod 700 _tempfile_",
+        "export GNUPGHOME=\"_tempfile_\" && gpg --batch --keyserver \"hkps://keyserver.ubuntu.com\" --recv-keys 0xD88E42B4",
+        "export GNUPGHOME=\"_tempfile_\" && gpg --batch --export 0xD88E42B4 > \"/etc/apt/keyrings/vendor.gpg\"",
         "mkdir -p /etc/apt/keyrings",
         "touch /etc/apt/keyrings/vendor.gpg",
         "chmod 644 /etc/apt/keyrings/vendor.gpg"

--- a/tests/operations/gpg.key/keyserver_single_idempotent.json
+++ b/tests/operations/gpg.key/keyserver_single_idempotent.json
@@ -1,0 +1,42 @@
+{
+    "args": [],
+    "kwargs": {
+        "keyserver": "hkps://keyserver.ubuntu.com",
+        "keyid": ["0xD88E42B4"],
+        "dest": "/etc/apt/keyrings/vendor.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": {
+                "mode": "755",
+                "user": "root",
+                "group": "root"
+            },
+            "path=/tmp/pyinfra-gpg-empfile_": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": {
+                "mode": "644",
+                "user": "root",
+                "group": "root"
+            }
+        },
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/keyrings']": {
+                "/etc/apt/keyrings/vendor.gpg": {
+                    "format": "gpg",
+                    "keys": {
+                        "D88E42B4": {
+                            "length": 4096,
+                            "uid": "Test Key <test@example.com>"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "commands": [
+        "chmod 644 /etc/apt/keyrings/vendor.gpg"
+    ],
+    "noop_description": "GPG keys ['0xD88E42B4'] already exist in /etc/apt/keyrings/vendor.gpg"
+}

--- a/tests/operations/gpg.key/keyserver_single_idempotent.json
+++ b/tests/operations/gpg.key/keyserver_single_idempotent.json
@@ -12,7 +12,7 @@
                 "user": "root",
                 "group": "root"
             },
-            "path=/tmp/pyinfra-gpg-empfile_": null
+            "path=_tempfile_": null
         },
         "files.File": {
             "path=/etc/apt/keyrings/vendor.gpg": {

--- a/tests/operations/gpg.key/local_file.json
+++ b/tests/operations/gpg.key/local_file.json
@@ -1,0 +1,23 @@
+{
+    "args": [],
+    "kwargs": {
+        "src": "/tmp/local-key.asc",
+        "dest": "/etc/apt/keyrings/test.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/test.gpg": null
+        }
+    },
+    "commands": [
+        "mkdir -p /etc/apt/keyrings",
+        "chmod 755 /etc/apt/keyrings",
+        "if grep -q \"BEGIN PGP PUBLIC KEY BLOCK\" \"/tmp/local-key.asc\"; then gpg --batch --dearmor -o \"/etc/apt/keyrings/test.gpg\" \"/tmp/local-key.asc\"; else cp \"/tmp/local-key.asc\" \"/etc/apt/keyrings/test.gpg\"; fi",
+        "mkdir -p /etc/apt/keyrings",
+        "touch /etc/apt/keyrings/test.gpg",
+        "chmod 644 /etc/apt/keyrings/test.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/no_dearmor.json
+++ b/tests/operations/gpg.key/no_dearmor.json
@@ -1,0 +1,24 @@
+{
+    "args": [],
+    "kwargs": {
+        "src": "/tmp/local-key.gpg",
+        "dest": "/etc/apt/keyrings/test.gpg",
+        "dearmor": false
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/test.gpg": null
+        }
+    },
+    "commands": [
+        "mkdir -p /etc/apt/keyrings",
+        "chmod 755 /etc/apt/keyrings",
+        "cp \"/tmp/local-key.gpg\" \"/etc/apt/keyrings/test.gpg\"",
+        "mkdir -p /etc/apt/keyrings",
+        "touch /etc/apt/keyrings/test.gpg",
+        "chmod 644 /etc/apt/keyrings/test.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/no_dest.json
+++ b/tests/operations/gpg.key/no_dest.json
@@ -1,0 +1,11 @@
+{
+    "args": [],
+    "kwargs": {
+        "src": "/tmp/test.asc"
+    },
+    "facts": {},
+    "exception": {
+        "names": ["OperationError"],
+        "message": "`dest` must be provided for installation"
+    }
+}

--- a/tests/operations/gpg.key/no_src_or_keyserver.json
+++ b/tests/operations/gpg.key/no_src_or_keyserver.json
@@ -1,0 +1,11 @@
+{
+    "args": [],
+    "kwargs": {
+        "dest": "/etc/apt/keyrings/test.gpg"
+    },
+    "exception": {
+        "names": ["OperationError"],
+        "message": "Either `src` or `keyserver` must be provided for installation"
+    },
+    "facts": {}
+}

--- a/tests/operations/gpg.key/remote_url.json
+++ b/tests/operations/gpg.key/remote_url.json
@@ -1,0 +1,29 @@
+{
+    "args": [],
+    "kwargs": {
+        "src": "https://example.com/key.asc",
+        "dest": "/etc/apt/keyrings/test.gpg"
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/etc/apt/keyrings": null
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/test.gpg": null,
+            "path=_tempfile_": null
+        },
+        "server.Which": {
+            "command=curl": "/usr/bin/curl"
+        }
+    },
+    "commands": [
+        "mkdir -p /etc/apt/keyrings",
+        "chmod 755 /etc/apt/keyrings",
+        "curl -sSLf https://example.com/key.asc -o _tempfile_",
+        "mv _tempfile_ _tempfile_",
+        "if grep -q \"BEGIN PGP PUBLIC KEY BLOCK\" \"_tempfile_\"; then gpg --batch --dearmor -o \"/etc/apt/keyrings/test.gpg\" \"_tempfile_\"; else cp \"_tempfile_\" \"/etc/apt/keyrings/test.gpg\"; fi",
+        "mkdir -p /etc/apt/keyrings",
+        "touch /etc/apt/keyrings/test.gpg",
+        "chmod 644 /etc/apt/keyrings/test.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/remove_by_full_fingerprint.json
+++ b/tests/operations/gpg.key/remove_by_full_fingerprint.json
@@ -1,0 +1,33 @@
+{
+    "kwargs": {
+        "dest": "/etc/apt/keyrings/vendor.gpg",
+        "keyid": "0xAABBCCDD11223344AABBCCDD112233440011CAFE",
+        "present": false
+    },
+    "facts": {
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/keyrings']": {
+                "/etc/apt/keyrings/vendor.gpg": {
+                    "format": "gpg",
+                    "keys": {
+                        "112233440011CAFE": {
+                            "validity": "-",
+                            "length": 4096,
+                            "subkeys": {},
+                            "fingerprint": "AABBCCDD11223344AABBCCDD112233440011CAFE",
+                            "uid_hash": "ABC123DEF456",
+                            "uid": "Vendor Key <vendor@example.com>"
+                        }
+                    }
+                }
+            }
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": {"mode": 644}
+        }
+    },
+    "commands": [
+        "gpg --batch --yes --no-default-keyring --keyring \"/etc/apt/keyrings/vendor.gpg\" --delete-keys AABBCCDD11223344AABBCCDD112233440011CAFE",
+        "gpg --batch --no-default-keyring --keyring \"/etc/apt/keyrings/vendor.gpg\" --list-keys 2>/dev/null | grep -q \"^pub\" || rm -f \"/etc/apt/keyrings/vendor.gpg\""
+    ]
+}

--- a/tests/operations/gpg.key/remove_by_id.json
+++ b/tests/operations/gpg.key/remove_by_id.json
@@ -1,0 +1,32 @@
+{
+    "kwargs": {
+        "dest": "/etc/apt/keyrings/vendor.gpg",
+        "keyid": "0xABCDEF12",
+        "present": false
+    },
+    "facts": {
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/keyrings']": {
+                "/etc/apt/keyrings/vendor.gpg": {
+                    "format": "gpg",
+                    "keys": {
+                        "ABCDEF1234567890": {
+                            "validity": "-",
+                            "length": 4096,
+                            "subkeys": {},
+                            "fingerprint": "ABCDEF1234567890FEDCBA0987654321ABCDEF12",
+                            "uid_hash": "ABC123DEF456",
+                            "uid": "Vendor Key <vendor@example.com>"
+                        }
+                    }
+                }
+            }
+        },
+        "files.File": {
+            "path=/etc/apt/keyrings/vendor.gpg": {"mode": 644}
+        }
+    },
+    "commands": [
+        "rm -f /etc/apt/keyrings/vendor.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/remove_by_id.json
+++ b/tests/operations/gpg.key/remove_by_id.json
@@ -27,6 +27,7 @@
         }
     },
     "commands": [
-        "rm -f /etc/apt/keyrings/vendor.gpg"
+        "gpg --batch --yes --no-default-keyring --keyring \"/etc/apt/keyrings/vendor.gpg\" --delete-keys ABCDEF1234567890FEDCBA0987654321ABCDEF12",
+        "gpg --batch --no-default-keyring --keyring \"/etc/apt/keyrings/vendor.gpg\" --list-keys 2>/dev/null | grep -q \"^pub\" || rm -f \"/etc/apt/keyrings/vendor.gpg\""
     ]
 }

--- a/tests/operations/gpg.key/remove_by_id_asc_partial.json
+++ b/tests/operations/gpg.key/remove_by_id_asc_partial.json
@@ -1,0 +1,38 @@
+{
+    "kwargs": {
+        "dest": "/etc/apt/trusted.gpg.d/multi-key.asc",
+        "keyid": "0xABCDEF12",
+        "present": false
+    },
+    "facts": {
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/trusted.gpg.d']": {
+                "/etc/apt/trusted.gpg.d/multi-key.asc": {
+                    "format": "asc",
+                    "keys": {
+                        "ABCDEF1234567890": {
+                            "validity": "-",
+                            "length": 4096,
+                            "subkeys": {},
+                            "fingerprint": "ABCDEF1234567890FEDCBA0987654321ABCDEF12",
+                            "uid_hash": "ABC123DEF456",
+                            "uid": "Key One <one@example.com>"
+                        },
+                        "111111111111AAAA": {
+                            "validity": "-",
+                            "length": 4096,
+                            "subkeys": {},
+                            "fingerprint": "111111111111AAAA222222222222BBBB33333333",
+                            "uid_hash": "DEF456GHI789",
+                            "uid": "Key Two <two@example.com>"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "exception": {
+        "names": ["OperationError"],
+        "message": "Cannot remove individual keys from armored keyring '/etc/apt/trusted.gpg.d/multi-key.asc': the file contains other keys and cannot be edited in-place. Remove the file explicitly with present=False and no keyid."
+    }
+}

--- a/tests/operations/gpg.key/remove_file.json
+++ b/tests/operations/gpg.key/remove_file.json
@@ -1,0 +1,14 @@
+{
+    "kwargs": {
+        "dest": "/etc/apt/keyrings/test.gpg",
+        "present": false
+    },
+    "facts": {
+        "files.File": {
+            "path=/etc/apt/keyrings/test.gpg": {"mode": 644}
+        }
+    },
+    "commands": [
+        "rm -f /etc/apt/keyrings/test.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/remove_from_all_keyrings.json
+++ b/tests/operations/gpg.key/remove_from_all_keyrings.json
@@ -27,6 +27,7 @@
         }
     },
     "commands": [
-        "rm -f /etc/apt/trusted.gpg.d/compromised.gpg"
+        "gpg --batch --yes --no-default-keyring --keyring \"/etc/apt/trusted.gpg.d/compromised.gpg\" --delete-keys COMPROMISED123567890FEDCBA0987654321COMPROMISED123",
+        "gpg --batch --no-default-keyring --keyring \"/etc/apt/trusted.gpg.d/compromised.gpg\" --list-keys 2>/dev/null | grep -q \"^pub\" || rm -f \"/etc/apt/trusted.gpg.d/compromised.gpg\""
     ]
 }

--- a/tests/operations/gpg.key/remove_from_all_keyrings.json
+++ b/tests/operations/gpg.key/remove_from_all_keyrings.json
@@ -1,0 +1,32 @@
+{
+    "kwargs": {
+        "keyid": "0xCOMPROMISED123",
+        "present": false,
+        "working_dirs": ["/etc/apt/trusted.gpg.d", "/etc/apt/keyrings", "/usr/share/keyrings"]
+    },
+    "facts": {
+        "gpg.GpgKeyrings": {
+            "directories=['/etc/apt/trusted.gpg.d', '/etc/apt/keyrings', '/usr/share/keyrings']": {
+                "/etc/apt/trusted.gpg.d/compromised.gpg": {
+                    "format": "gpg",
+                    "keys": {
+                        "COMPROMISED123567890": {
+                            "validity": "-",
+                            "length": 4096,
+                            "subkeys": {},
+                            "fingerprint": "COMPROMISED123567890FEDCBA0987654321COMPROMISED123",
+                            "uid_hash": "ABC123DEF456",
+                            "uid": "Compromised Key <compromised@example.com>"
+                        }
+                    }
+                }
+            }
+        },
+        "files.File": {
+            "path=/etc/apt/trusted.gpg.d/compromised.gpg": {"mode": 644}
+        }
+    },
+    "commands": [
+        "rm -f /etc/apt/trusted.gpg.d/compromised.gpg"
+    ]
+}

--- a/tests/operations/gpg.key/remove_no_dest_no_keyid.json
+++ b/tests/operations/gpg.key/remove_no_dest_no_keyid.json
@@ -1,0 +1,10 @@
+{
+    "kwargs": {
+        "present": false
+    },
+    "exception": {
+        "names": ["OperationError"],
+        "message": "For removal, either `dest` or both `keyid` and `working_dirs` must be provided"
+    },
+    "facts": {}
+}


### PR DESCRIPTION
Add new gpg.key and gpg.dearmor operations to manage GPG keys and keyrings. These operations provide a modern alternative to apt-key for managing APT repository keys.

Features:
- Install keys from URLs, local files, or keyservers
- Remove keys by ID or entire keyring files
- Convert ASCII armored keys to binary format
- Manage keys in specific keyrings or across all APT keyrings

This is part 1/3 of modernizing APT key management.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
