### PR TITLE
operations.docker: add support for env files

### DIFF
--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -27,6 +27,7 @@ def container(
     networks: list[str] | None = None,
     volumes: list[str] | None = None,
     env_vars: list[str] | None = None,
+    env_files: list[str] | None = None,
     labels: list[str] | None = None,
     pull_always: bool = False,
     present: bool = True,
@@ -44,6 +45,7 @@ def container(
     + ports: port list to expose
     + volumes: volume list to map on container
     + env_vars: environment variable list to inject on container
+    + env_files: list of files containing environment variables to inject on container
     + labels: Label list to attach to the container
     + pull_always: force image pull
     + force: remove a container with same name and create a new one
@@ -93,6 +95,7 @@ def container(
         networks or list(),
         volumes or list(),
         env_vars or list(),
+        env_files or list(),
         labels or list(),
         pull_always,
         restart_policy,

--- a/src/pyinfra/operations/util/docker.py
+++ b/src/pyinfra/operations/util/docker.py
@@ -163,6 +163,7 @@ class ContainerSpec:
     networks: list[str] = field(default_factory=list)
     volumes: list[str] = field(default_factory=list)
     env_vars: list[str] = field(default_factory=list)
+    env_files: list[str] = field(default_factory=list)
     labels: list[str] = field(default_factory=list)
     pull_always: bool = False
     restart_policy: str | None = None
@@ -181,6 +182,9 @@ class ContainerSpec:
 
         for env_var in self.env_vars:
             args.append("-e {0}".format(env_var))
+
+        for env_file in self.env_files:
+            args.append("--env-file {0}".format(env_file))
 
         for label in self.labels:
             args.append("--label {0}".format(label))

--- a/tests/operations/docker.container/add_container_with_env_file.json
+++ b/tests/operations/docker.container/add_container_with_env_file.json
@@ -1,0 +1,19 @@
+{
+    "kwargs": {
+        "container": "nginx",
+        "image": "nginx:alpine",
+        "present": "true",
+        "start": false,
+        "env_files": [
+            "a_file.env"
+        ]
+    },
+    "facts": {
+        "docker.DockerContainer": {
+            "object_id=nginx": []
+        }
+    },
+    "commands": [
+        "docker container create --name nginx --env-file a_file.env nginx:alpine"
+    ]
+}

--- a/tests/operations/docker.container/add_container_with_multiple_env_files.json
+++ b/tests/operations/docker.container/add_container_with_multiple_env_files.json
@@ -1,0 +1,20 @@
+{
+    "kwargs": {
+        "container": "nginx",
+        "image": "nginx:alpine",
+        "present": "true",
+        "start": false,
+        "env_files": [
+            "a_file.env",
+            "b_file.env"
+        ]
+    },
+    "facts": {
+        "docker.DockerContainer": {
+            "object_id=nginx": []
+        }
+    },
+    "commands": [
+        "docker container create --name nginx --env-file a_file.env --env-file b_file.env nginx:alpine"
+    ]
+}


### PR DESCRIPTION
Hi there! Noticed the --env-file flag is not currently supported. Since multiple files can be passed to `docker create` I made it a list.
Do let me know id there's anything that needs to be revisited!

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
