### PR TITLE
docs: fix documentation generation formatting issues

### DIFF
--- a/docs/utils.py
+++ b/docs/utils.py
@@ -9,5 +9,5 @@ def format_doc_line(line):
     # Bold the <arg>: part of each line
     line = re.sub(r"\+ ([0-9a-z_\/\*]+)(.*)", r"+ **\1**\2", line)
 
-    # Strip the first 4 characters (first indent from docstring)
-    return line[4:]
+    # Python's __doc__ attribute already dedents docstrings, so we don't need to strip anything
+    return line

--- a/scripts/generate_arguments_doc.py
+++ b/scripts/generate_arguments_doc.py
@@ -40,6 +40,7 @@ def build_arguments_doc():
 
         if arguments_title_doc:
             lines.append(cleandoc(arguments_title_doc))
+            lines.append("")
 
         lines.append(
             """.. list-table::

--- a/src/pyinfra/facts/crontab.py
+++ b/src/pyinfra/facts/crontab.py
@@ -125,15 +125,15 @@ class Crontab(FactBase[CrontabFile]):
         # or CrontabFile.to_json()
         [
             {
-               command: "/path/to/command",
-               minute: "*",
-               hour: "*",
-               month: "*",
-               day_of_month: "*",
-               day_of_week: "*",
+                "command": "/path/to/command",
+                "minute": "*",
+                "hour": "*",
+                "month": "*",
+                "day_of_month": "*",
+                "day_of_week": "*",
             },
             {
-                "command": "echo another command
+                "command": "echo another command",
                 "special_time": "@daily",
             }
         ]


### PR DESCRIPTION
- Fix indentation handling in format_doc_line by removing manual strip
- Add blank line after arguments title in generated docs
- Fix JSON formatting in crontab fact docstring examples

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
