### PR TITLE
Add server.timezone operation and Timezone fact

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -156,6 +156,20 @@ class Command(FactBase[str]):
         return command
 
 
+class Timezone(FactBase[str]):
+    """
+    Returns the current system timezone (e.g. ``Europe/Amsterdam``).
+    """
+
+    @override
+    def command(self) -> str:
+        return "readlink -f /etc/localtime | sed 's|.*/zoneinfo/||'"
+
+    @override
+    def process(self, output: list[str]) -> str:
+        return output[0]
+
+
 class Which(FactBase[Optional[str]]):
     """
     Returns the path of a given command according to `command -v`, if available.

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -26,6 +26,7 @@ from pyinfra.facts.server import (
     Mounts,
     Os,
     Sysctl,
+    Timezone,
     Users,
     Which,
 )
@@ -411,6 +412,39 @@ def hostname(hostname: str, hostname_file: str | None = None):
 
         # And ensure it exists
         yield from files.put._inner(src=file, dest=hostname_file)
+
+
+@operation()
+def timezone(timezone: str):
+    """
+    Set the system timezone.
+
+    Uses ``timedatectl`` when available (systemd systems), otherwise falls back to
+    symlinking ``/etc/localtime`` directly.
+
+    + timezone: the timezone to set (e.g. ``Europe/Amsterdam``, ``UTC``)
+
+    **Example:**
+
+    .. code:: python
+
+        server.timezone(
+            name="Set the timezone to Europe/Amsterdam",
+            timezone="Europe/Amsterdam",
+        )
+    """
+
+    current_timezone = host.get_fact(Timezone)
+
+    if current_timezone == timezone:
+        host.noop("timezone is set")
+        return
+
+    if host.get_fact(Which, command="timedatectl"):
+        yield "timedatectl set-timezone {0}".format(timezone)
+    else:
+        yield "ln -sf /usr/share/zoneinfo/{0} /etc/localtime".format(timezone)
+        yield "echo {0} > /etc/timezone".format(timezone)
 
 
 @operation()

--- a/tests/facts/server.Timezone/timezone.json
+++ b/tests/facts/server.Timezone/timezone.json
@@ -1,0 +1,5 @@
+{
+    "command": "readlink -f /etc/localtime | sed 's|.*/zoneinfo/||'",
+    "output": ["Europe/Amsterdam"],
+    "fact": "Europe/Amsterdam"
+}

--- a/tests/operations/server.timezone/noop.json
+++ b/tests/operations/server.timezone/noop.json
@@ -1,0 +1,8 @@
+{
+    "args": ["Europe/Amsterdam"],
+    "facts": {
+        "server.Timezone": "Europe/Amsterdam"
+    },
+    "commands": [],
+    "noop_description": "timezone is set"
+}

--- a/tests/operations/server.timezone/set_no_timedatectl.json
+++ b/tests/operations/server.timezone/set_no_timedatectl.json
@@ -1,0 +1,11 @@
+{
+    "args": ["Europe/Amsterdam"],
+    "facts": {
+        "server.Timezone": "UTC",
+        "server.Which": {"command=timedatectl": null}
+    },
+    "commands": [
+        "ln -sf /usr/share/zoneinfo/Europe/Amsterdam /etc/localtime",
+        "echo Europe/Amsterdam > /etc/timezone"
+    ]
+}

--- a/tests/operations/server.timezone/set_timedatectl.json
+++ b/tests/operations/server.timezone/set_timedatectl.json
@@ -1,0 +1,10 @@
+{
+    "args": ["Europe/Amsterdam"],
+    "facts": {
+        "server.Timezone": "UTC",
+        "server.Which": {"command=timedatectl": "/usr/bin/timedatectl"}
+    },
+    "commands": [
+        "timedatectl set-timezone Europe/Amsterdam"
+    ]
+}


### PR DESCRIPTION
Add a Timezone fact that reads the current timezone via /etc/localtime, and a timezone operation that sets it using timedatectl on systemd systems with a fallback to symlinking /etc/localtime for non-systemd systems.

Closes #1555
- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)

