### PR TITLE
Fix FindFiles args parameter being ignored

### DIFF
--- a/src/pyinfra/facts/files.py
+++ b/src/pyinfra/facts/files.py
@@ -547,6 +547,8 @@ class FindFilesBase(FactBase):
             command.append("-regex")
             command.append(maybe_quote(regex))
 
+        command.extend(args)
+
         command.append("||")
         command.append("true")
 

--- a/tests/facts/files.FindFiles/files_with_args.json
+++ b/tests/facts/files.FindFiles/files_with_args.json
@@ -1,0 +1,14 @@
+{
+    "arg": {
+        "path": "/",
+        "maxdepth": 1,
+        "args": ["-perm", "644"]
+    },
+    "command": "find / -type f -maxdepth 1 -perm 644 || true",
+    "output": [
+        "myfile"
+    ],
+    "fact": [
+        "myfile"
+    ]
+}


### PR DESCRIPTION
The `args` parameter in FindFilesBase.command() was accepted but never actually added to the generated find command. The code checked if certain flags were present in `args` to avoid duplicates, but then never extended the command with the args list.

Fixes #1537 

Summary of changes:
- src/pyinfra/facts/files.py: Added command.extend(args) before the || true part of the command
- tests/facts/files.FindFiles/files_with_args.json: Added test case for the args parameter

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)

(made in #FOSDEM)