### PR TITLE
cli: add option `--same-sudo-password`

### DIFF
--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -84,12 +84,6 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     show_envvar=True,
 )
 @click.option(
-    "--same-sudo-password",
-    is_flag=True,
-    default=False,
-    help="All hosts have the same sudo password, so ask only once.",
-)
-@click.option(
     "--limit",
     help="Restrict the target hosts by name and group name.",
     multiple=True,
@@ -123,6 +117,12 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     help="Whether to execute operations with sudo.",
 )
 @click.option("--sudo-user", help="Which user to sudo when sudoing.")
+@click.option(
+    "--same-sudo-password",
+    is_flag=True,
+    default=False,
+    help="All hosts have the same sudo password, so ask only once.",
+)
 @click.option(
     "--use-sudo-password",
     is_flag=True,
@@ -334,6 +334,7 @@ def _main(
         sudo,
         sudo_user,
         use_sudo_password,
+        same_sudo_password,
         su_user,
         parallel,
         shell_executable,
@@ -351,9 +352,6 @@ def _main(
         ssh_port,
         ssh_password,
     )
-
-    if same_sudo_password:
-        config.SUDO_PASSWORD = getpass("sudo password: ")
 
     if yes is False:
         _set_fail_prompts(state, config)
@@ -579,6 +577,7 @@ def _set_config(
     sudo,
     sudo_user,
     use_sudo_password,
+    same_sudo_password,
     su_user,
     parallel,
     shell_executable,
@@ -608,6 +607,9 @@ def _set_config(
 
     if use_sudo_password:
         config.USE_SUDO_PASSWORD = use_sudo_password
+
+    if same_sudo_password:
+        config.SUDO_PASSWORD = getpass("sudo password: ")
 
     if su_user:
         config.SU_USER = su_user

--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import warnings
 from fnmatch import fnmatch
+from getpass import getpass
 from os import chdir as os_chdir, getcwd, path
 from typing import Iterable, List, Tuple, Union
 
@@ -81,6 +82,12 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     help="Execute operations immediately on hosts without prompt or checking for changes.",
     envvar="PYINFRA_YES",
     show_envvar=True,
+)
+@click.option(
+    "--same-sudo-password",
+    is_flag=True,
+    default=False,
+    help="All hosts have the same sudo password, so ask only once.",
 )
 @click.option(
     "--limit",
@@ -274,6 +281,7 @@ def _main(
     ssh_key,
     ssh_key_password: str,
     ssh_password: str,
+    same_sudo_password: bool,
     shell_executable,
     sudo: bool,
     sudo_user: str,
@@ -343,6 +351,9 @@ def _main(
         ssh_port,
         ssh_password,
     )
+
+    if same_sudo_password:
+        config.SUDO_PASSWORD = getpass("sudo password: ")
 
     if yes is False:
         _set_fail_prompts(state, config)

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -170,6 +170,7 @@ class TestDirectMainExecution(PatchSSHTestCase):
                 ssh_key=None,
                 ssh_key_password=None,
                 ssh_password=None,
+                same_sudo_password=False,
                 sudo=False,
                 sudo_user=None,
                 use_sudo_password=False,


### PR DESCRIPTION
To tell all hosts in the inventory uses the same password, which will be prompted only once.

In my setup, all SSH hosts of my inventory have the same sudo password. The problem is that when I run an operation which requires sudo on all my inventory, I am prompted to give the sudo password for each host, and all the prompts are somehow mixed on the same line:
<img width="498" height="195" alt="pyinfra-sudo-1" src="https://github.com/user-attachments/assets/be8e8ae0-7e22-4a94-a4b0-7f4c1ac5df0e" />
<img width="491" height="205" alt="pyinfra-sudo-2" src="https://github.com/user-attachments/assets/4d981994-1c59-424f-938d-b3c6501991dd" />

I don't want to put the sudo password as a parameter of `pyinfra` command (to avoid leaking it in my shell history), but rather I want to be prompted, but only once.

So this PR adds the option `--same-sudo-password` to prompt for sudo password only once at the beginning of the execution.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [ ] Pull request includes tests for any new/updated operations/facts => any hint (where to look for inspiration) to add the corresponding test would be welcome 
- [ ] Pull request includes documentation for any new/updated operations/facts => where should I mention this option in the documentation?
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
