### PR TITLE
facts: fix requires_command shell operator precedence with compound commands

### DIFF
--- a/src/pyinfra/api/facts.py
+++ b/src/pyinfra/api/facts.py
@@ -240,7 +240,9 @@ def _get_fact(
             requires_command,
             ">/dev/null",
             "||",
+            "(",
             command,
+            ")",
         )
 
     status = False


### PR DESCRIPTION
When a fact uses `requires_command` and its command contains `&&` chains (e.g. runit.RunitStatus), the generated shell command has incorrect operator precedence:

  ! command -v sv >/dev/null || export SVDIR=... && cd "$SVDIR" && ...

Shell parses `||` and `&&` left-to-right, so when `sv` is missing the `||` short-circuits but subsequent `&&` clauses still run and fail, causing the fact to error instead of returning the default value.

Wrap the fact command in a subshell so `||` applies to the entire chain:

  ! command -v sv >/dev/null || ( export SVDIR=... && cd "$SVDIR" && ... )

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
