### PR TITLE
Fix CLI flags lost on multiple deploy files

### DIFF
--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -595,10 +595,6 @@ def _set_config(
     if path.exists(config_filename):
         exec_file(config_filename)
 
-    # Lock the current config, this allows us to restore this version after
-    # executing deploy files that may alter them.
-    config.lock_current_state()
-
     # Arg based config overrides
     if sudo:
         config.SUDO = True
@@ -631,6 +627,11 @@ def _set_config(
 
     if retry_delay is not None:
         config.RETRY_DELAY = retry_delay
+
+    # Lock the current config, this allows us to restore this version after
+    # executing deploy files that may alter them. This must happen after CLI
+    # args are applied so they persist across multiple deploy files.
+    config.lock_current_state()
 
     return config
 


### PR DESCRIPTION
Move config.lock_current_state() to after CLI argument processing so that flags like --diff, --sudo, --parallel, etc. are included in the locked config state. Previously, the lock was created before CLI args were applied, causing them to be lost when the config was restored between deploy file executions.

Fixes #1527 

Summary of the fix:
- src/pyinfra_cli/cli.py: Moved config.lock_current_state() from line 600 (before CLI args) to line 634 (after all CLI args are applied)

#FOSDEM

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
