### PR TITLE
docs: minor errors

### DIFF
--- a/docs/api/connectors.md
+++ b/docs/api/connectors.md
@@ -18,6 +18,8 @@ In the example below `make_names_data` is yielding a hostname, data, groups tupl
 could be stored and processed in any data structure.
 
 ```py
+from pyinfra.connectors.base import BaseConnector
+
 class InventoryConnector(BaseConnector):
     handles_execution = False
 
@@ -32,11 +34,11 @@ class InventoryConnector(BaseConnector):
         # connect to api/parse files/process data here, resulting in a list of tuples;
         gathered_hosts = [
             ('@local', {}, ['@local']),
-            ('foundhost', {'ip': 198.51.100.4}, ['remote', 'example'])
-            ]
+            ('foundhost', {'ip': '198.51.100.4'}, ['remote', 'example'])
+        ]
 
         for loop_host in gathered_hosts:
-          yield gathered_hosts[0], gathered_hosts[1], gathered_hosts[2]
+          yield loop_host[0], loop_host[1], loop_host[2]
 ```
 
 To use the inventory connector call `pyinfra @[name of connector in pyinfra.connectors] [deployment script].py`
@@ -128,10 +130,10 @@ class MyConnector(BaseConnector):
 
 ## Where to make changes
 
-Connectors enable pyinfra to expand work done `in its 5 stages <deploy-process.html#how-pyinfra-works>`_ by providing methods which can be called at
+Connectors enable pyinfra to expand work done [in its 5 stages](../deploy-process) by providing methods which can be called at
 appropriate times.
 
-To hook in to to the various steps with the methods outlined below.
+To hook in to the various steps with the methods outlined below.
 ```
 --> Loading config...
 --> Loading inventory...
@@ -139,7 +141,7 @@ To hook in to to the various steps with the methods outlined below.
 `make_names_data` is used to supply inventory data about a host while at 'Loading inventory' stage.
 
 Its worth being aware up front that due to `make_names_data` being a `staticmethod` it has no automatic access to the parent classes attributes.
-To work around this - eg to configure an API connector - configuration will have to happen outside the function and be imported in. Two examples
+To work around this - e.g. to configure an API connector - configuration will have to happen outside the function and be imported in. Two examples
 (`getattr` and a function) are provided below.
 
 ```py
@@ -153,7 +155,7 @@ class InventoryConnector(BaseConnector):
   ...
 
   @staticmethod
-  def make_names_data(_=None)
+  def make_names_data(_=None):
     api_client = getattr(InventoryConnector, 'api_instance')
     api_settings = load_settings()
     ...

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -3,7 +3,7 @@ Using the API
 
 In addition to :doc:`the pyinfra CLI <../cli>`, pyinfra provides a full Python API. As of ``v3`` this API can be considered mostly stable. See the :doc:`./reference`.
 
-You can also reference `pyinfra's own main.py <https://github.com/pyinfra-dev/pyinfra/blob/3.x/pyinfra_cli/main.py>`_, and the `pyinfra API source code <https://github.com/pyinfra-dev/pyinfra/tree/3.x/pyinfra/api>`_.
+You can also reference `pyinfra's own main.py <https://github.com/pyinfra-dev/pyinfra/blob/3.x/src/pyinfra_cli/main.py>`_, and the `pyinfra API source code <https://github.com/pyinfra-dev/pyinfra/tree/3.x/src/pyinfra/api>`_.
 
 Full Example
 ------------

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -3,7 +3,7 @@ Using the API
 
 In addition to :doc:`the pyinfra CLI <../cli>`, pyinfra provides a full Python API. As of ``v3`` this API can be considered mostly stable. See the :doc:`./reference`.
 
-You can also reference `pyinfra's own main.py <https://github.com/pyinfra-dev/pyinfra/blob/3.x/src/pyinfra_cli/main.py>`_, and the `pyinfra API source code <https://github.com/pyinfra-dev/pyinfra/tree/3.x/src/pyinfra/api>`_.
+You can also reference `pyinfra's own main.py <https://github.com/pyinfra-dev/pyinfra/blob/3.x/pyinfra_cli/main.py>`_, and the `pyinfra API source code <https://github.com/pyinfra-dev/pyinfra/tree/3.x/pyinfra/api>`_.
 
 Full Example
 ------------

--- a/docs/arguments.rst
+++ b/docs/arguments.rst
@@ -1,3 +1,5 @@
+.. arguments:
+
 Global Arguments
 ================
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -37,7 +37,7 @@ pyinfra INVENTORY debug-inventory
 
 ### Verbosity
 
-By default pyinfra only prints high level information (this host connected, this operation started), this can be increased as follows:
+By default, pyinfra only prints high level information (this host connected, this operation started), this can be increased as follows:
 
 + `-v`: print out facts collected as well as noop information (package X already installed)
 + `-vv`: as above plus print shell input to the remote host

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -64,9 +64,9 @@ uv run pytest tests/test_facts.py -k "efibootmgr.EFIBootMGR"
 uv run pytest tests/test_operations.py -k "selinux."
 ```
 
-#### End to End Tests
+#### End-to-End Tests
 
-The end to end tests are also executed via `pytest` but not selected by default, options/usage:
+The end-to-end tests are also executed via `pytest` but not selected by default, options/usage:
 
 ```sh
 # Run all the e2e tests (local, SSH, Docker)

--- a/docs/examples/data_multiple_environments.md
+++ b/docs/examples/data_multiple_environments.md
@@ -1,6 +1,6 @@
 # Data Across Multiple Environments
 
-Lets say you have an app that you wish to deploy in two environments: staging and production, with the dev VM as the default. A good layout for this would be:
+Let's say you have an app that you wish to deploy in two environments: staging and production, with the dev VM as the default. A good layout for this would be:
 
 + ``deploy.py``
 + ``inventories/production.py`` - production inventory

--- a/docs/examples/dynamic_execution_deploy.md
+++ b/docs/examples/dynamic_execution_deploy.md
@@ -2,7 +2,7 @@
 
 **Note:** this example is out of date (the code is valid, but there's better ways to do it), please see [using operations: operation output & callbacks](/using-operations).
 
-pyinfra is designed around the idea of defining the end-state _before_ executing any changes on the remote server. Generally this works well but sometimes you need the output of one command to feed into another. This can be achieved by executing Python functions mid-deploy.
+pyinfra is designed around the idea of defining the end-state _before_ executing any changes on the remote server. Generally this works well, but sometimes you need the output of one command to feed into another. This can be achieved by executing Python functions mid-deploy.
 
 In this example we install a service (ZeroTier) that generates a random ID for the remote host. We then use this ID to authenticate the server with the ZeroTier API.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -25,7 +25,7 @@ The currently executing host can be fetched from the ``host`` context variable. 
 How do I use sudo in an operation?
 ----------------------------------
 
-Sudo is controlled by one of the `privilege and user escalation arguments <arguments.html#privilege-user-escalation>`_, there are a number of additional arguments to control sudo execution:
+Sudo is controlled by one of the :ref:`privilege and user escalation arguments <arguments#privilege-user-escalation>`_, there are a number of additional arguments to control sudo execution:
 
 .. code:: python
 
@@ -56,7 +56,7 @@ Use the LINK ``files.file``, ``files.directory`` or ``files.link`` operations to
 How do I handle unreliable operations or network issues?
 --------------------------------------------------------
 
-Use the `retry behavior arguments <arguments.html#retry-behavior>`_ to automatically retry failed operations. This is especially useful for network operations or services that may be temporarily unavailable:
+Use the :ref:`retry behavior arguments <arguments#retry-behavior>`_ to automatically retry failed operations. This is especially useful for network operations or services that may be temporarily unavailable:
 
 .. code:: python
 

--- a/docs/support.md
+++ b/docs/support.md
@@ -7,7 +7,7 @@ Need a hand with using pyinfra or have some questions? You can find official pyi
 
 ## I think I've got a bug!
 
-+ Please have a quick scan of the [the compatibility page](./compatibility) to see if the issue is referenced there
++ Please have a quick scan of the [compatibility page](./compatibility) to see if the issue is referenced there
 + Check [the issue list](https://github.com/Fizzadar/pyinfra/issues) to see if anyone else has this issue
 + Submit [a new bug report](https://github.com/Fizzadar/pyinfra/issues/new/choose)
 

--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -132,7 +132,7 @@ Facts allow you to use information about the target host to control and configur
 
     pyinfra inventory.py fact server.LinuxName
 
-Facts are imported from ``pyinfra.facts.*`` and can be retrieved using the ``host.get_fact`` function. If you save this in a file called `nano.py`:
+Facts are imported from ``pyinfra.facts.*`` and can be retrieved using the ``host.get_fact`` function. If you save this in a file called :file:`{nano}.py`:
 
 .. code:: python
 
@@ -162,7 +162,7 @@ Facts are imported from ``pyinfra.facts.*`` and can be retrieved using the ``hos
 See :doc:`facts` for a full list of available facts and arguments.
 
 .. Important::
-    Only use immutable facts in deploy code (installed OS, Arch, etc) unless you are absolutely sure they will not change. See: `using host facts <deploy-process.html#using-host-facts>`_.
+    Only use immutable facts in deploy code (installed OS, Arch, etc) unless you are absolutely sure they will not change. See: :ref:`using host facts <deploy-process#using-host-facts>`_.
 
 Fact Errors
 ^^^^^^^^^^^
@@ -236,7 +236,8 @@ All operations return an operation meta object which provides information about 
 Output & Callbacks
 ------------------
 
-pyinfra doesn't immediately execute operations, meaning output is not available right away. It is possible to access this output at runtime by providing a callback function using the :ref:`operations:python.call` operation. Callback functions may also call other operations which will be immediately executed. Why/how this works `is described here <deploy-process.html#how-pyinfra-detects-changes-orders-operations>`_.
+pyinfra doesn't immediately execute operations, meaning output is not available right away. It is possible to access this output at runtime by providing a callback function using the :ref:`operations:python.call` operation. Callback functions may also call other operations which will be immediately executed.
+Why/how this works :ref:`is described here <deploy-process#how-pyinfra-detects-changes-orders-operations>`_.
 
 .. code:: python
 
@@ -289,7 +290,7 @@ Including files can be used to break out operations across multiple files. Files
     # Include & call all the operations in tasks/install_something.py
     local.include("tasks/install_something.py")
 
-Additional data can be passed across files via the ``data`` param to parameterize tasks and is available in ``host.data``. For example `tasks/create_user.py` could look like:
+Additional data can be passed across files via the ``data`` param to parameterize tasks and is available in ``host.data``. For example :file:`tasks/{create_user}.py` could look like:
 
 .. code:: python
 
@@ -339,7 +340,8 @@ Like ``host`` and ``inventory``, ``config`` can be used to set global defaults f
 Enforcing Requirements
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The config object can be used to enforce a pyinfra version or Python package requirements. This can either be defined as a requirements text file path or simply a list of requirements. For example, if you create a `requirements.py` file with:
+The config object can be used to enforce a pyinfra version or Python package requirements. This can either be defined as a requirements text file path or simply a list of requirements.
+For example, if you create a :file:`{requirements}.py` file with:
 
 .. code:: python
 
@@ -352,13 +354,14 @@ The config object can be used to enforce a pyinfra version or Python package req
         "pyinfra~=3.0",
     ]
 
-And create a `requirements.txt` file with something like this:
+And create a :file:`requirements.txt` file with something like this:
 
 .. code:: bash
 
     pyinfra
 
-Then modify the `nano.py` above to include these lines:
+Then modify the :file:`{nano}.py` above to include these lines:
+
 .. code:: python
 
     from pyinfra import local


### PR DESCRIPTION
I did fix a few errors in the documentation I came through today.

Quick questions:
1. There are a lot of Markdown pages (connectors, support…); would you accept if I converted them in ReST to get the benefits of the Sphinx domains (ie: ref, samp…)?
2. There are a lot of "generated ReST files", (apidocs/, connectors/, facts/, operations/, etc.); why not use [autodoc](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html) and remove a lot of complexity (and avoid errors such as `pyinfra/docs/operations/opkg.rst:22: WARNING: Lexing literal_block 'opkg.packages(\n    packages: str | typing.List[str]="", present: <class \'bool\'>=True,\n    latest: <class \'bool\'>=False, update: <class \'
bool\'>=True, **kwargs,\n)' as "python" resulted in an error at token: "'". Retrying in relaxed mode. [misc.highlighting_failure]`)