### PR TITLE
ops.files.template: allow custom jinja2 template loaders

### DIFF
--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -1156,11 +1156,14 @@ def template(
     if not set explicitly.
 
     Notes:
-       Common convention is to store templates in a "templates" directory and
-       have a filename suffix with '.j2' (for jinja2).
+        Common convention is to store templates in a "templates" directory and
+        have a filename suffix with '.j2' (for jinja2).
 
-       For information on the template syntax, see
-       `the jinja2 docs <https://jinja.palletsprojects.com>`_.
+        The default template lookup directory (used with jinjas ``extends``, ``import`` and
+        ``include`` statements) is the current working directory.
+
+        For information on the template syntax, see
+        `the jinja2 docs <https://jinja.palletsprojects.com>`_.
 
     **Examples:**
 


### PR DESCRIPTION
<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

Implements the feature requested in #1485 

It is now possible to override the default template loader used in the `files.template` operation by passing a custom instance as shown in the example in the issue.

I did not add any new tests, as I did not understand how the test system works. I also did not find any tests for the function I changed 🤷

- [x] Pull request is based on the default branch (`3.x` at this time)
- [ ] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
