### PR TITLE
feat(docker): add platform and architecture option

### DIFF
--- a/src/pyinfra/connectors/docker.py
+++ b/src/pyinfra/connectors/docker.py
@@ -26,10 +26,14 @@ if TYPE_CHECKING:
 
 class ConnectorData(TypedDict):
     docker_identifier: str
+    docker_platform: str
+    docker_architecture: str
 
 
 connector_data_meta: dict[str, DataMeta] = {
     "docker_identifier": DataMeta("ID of container or image to start from"),
+    "docker_platform": DataMeta("Platform to use for Docker image (e.g., linux/amd64)"),
+    "docker_architecture": DataMeta("Architecture to use for Docker image (e.g., amd64, arm64)"),
 }
 
 
@@ -108,9 +112,29 @@ class DockerConnector(BaseConnector):
         return container_id, True
 
     def _start_docker_image(self, image_name):
+        docker_cmd_parts = [
+            self.docker_cmd,
+            "run",
+            "-d",
+        ]
+
+        if self.data.get("docker_platform"):
+            docker_cmd_parts.extend(["--platform", self.data["docker_platform"]])
+        if self.data.get("docker_architecture"):
+            docker_cmd_parts.extend(["--arch", self.data["docker_architecture"]])
+
+        docker_cmd_parts.extend(
+            [
+                image_name,
+                "tail",
+                "-f",
+                "/dev/null",
+            ]
+        )
+
         try:
             return local.shell(
-                f"{self.docker_cmd} run -d {image_name} tail -f /dev/null",
+                " ".join(docker_cmd_parts),
                 splitlines=True,
             )[-1]  # last line is the container ID
         except PyinfraError as e:

--- a/tests/test_connectors/test_docker.py
+++ b/tests/test_connectors/test_docker.py
@@ -180,12 +180,56 @@ class TestContainerConnector(TestCase):
         with self.assertRaises(IOError):
             host.get_file("not-a-file", "not-another-file", print_output=True)
 
+    def test_docker_platform(self):
+        inventory = make_inventory(
+            hosts=((f"@{self.connector_name}/not-an-image", {"docker_platform": "linux/amd64"}),),
+        )
+        State(inventory, Config())
+
+        host = inventory.get_host(f"@{self.connector_name}/not-an-image")
+        assert host.data.docker_platform == "linux/amd64"
+
+    def test_docker_architecture(self):
+        inventory = make_inventory(
+            hosts=((f"@{self.connector_name}/not-an-image", {"docker_architecture": "arm64"}),),
+        )
+        State(inventory, Config())
+
+        host = inventory.get_host(f"@{self.connector_name}/not-an-image")
+        assert host.data.docker_architecture == "arm64"
+
+    def test_connect_with_docker_platform(self):
+        inventory = make_inventory(
+            hosts=((f"@{self.connector_name}/not-an-image", {"docker_platform": "linux/amd64"}),),
+        )
+        state = State(inventory, Config())
+        host = inventory.get_host(f"@{self.connector_name}/not-an-image")
+        host.connect(reason=True)
+        assert len(state.active_hosts) == 0
+        host.disconnect()
+
+    def test_connect_with_docker_architecture(self):
+        inventory = make_inventory(
+            hosts=((f"@{self.connector_name}/not-an-image", {"docker_architecture": "arm64"}),),
+        )
+        state = State(inventory, Config())
+        host = inventory.get_host(f"@{self.connector_name}/not-an-image")
+        host.connect(reason=True)
+        assert len(state.active_hosts) == 0
+        host.disconnect()
+
 
 # Reuse the container testing code for docker and podman
 
 
 def fake_docker_shell(command, splitlines=None):
     if command == "docker run -d not-an-image tail -f /dev/null":
+        return ["containerid"]
+
+    if command == "docker run -d --platform linux/amd64 not-an-image tail -f /dev/null":
+        return ["containerid"]
+
+    if command == "docker run -d --arch arm64 not-an-image tail -f /dev/null":
         return ["containerid"]
 
     if command == "docker commit containerid":
@@ -211,6 +255,12 @@ class TestDocker2Connector(TestContainerConnector):
 
 def fake_podman_shell(command, splitlines=None):
     if command == "podman run -d not-an-image tail -f /dev/null":
+        return ["containerid"]
+
+    if command == "podman run -d --platform linux/amd64 not-an-image tail -f /dev/null":
+        return ["containerid"]
+
+    if command == "podman run -d --arch arm64 not-an-image tail -f /dev/null":
         return ["containerid"]
 
     if command == "podman commit containerid":


### PR DESCRIPTION
Add new options to the Docker connector allowing the platform and/or architecture to be specified. For example, this can allow a macOS ARM host to run a `linux/x86_64` container (e.g., for testing).

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [~] Tests pass (see `scripts/dev-test.sh`) (some tests failed on my computer, but my changes should be unrelated)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
