### PR TITLE
facts.server.Port: add UDP support and multi-platform backends

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -340,18 +340,14 @@ class Port(FactBase[Union[Tuple[str, int], Tuple[None, None]]]):
             return self._process_sockstat(output)
         return None, None
 
-    def _process_ss(
-        self, output: Iterable[str]
-    ) -> Union[Tuple[str, int], Tuple[None, None]]:
+    def _process_ss(self, output: Iterable[str]) -> Union[Tuple[str, int], Tuple[None, None]]:
         for line in output:
             proc = line.split('"')[1]
             pid = int(line.split("pid=")[1].split(",")[0])
             return (proc, pid)
         return None, None
 
-    def _process_netstat(
-        self, output: Iterable[str]
-    ) -> Union[Tuple[str, int], Tuple[None, None]]:
+    def _process_netstat(self, output: Iterable[str]) -> Union[Tuple[str, int], Tuple[None, None]]:
         for line in output:
             line = line.strip()
             if not line:
@@ -363,9 +359,7 @@ class Port(FactBase[Union[Tuple[str, int], Tuple[None, None]]]):
                 return (proc, int(pid_str))
         return None, None
 
-    def _process_sockstat(
-        self, output: Iterable[str]
-    ) -> Union[Tuple[str, int], Tuple[None, None]]:
+    def _process_sockstat(self, output: Iterable[str]) -> Union[Tuple[str, int], Tuple[None, None]]:
         for line in output:
             line = line.strip()
             if not line or line.startswith("USER"):
@@ -989,7 +983,7 @@ class RebootRequired(FactBase[bool]):
     Returns a boolean indicating whether the system requires a reboot.
 
     On Linux systems:
-    
+
     - Checks /var/run/reboot-required and /var/run/reboot-required.pkgs
     - On Alpine Linux, compares installed kernel with running kernel
 

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -342,6 +342,8 @@ class Port(FactBase[Union[Tuple[str, int], Tuple[None, None]]]):
 
     def _process_ss(self, output: Iterable[str]) -> Union[Tuple[str, int], Tuple[None, None]]:
         for line in output:
+            if '"' not in line or "pid=" not in line:
+                continue
             proc = line.split('"')[1]
             pid = int(line.split("pid=")[1].split(",")[0])
             return (proc, pid)

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -298,18 +298,81 @@ class Mounts(FactBase[Dict[str, MountsDict]]):
 
 class Port(FactBase[Union[Tuple[str, int], Tuple[None, None]]]):
     """
-    Returns the process occuping a port and its PID
+    Returns the process occupying a port and its PID.
+
+    Supports TCP and UDP protocols via the ``protocol`` argument (default ``"tcp"``).
+    Uses ``ss`` on Linux (with ``netstat`` fallback) and ``sockstat`` on FreeBSD.
+
+    .. code:: python
+
+        # TCP (default)
+        host.get_fact(Port, port=80)
+        # UDP
+        host.get_fact(Port, port=53, protocol="udp")
     """
 
     @override
-    def command(self, port: int) -> str:
-        return f"ss -lptnH 'src :{port}'"
+    def command(self, port: int, protocol: str = "tcp") -> str:
+        self._kernel = host.get_fact(Kernel)
+
+        if self._kernel.strip() == "FreeBSD":
+            self._tool = "sockstat"
+            return f"sockstat -l -p {port} -P {protocol}"
+
+        # Linux - prefer ss, fall back to netstat
+        self._has_ss = host.get_fact(Which, "ss")
+        if self._has_ss:
+            self._tool = "ss"
+            proto_flag = "t" if protocol == "tcp" else "u"
+            return f"ss -lp{proto_flag}nH 'src :{port}'"
+        else:
+            self._tool = "netstat"
+            proto_flag = "t" if protocol == "tcp" else "u"
+            return f"netstat -{proto_flag}lnp 2>/dev/null | awk '$4 ~ /:{port}$/'"
 
     @override
     def process(self, output: Iterable[str]) -> Union[Tuple[str, int], Tuple[None, None]]:
+        if self._tool == "ss":
+            return self._process_ss(output)
+        elif self._tool == "netstat":
+            return self._process_netstat(output)
+        elif self._tool == "sockstat":
+            return self._process_sockstat(output)
+        return None, None
+
+    def _process_ss(
+        self, output: Iterable[str]
+    ) -> Union[Tuple[str, int], Tuple[None, None]]:
         for line in output:
-            proc, pid = line.split('"')[1], int(line.split("pid=")[1].split(",")[0])
+            proc = line.split('"')[1]
+            pid = int(line.split("pid=")[1].split(",")[0])
             return (proc, pid)
+        return None, None
+
+    def _process_netstat(
+        self, output: Iterable[str]
+    ) -> Union[Tuple[str, int], Tuple[None, None]]:
+        for line in output:
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            pid_prog = parts[-1]
+            if "/" in pid_prog:
+                pid_str, proc = pid_prog.split("/", 1)
+                return (proc, int(pid_str))
+        return None, None
+
+    def _process_sockstat(
+        self, output: Iterable[str]
+    ) -> Union[Tuple[str, int], Tuple[None, None]]:
+        for line in output:
+            line = line.strip()
+            if not line or line.startswith("USER"):
+                continue
+            parts = line.split()
+            if len(parts) >= 3:
+                return (parts[1], int(parts[2]))
         return None, None
 
 
@@ -926,10 +989,12 @@ class RebootRequired(FactBase[bool]):
     Returns a boolean indicating whether the system requires a reboot.
 
     On Linux systems:
+    
     - Checks /var/run/reboot-required and /var/run/reboot-required.pkgs
     - On Alpine Linux, compares installed kernel with running kernel
 
     On FreeBSD systems:
+
     - Compares running kernel version with installed kernel version
     """
 

--- a/tests/facts/server.Port/netstat-tcp-empty.json
+++ b/tests/facts/server.Port/netstat-tcp-empty.json
@@ -1,0 +1,12 @@
+{
+  "command": "netstat -tlnp 2>/dev/null | awk '$4 ~ /:80$/'",
+  "arg": {"port": 80, "protocol": "tcp"},
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=ss": null
+    }
+  },
+  "output": [],
+  "fact": [null, null]
+}

--- a/tests/facts/server.Port/netstat-tcp-one-process.json
+++ b/tests/facts/server.Port/netstat-tcp-one-process.json
@@ -1,0 +1,17 @@
+{
+  "command": "netstat -tlnp 2>/dev/null | awk '$4 ~ /:80$/'",
+  "arg": {"port": 80, "protocol": "tcp"},
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=ss": null
+    }
+  },
+  "output": [
+    "tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      1234/nginx"
+  ],
+  "fact": [
+    "nginx",
+    1234
+  ]
+}

--- a/tests/facts/server.Port/netstat-udp-one-process.json
+++ b/tests/facts/server.Port/netstat-udp-one-process.json
@@ -1,0 +1,17 @@
+{
+  "command": "netstat -ulnp 2>/dev/null | awk '$4 ~ /:53$/'",
+  "arg": {"port": 53, "protocol": "udp"},
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=ss": null
+    }
+  },
+  "output": [
+    "udp        0      0 0.0.0.0:53              0.0.0.0:*                           1234/named"
+  ],
+  "fact": [
+    "named",
+    1234
+  ]
+}

--- a/tests/facts/server.Port/one-process.json
+++ b/tests/facts/server.Port/one-process.json
@@ -1,7 +1,12 @@
 {
   "command": "ss -lptnH 'src :10025'",
   "arg": 10025,
-  "requires_command": "ss",
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=ss": "/usr/sbin/ss"
+    }
+  },
   "output": [
     "LISTEN 0      100        127.0.0.1:10025      0.0.0.0:*    users:((\"smtpd\",pid=3927036,fd=6),(\"master\",pid=1997758,fd=97))"
   ],

--- a/tests/facts/server.Port/sockstat-tcp-empty.json
+++ b/tests/facts/server.Port/sockstat-tcp-empty.json
@@ -1,0 +1,11 @@
+{
+  "command": "sockstat -l -p 80 -P tcp",
+  "arg": {"port": 80, "protocol": "tcp"},
+  "facts": {
+    "server.Kernel": "FreeBSD"
+  },
+  "output": [
+    "USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS         FOREIGN ADDRESS"
+  ],
+  "fact": [null, null]
+}

--- a/tests/facts/server.Port/sockstat-tcp-one-process.json
+++ b/tests/facts/server.Port/sockstat-tcp-one-process.json
@@ -1,0 +1,15 @@
+{
+  "command": "sockstat -l -p 80 -P tcp",
+  "arg": {"port": 80, "protocol": "tcp"},
+  "facts": {
+    "server.Kernel": "FreeBSD"
+  },
+  "output": [
+    "USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS         FOREIGN ADDRESS",
+    "www      nginx      1234  3  tcp4   *:80                  *:*"
+  ],
+  "fact": [
+    "nginx",
+    1234
+  ]
+}

--- a/tests/facts/server.Port/sockstat-udp-one-process.json
+++ b/tests/facts/server.Port/sockstat-udp-one-process.json
@@ -1,0 +1,15 @@
+{
+  "command": "sockstat -l -p 53 -P udp",
+  "arg": {"port": 53, "protocol": "udp"},
+  "facts": {
+    "server.Kernel": "FreeBSD"
+  },
+  "output": [
+    "USER     COMMAND    PID   FD PROTO  LOCAL ADDRESS         FOREIGN ADDRESS",
+    "root     named      5678  20 udp4   *:53                  *:*"
+  ],
+  "fact": [
+    "named",
+    5678
+  ]
+}

--- a/tests/facts/server.Port/ss-tcp-no-process-info.json
+++ b/tests/facts/server.Port/ss-tcp-no-process-info.json
@@ -1,0 +1,15 @@
+{
+  "command": "ss -lptnH 'src :22'",
+  "arg": 22,
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=ss": "/usr/sbin/ss"
+    }
+  },
+  "output": [
+    "LISTEN 0      128          0.0.0.0:22        0.0.0.0:*",
+    "LISTEN 0      128             [::]:22           [::]:*"
+  ],
+  "fact": [null, null]
+}

--- a/tests/facts/server.Port/ss-udp-empty.json
+++ b/tests/facts/server.Port/ss-udp-empty.json
@@ -1,6 +1,6 @@
 {
-  "command": "ss -lptnH 'src :53'",
-  "arg": 53,
+  "command": "ss -lpunH 'src :53'",
+  "arg": {"port": 53, "protocol": "udp"},
   "facts": {
     "server.Kernel": "Linux",
     "server.Which": {

--- a/tests/facts/server.Port/ss-udp-one-process.json
+++ b/tests/facts/server.Port/ss-udp-one-process.json
@@ -1,0 +1,17 @@
+{
+  "command": "ss -lpunH 'src :53'",
+  "arg": {"port": 53, "protocol": "udp"},
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=ss": "/usr/sbin/ss"
+    }
+  },
+  "output": [
+    "UNCONN 0      0          0.0.0.0:53        0.0.0.0:*    users:((\"named\",pid=1234,fd=512))"
+  ],
+  "fact": [
+    "named",
+    1234
+  ]
+}

--- a/tests/facts/server.Port/two-processes.json
+++ b/tests/facts/server.Port/two-processes.json
@@ -1,7 +1,12 @@
 {
   "command": "ss -lptnH 'src :443'",
   "arg": 443,
-  "requires_command": "ss",
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=ss": "/usr/sbin/ss"
+    }
+  },
   "output": [
     "LISTEN 0      511          0.0.0.0:443       0.0.0.0:*    users:((\"nginx\",pid=3759498,fd=3),(\"nginx\",pid=3759496,fd=3),(\"nginx\",pid=3759495,fd=3),(\"nginx\",pid=3759494,fd=3),(\"nginx\",pid=3759493,fd=3),(\"nginx\",pid=3759492,fd=3),(\"nginx\",pid=3759491,fd=3),(\"nginx\",pid=3759490,fd=3),(\"nginx\",pid=2274336,fd=3))",
     "LISTEN 0      511             [::]:443          [::]:*    users:((\"nginx\",pid=3759498,fd=4),(\"nginx\",pid=3759496,fd=4),(\"nginx\",pid=3759495,fd=4),(\"nginx\",pid=3759494,fd=4),(\"nginx\",pid=3759493,fd=4),(\"nginx\",pid=3759492,fd=4),(\"nginx\",pid=3759491,fd=4),(\"nginx\",pid=3759490,fd=4),(\"nginx\",pid=2274336,fd=4))"
@@ -11,4 +16,3 @@
     3759498
   ]
 }
-


### PR DESCRIPTION
Support TCP/UDP via a protocol argument and use ss (with netstat fallback) on Linux and sockstat on FreeBSD.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
