### PR TITLE
facts.runit.RunitManaged: handle missing service directory gracefully

### DIFF
--- a/src/pyinfra/facts/runit.py
+++ b/src/pyinfra/facts/runit.py
@@ -68,7 +68,10 @@ class RunitManaged(FactBase):
     @override
     def command(self, service=None, svdir="/var/service"):
         if service is None:
-            return 'cd "{0}" && find -mindepth 1 -maxdepth 1 -type l -printf "%f\n"'.format(svdir)
+            return (
+                '[ -d "{0}" ] && cd "{0}" '
+                '&& find -mindepth 1 -maxdepth 1 -type l -printf "%f\\n" || true'
+            ).format(svdir)
         else:
             return 'cd "{0}" && test -h "{1}" && echo "{1}" || true'.format(svdir, service)
 

--- a/tests/facts/runit.RunitManaged/status.json
+++ b/tests/facts/runit.RunitManaged/status.json
@@ -1,6 +1,6 @@
 {
     "arg": [null, "/var/service"],
-    "command": "cd \"/var/service\" && find -mindepth 1 -maxdepth 1 -type l -printf \"%f\n\"",
+    "command": "[ -d \"/var/service\" ] && cd \"/var/service\" && find -mindepth 1 -maxdepth 1 -type l -printf \"%f\\n\" || true",
     "requires_command": "sv",
     "output": [
         "agetty-tty1",


### PR DESCRIPTION
When the svdir (default `/var/service`) does not exist, `cd` fails and pyinfra treats the fact as an error. Guard with `[ -d ... ]` so the command succeeds with no output, returning an empty set instead.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)