### PR TITLE
fix: check directory exists before cd in npm fact

### DIFF
--- a/src/pyinfra/facts/npm.py
+++ b/src/pyinfra/facts/npm.py
@@ -30,7 +30,7 @@ class NpmPackages(FactBase):
     @override
     def command(self, directory=None):
         if directory:
-            return ("cd {0} && npm list -g --depth=0").format(directory)
+            return ("! test -d {0} || (cd {0} && npm list -g --depth=0)").format(directory)
         return "npm list -g --depth=0"
 
     @override

--- a/tests/facts/npm.NpmPackages/local_packages.json
+++ b/tests/facts/npm.NpmPackages/local_packages.json
@@ -1,6 +1,6 @@
 {
     "arg": "somedir",
-    "command": "cd somedir && npm list -g --depth=0",
+    "command": "! test -d somedir || (cd somedir && npm list -g --depth=0)",
     "requires_command": "npm",
     "output": [
         "├── pydash@3.48",


### PR DESCRIPTION
Previously, the npm fact would fail when the specified directory didn't exist because it attempted to cd into it without checking. This adds a directory existence check using the same pattern as other facts (e.g., git facts).

Fixes #1396
- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
