### PR TITLE
facts.apt.update: fix computation of cache_time when host is not UTC

### DIFF
--- a/tests/operations/apt.packages/update_cached_tz.json
+++ b/tests/operations/apt.packages/update_cached_tz.json
@@ -1,0 +1,17 @@
+{
+    "kwargs": {
+        "update": true,
+        "cache_time": 3600
+    },
+    "facts": {
+        "deb.DebPackages": {},
+        "server.Date": "datetime:2015-01-01T22:44:00+01:00",
+        "files.File": {
+            "path=/var/lib/apt/periodic/update-success-stamp": {
+                "mtime": "datetime:2015-01-01T21:40:00"
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "apt is already up to date"
+}


### PR DESCRIPTION
And reorganize a bit the logic to gather the Date fact only if required.

The timezone of my hosts are set on UTC+1. I noticed that the operation `apt.update` was always executed, even when the `cache_time` parameter was supposed to make it a noop. See the comment in the code for an explanation of the problem.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts => not applicable
- [x] Tests pass (see `scripts/dev-test.sh`) => let's see the result of the CI
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
