### PR TITLE
connectors: close stdin after writing any input

### DIFF
--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -397,8 +397,10 @@ class SSHConnector(BaseConnector):
                 get_pty=_get_pty,
             )
 
+            # Write any stdin and then close it
             if _stdin:
                 write_stdin(_stdin, stdin_buffer)
+            stdin_buffer.close()
 
             combined_output = read_output_buffers(
                 stdout_buffer,

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -44,11 +44,14 @@ def run_local_process(
 ) -> tuple[int, "CommandOutput"]:
     process = Popen(command, shell=True, stdout=PIPE, stderr=PIPE, stdin=PIPE)
 
-    if stdin:
-        write_stdin(stdin, process.stdin)
-
     assert process.stdout is not None
     assert process.stderr is not None
+    assert process.stdin is not None
+
+    # Write any stdin and then close it
+    if stdin:
+        write_stdin(stdin, process.stdin)
+    process.stdin.close()
 
     combined_output = read_output_buffers(
         process.stdout,


### PR DESCRIPTION
Turns out some applications will wait on stdin being closed before going anything (ollama), see: https://github.com/pyinfra-dev/pyinfra/issues/1355