### PR TITLE
allow empty package list in packaging.ensure_packages()

### DIFF
--- a/src/pyinfra/operations/util/packaging.py
+++ b/src/pyinfra/operations/util/packaging.py
@@ -172,6 +172,8 @@ def ensure_packages(
         return
     if isinstance(packages_to_ensure, str):
         packages_to_ensure = [packages_to_ensure]
+    if len(packages_to_ensure) == 0:
+        return
 
     packages: list[PkgInfo] = []
     if isinstance(packages_to_ensure[0], PkgInfo):


### PR DESCRIPTION
Allow passing an empty list of packages to `packaging.ensure_packages()` instead of raising an `IndexError`.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
