### PR TITLE
facts.server.Sysctl: fix non-zero exit code causing empty result

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -527,8 +527,8 @@ class Sysctl(FactBase):
     @override
     def command(self, keys=None):
         if keys is None:
-            return "sysctl -a"
-        return f"sysctl {' '.join(keys)}"
+            return "sysctl -a 2>/dev/null || true"
+        return f"sysctl {' '.join(keys)} 2>/dev/null || true"
 
     @override
     def process(self, output):

--- a/tests/facts/server.Sysctl/sysctl_linux.json
+++ b/tests/facts/server.Sysctl/sysctl_linux.json
@@ -1,5 +1,5 @@
 {
-    "command": "sysctl -a",
+    "command": "sysctl -a 2>/dev/null || true",
     "output": [
         "net.ipv4.tcp_adv_win_scale = -2",
         "vm.nr_hugepages_mempolicy = 0",

--- a/tests/facts/server.Sysctl/sysctl_macos.json
+++ b/tests/facts/server.Sysctl/sysctl_macos.json
@@ -1,5 +1,5 @@
 {
-    "command": "sysctl -a",
+    "command": "sysctl -a 2>/dev/null || true",
     "output": [
         "security.mac.sysvmsg_enforce: 1",
         "security.mac.sysvsem_enforce: 1",


### PR DESCRIPTION
`sysctl -a` exits with code 1 on Linux when some keys are unreadable (e.g. net.ipv6.conf.*.stable_secret I/O errors), causing pyinfra to skip processing stdout and return an empty dict. Suppress stderr and force a zero exit code so valid output is always parsed.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
