### PR TITLE
connectors.ssh: fix parsing of SSH config file comments

### DIFF
--- a/src/pyinfra/connectors/sshuserclient/config.py
+++ b/src/pyinfra/connectors/sshuserclient/config.py
@@ -48,7 +48,7 @@ paramiko.config.invoke = FakeInvoke  # type: ignore
 
 
 def _strip_inline_comment(line):
-    """Strip inline comments from SSH config lines, respecting quoted strings."""
+    """Strip inline comments from SSH config lines, respecting quoted strings"""
     in_quote = False
     quote_char = None
     for i, char in enumerate(line):

--- a/src/pyinfra/connectors/sshuserclient/config.py
+++ b/src/pyinfra/connectors/sshuserclient/config.py
@@ -47,6 +47,22 @@ class FakeInvoke:
 paramiko.config.invoke = FakeInvoke  # type: ignore
 
 
+def _strip_inline_comment(line):
+    """Strip inline comments from SSH config lines, respecting quoted strings."""
+    in_quote = False
+    quote_char = None
+    for i, char in enumerate(line):
+        if char in ('"', "'") and not in_quote:
+            in_quote = True
+            quote_char = char
+        elif char == quote_char and in_quote:
+            in_quote = False
+            quote_char = None
+        elif char == "#" and not in_quote and i > 0 and line[i - 1] in (" ", "\t"):
+            return line[:i].rstrip()
+    return line
+
+
 def _expand_include_statements(file_obj, parsed_files=None):
     parsed_lines = []
 
@@ -54,6 +70,8 @@ def _expand_include_statements(file_obj, parsed_files=None):
         line = line.strip()
         if not line or line.startswith("#"):
             continue
+
+        line = _strip_inline_comment(line)
 
         match = re.match(SETTINGS_REGEX, line)
         if not match:

--- a/tests/test_connectors/test_sshuserclient.py
+++ b/tests/test_connectors/test_sshuserclient.py
@@ -19,6 +19,13 @@ Host 127.0.0.1
 Include other_file
 """
 
+SSH_CONFIG_INLINE_COMMENTS = """
+Host 127.0.0.1
+    IdentityFile /id_rsa   # my main key
+    User testuser # the test user
+    Port 33 # custom port
+"""
+
 SSH_CONFIG_OTHER_FILE = """
 Host 192.168.1.1
     User "otheruser"
@@ -160,6 +167,23 @@ class TestSSHUserConfig(TestCase):
         assert forward_agent is True
         assert isinstance(missing_host_key_policy, AskPolicy)
         assert host_keys_file == ("~/.ssh/test3",)
+
+    @patch(
+        "pyinfra.connectors.sshuserclient.client.open",
+        mock_open(read_data=SSH_CONFIG_INLINE_COMMENTS),
+        create=True,
+    )
+    def test_load_ssh_config_inline_comments(self):
+        """Test that inline comments are stripped from SSH config values (issue #1568)."""
+        client = SSHClient()
+
+        _, config, forward_agent, missing_host_key_policy, host_keys_file, keep_alive = (
+            client.parse_config("127.0.0.1")
+        )
+
+        assert config.get("key_filename") == ["/id_rsa"]
+        assert config.get("username") == "testuser"
+        assert config.get("port") == 33
 
     @patch(
         "pyinfra.connectors.sshuserclient.client.open",


### PR DESCRIPTION
SSH config lines with inline comments (e.g. "IdentityFile ~/.ssh/key # comment") were passed through to paramiko with the comment included, causing issues like "No such file or directory: '/home/user/.ssh/key # comment'".

Fixes pyinfra-dev/pyinfra#1568

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
