### PR TITLE
facts.hardware.Memory: use LANG=C while calling vmstat

### DIFF
--- a/src/pyinfra/facts/hardware.py
+++ b/src/pyinfra/facts/hardware.py
@@ -35,7 +35,7 @@ class Memory(FactBase):
 
     @override
     def command(self) -> str:
-        return "vmstat -s"
+        return "LANG=C vmstat -s"
 
     @override
     def process(self, output):

--- a/tests/facts/hardware.Memory/vmstat_bsd.json
+++ b/tests/facts/hardware.Memory/vmstat_bsd.json
@@ -1,5 +1,5 @@
 {
-    "command": "vmstat -s",
+    "command": "LANG=C vmstat -s",
     "requires_command": "vmstat",
     "output": [
         "4096 bytes per page",

--- a/tests/facts/hardware.Memory/vmstat_linux.json
+++ b/tests/facts/hardware.Memory/vmstat_linux.json
@@ -1,5 +1,5 @@
 {
-    "command": "vmstat -s",
+    "command": "LANG=C vmstat -s",
     "requires_command": "vmstat",
     "output": [
         "131766608  total memory",


### PR DESCRIPTION
Looks like reading available memory fails when system locale is not set to English (or similar). Forcing `LANG=C` for vmstat call to avoid this.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
