### PR TITLE
Add _su_password argument for su password authentication

### DIFF
--- a/src/pyinfra/api/arguments.py
+++ b/src/pyinfra/api/arguments.py
@@ -58,6 +58,7 @@ class ConnectorArguments(TypedDict, total=False):
     _use_su_login: bool
     _preserve_su_env: bool
     _su_shell: str
+    _su_password: str
     _doas: bool
     _doas_user: str
 
@@ -125,6 +126,10 @@ auth_argument_meta: dict[str, ArgumentMeta] = {
         + "Only available under Linux, for use when using `su` with a user that "
         + "has nologin/similar as their login shell.",
         default=lambda config: config.SU_SHELL,
+    ),
+    "_su_password": ArgumentMeta(
+        "Password to su with.",
+        default=lambda config: config.SU_PASSWORD,
     ),
     "_doas": ArgumentMeta(
         "Execute/apply any changes with doas.",

--- a/src/pyinfra/api/arguments_typed.py
+++ b/src/pyinfra/api/arguments_typed.py
@@ -34,6 +34,7 @@ class PyinfraOperation(Generic[P], Protocol):
         _use_su_login: bool = False,
         _preserve_su_env: bool = False,
         _su_shell: None | str = None,
+        _su_password: None | str = None,
         _doas: bool = False,
         _doas_user: None | str = None,
         # Shell arguments

--- a/src/pyinfra/api/config.py
+++ b/src/pyinfra/api/config.py
@@ -40,6 +40,7 @@ class ConfigDefaults:
     USE_SU_LOGIN: bool = False
     SU_SHELL: bool = False
     PRESERVE_SU_ENV: bool = False
+    SU_PASSWORD: Optional[str] = None
     # Use sudo and optional user
     SUDO: bool = False
     SUDO_USER: Optional[str] = None

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 
 SUDO_ASKPASS_ENV_VAR = "PYINFRA_SUDO_PASSWORD"
+SU_ASKPASS_ENV_VAR = "PYINFRA_SU_PASSWORD"
 
 
 SUDO_ASKPASS_COMMAND = r"""
@@ -237,6 +238,11 @@ def remove_any_sudo_askpass_file(host) -> None:
         host.run_shell_command("rm -f {0}".format(sudo_askpass_path))
         host.connector_data["sudo_askpass_path"] = None
 
+    su_askpass_path = host.connector_data.get("su_askpass_path")
+    if su_askpass_path:
+        host.run_shell_command("rm -f {0}".format(su_askpass_path))
+        host.connector_data["su_askpass_path"] = None
+
 
 @memoize
 def _show_use_su_login_warning() -> None:
@@ -273,25 +279,39 @@ def _ensure_sudo_askpass_set_for_host(host: "Host"):
     host.connector_data["sudo_askpass_path"] = shlex.quote(output.stdout_lines[0])
 
 
+def _ensure_su_askpass_set_for_host(host: "Host"):
+    if host.connector_data.get("su_askpass_path"):
+        return
+    _, output = host.run_shell_command(
+        SUDO_ASKPASS_COMMAND.format(host.get_temp_dir_config(), SU_ASKPASS_ENV_VAR)
+    )
+    host.connector_data["su_askpass_path"] = shlex.quote(output.stdout_lines[0])
+
+
 def make_unix_command_for_host(
     state: "State",
     host: "Host",
     command: StringCommand,
     **command_arguments,
 ) -> StringCommand:
-    if not command_arguments.get("_sudo"):
-        # If no sudo, we've nothing to do here
-        return make_unix_command(command, **command_arguments)
+    # Handle sudo password
+    if command_arguments.get("_sudo"):
+        # If the sudo password is not set in the direct arguments,
+        # set it from the connector data value.
+        if "_sudo_password" not in command_arguments or not command_arguments["_sudo_password"]:
+            command_arguments["_sudo_password"] = host.connector_data.get("prompted_sudo_password")
 
-    # If the sudo password is not set in the direct arguments,
-    # set it from the connector data value.
-    if "_sudo_password" not in command_arguments or not command_arguments["_sudo_password"]:
-        command_arguments["_sudo_password"] = host.connector_data.get("prompted_sudo_password")
+        if command_arguments.get("_sudo_password"):
+            # Ensure the askpass path is correctly set and passed through
+            _ensure_sudo_askpass_set_for_host(host)
+            command_arguments["_sudo_askpass_path"] = host.connector_data["sudo_askpass_path"]
 
-    if command_arguments["_sudo_password"]:
-        # Ensure the askpass path is correctly set and passed through
-        _ensure_sudo_askpass_set_for_host(host)
-        command_arguments["_sudo_askpass_path"] = host.connector_data["sudo_askpass_path"]
+    # Handle su password
+    if command_arguments.get("_su_user"):
+        if command_arguments.get("_su_password"):
+            _ensure_su_askpass_set_for_host(host)
+            command_arguments["_su_askpass_path"] = host.connector_data["su_askpass_path"]
+
     return make_unix_command(command, **command_arguments)
 
 
@@ -309,6 +329,8 @@ def make_unix_command(
     _use_su_login=False,
     _su_shell=None,
     _preserve_su_env=False,
+    _su_password="",
+    _su_askpass_path=None,
     # Sudo config
     _sudo=False,
     _sudo_user=None,
@@ -375,6 +397,18 @@ def make_unix_command(
             command_bits.extend(("-u", _sudo_user))
 
     if _su_user:
+        if _su_password and _su_askpass_path:
+            command_bits.extend(
+                [
+                    "env",
+                    MaskString(
+                        "{0}={1}".format(SU_ASKPASS_ENV_VAR, shlex.quote(_su_password))
+                    ),
+                    _su_askpass_path,
+                    "|",
+                ],
+            )
+
         command_bits.append("su")
 
         if _use_su_login:

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -401,9 +401,7 @@ def make_unix_command(
             command_bits.extend(
                 [
                     "env",
-                    MaskString(
-                        "{0}={1}".format(SU_ASKPASS_ENV_VAR, shlex.quote(_su_password))
-                    ),
+                    MaskString("{0}={1}".format(SU_ASKPASS_ENV_VAR, shlex.quote(_su_password))),
                     _su_askpass_path,
                     "|",
                 ],

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -61,6 +61,18 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         command = make_unix_command("uptime", _su_user="pyinfra", _su_shell="bash")
         assert command.get_raw_value() == "su -s `which bash` pyinfra -c 'sh -c uptime'"
 
+    def test_su_password_command(self):
+        command = make_unix_command(
+            "uptime",
+            _su_user="pyinfra",
+            _su_password="mypassword",
+            _su_askpass_path="/tmp/pyinfra-su-askpass-XXXX",
+        )
+        assert command.get_raw_value() == (
+            "env PYINFRA_SU_PASSWORD=mypassword /tmp/pyinfra-su-askpass-XXXX "
+            "| su pyinfra -c 'sh -c uptime'"
+        )
+
     def test_command_env(self):
         command = make_unix_command(
             "uptime",


### PR DESCRIPTION
When using _su_user to switch users via su, there was no way to provide a password. This adds _su_password support using the same askpass-script mechanism as _sudo_password, piping the password to su via stdin.

Fixes pyinfra-dev/pyinfra#1570

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
