### PR TITLE
docs: replace `python -m` with `uv run -m`

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -35,7 +35,7 @@ uv sync
 
 ### Code Style & Type Checking
 
-Code style is enforced via [ruff](https://docs.astral.sh/ruff/). Types are checked with mypy currently, and pyright is 
+Code style is enforced via [ruff](https://docs.astral.sh/ruff/). Types are checked with mypy currently, and pyright is
 recommended for local development though currently optional. There is a script to run the linting & type-checking:
 
 ```sh
@@ -96,5 +96,5 @@ scripts/build-public-docs.sh
 To view ([localhost:8000](http://localhost:8000)):
 
 ```sh
-python -m http.server -d docs/public/en/latest/
+uv run -m http.server -d docs/public/en/latest/
 ```


### PR DESCRIPTION
All the instructions recommend that `uv run` be used (with good reason), save for one. So this makes a very minor update to the docs to suggest using `uv run -m ...` for consistency.

This is unlikely to be an issue as the `http.server` module is rather stable, but it won't harm to make sure that the same Python version and venv is used.

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [ ] ~Pull request includes tests for any new/updated operations/facts~
- [ ] ~Pull request includes documentation for any new/updated operations/facts~
- [ ] Tests pass (see `scripts/dev-test.sh`) (2026 bug)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
