### PR TITLE
facts.selinux.FileContext: handle missing SELinux context

### DIFF
--- a/src/pyinfra/facts/selinux.py
+++ b/src/pyinfra/facts/selinux.py
@@ -53,13 +53,15 @@ class FileContext(FactBase):
 
     @override
     def process(self, output):
-        context = {}
         components = output[0].split(":")
-        context["user"] = components[0]
-        context["role"] = components[1]
-        context["type"] = components[2]
-        context["level"] = components[3]
-        return context
+        if len(components) < 4:
+            return None
+        return {
+            "user": components[0],
+            "role": components[1],
+            "type": components[2],
+            "level": components[3],
+        }
 
 
 class FileContextMapping(FactBase):

--- a/tests/facts/selinux.FileContext/no_selinux.json
+++ b/tests/facts/selinux.FileContext/no_selinux.json
@@ -1,0 +1,8 @@
+{
+    "arg": "/etc/hostname",
+    "command": "stat -c %C /etc/hostname || exit 0",
+    "output": [
+        "?"
+    ],
+    "fact": null
+}


### PR DESCRIPTION
When SELinux is not enabled, `stat -c %C` outputs `?` which has no `:` separators. Splitting on `:` gives a single-element list, causing an IndexError when accessing components[1]. Return None when the output does not contain a valid SELinux context.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
