### PR TITLE
Paramiko no existing session workaround

### DIFF
--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -9,6 +9,7 @@ from typing import IO, TYPE_CHECKING, Any, Iterable, Optional, Protocol, Tuple
 
 import click
 from paramiko import AuthenticationException, BadHostKeyException, SFTPClient, SSHException
+from paramiko.agent import Agent
 from typing_extensions import TypedDict, Unpack, override
 
 from pyinfra import logger
@@ -286,9 +287,62 @@ class SSHConnector(BaseConnector):
                 f"Host key for {e.hostname} does not match.",
             )
 
+        except SSHException as e:
+            if self._retry_paramiko_agent_keys(hostname, kwargs, e):
+                return
+            raise
+
     @override
     def disconnect(self) -> None:
         self.get_file_transfer_connection.cache.clear()
+
+    def _retry_paramiko_agent_keys(
+        self,
+        hostname: str,
+        kwargs: dict[str, Any],
+        error: SSHException,
+    ) -> bool:
+        # Workaround for Paramiko multi-key bug (paramiko/paramiko#1390).
+        if "no existing session" not in str(error).lower():
+            return False
+
+        if not kwargs.get("allow_agent"):
+            return False
+
+        try:
+            agent_keys = list(Agent().get_keys())
+        except Exception:
+            return False
+
+        if not agent_keys:
+            return False
+
+        # Skip the first agent key, since Paramiko already attempted it
+        attempt_keys = agent_keys[1:] if len(agent_keys) > 1 else agent_keys
+
+        for agent_key in attempt_keys:
+            try:
+                self.client.close()
+            except Exception:
+                pass
+
+            self.client = SSHClient()
+
+            single_key_kwargs = dict(kwargs)
+            single_key_kwargs["allow_agent"] = False
+            single_key_kwargs["pkey"] = agent_key
+
+            try:
+                self.client.connect(hostname, **single_key_kwargs)
+                return True
+            except AuthenticationException:
+                continue
+            except SSHException as retry_error:
+                if "no existing session" in str(retry_error).lower():
+                    continue
+                raise retry_error
+
+        return False
 
     @override
     def run_shell_command(

--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -321,10 +321,11 @@ class SSHConnector(BaseConnector):
         attempt_keys = agent_keys[1:] if len(agent_keys) > 1 else agent_keys
 
         for agent_key in attempt_keys:
-            try:
-                self.client.close()
-            except Exception:
-                pass
+            if self.client is not None:
+                try:
+                    self.client.close()
+                except Exception:
+                    pass
 
             self.client = SSHClient()
 


### PR DESCRIPTION
## Background

Due to a long-standing Paramiko bug, SSH login can fail when multiple keys are loaded in your SSH agent, depending on how strict the SSH server is.

If the first key Paramiko tries is invalid, it transmits an extra SERVICE_REQUEST before the second key. Since this is incorrect behavior  (according to Damien Miller from OpenSSH (https://github.com/golang/go/issues/75268#issuecomment-3272602405), citing the RFC), some SSH servers  will reject it. This results in Paramiko raising a “No existing session” error on the second key attempt.

I use ssh2lxd (https://github.com/dfaerch/ssh2lxd) to allow pyinfra to SSH into Incus containers trough a single ssh-daemon running on the host. It’s  written in Go and uses the official Go SSH library, which, unfortunately for me, follows the RFC. Damien Miller’s comment above was written in an issue on said library only a month ago, and he additionally notes:

> OpenSSH is likely to match x/crypto/ssh's behaviour as it is more correct.

So we might eventually see an OpenSSH release that triggers the same Paramiko bug, suddenly affecting many more users.

- Paramiko issue (2019): paramiko/paramiko#1390
- Unmerged fix PR (2020): paramiko/paramiko#1687

Both remain open as of Oct 2025.

At that speed, I don’t know if we can expect a quick response even if OpenSSH tightens this, so I propose a fallback that fixes the issue right now for the few affected and buys time between any OpenSSH change and a Paramiko fix.

## My proposed solution

I’ve implemented a fallback that triggers when SSHException is raised during connect and the message is “No existing session.” In that case,  pyinfra gathers the agent keys and, in a loop, opens a fresh connection and tries to authenticate with each remaining key.

Opening a new connection per key is slower and not especially elegant, but it avoids having to patch Paramiko. And if you don't hit the bug, everything works as before.


---


- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
