### PR TITLE
facts.server.SecurityLimits: handle missing limits.conf

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -968,7 +968,7 @@ class SecurityLimits(FactBase):
 
     @override
     def command(self):
-        return "cat /etc/security/limits.conf"
+        return "cat /etc/security/limits.conf 2>/dev/null || true"
 
     default = list
 

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -968,7 +968,7 @@ class SecurityLimits(FactBase):
 
     @override
     def command(self):
-        return "cat /etc/security/limits.conf 2>/dev/null || true"
+        return "! test -e /etc/security/limits.conf || cat /etc/security/limits.conf"
 
     default = list
 

--- a/tests/facts/server.SecurityLimits/security_limits.json
+++ b/tests/facts/server.SecurityLimits/security_limits.json
@@ -1,5 +1,5 @@
 {
-    "command": "cat /etc/security/limits.conf",
+    "command": "cat /etc/security/limits.conf 2>/dev/null || true",
     "output": [
         "# <domain>      <type>  <item>         <value>",
         "#*               soft    core            ",

--- a/tests/facts/server.SecurityLimits/security_limits.json
+++ b/tests/facts/server.SecurityLimits/security_limits.json
@@ -1,5 +1,5 @@
 {
-    "command": "cat /etc/security/limits.conf 2>/dev/null || true",
+    "command": "! test -e /etc/security/limits.conf || cat /etc/security/limits.conf",
     "output": [
         "# <domain>      <type>  <item>         <value>",
         "#*               soft    core            ",


### PR DESCRIPTION
When `/etc/security/limits.conf` does not exist (e.g. on Alpine/minimal systems), `cat` fails and pyinfra errors instead of returning the default empty list. Suppress stderr and force exit 0 so a missing file is treated as no limits configured.


- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
