### PR TITLE
operations+facts: `server.Processes` fact and `server.kill` operation

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -210,6 +210,15 @@ class MacosVersion(FactBase[str]):
         return "sw_vers -productVersion"
 
 
+class ProcessDict(TypedDict):
+    user: str
+    state: str
+    cpu_percent: float
+    mem_percent: float
+    command: str
+    args: str
+
+
 class MountsDict(TypedDict):
     device: str
     type: str
@@ -1043,3 +1052,74 @@ echo "no_reboot_required"
     @override
     def process(self, output) -> bool:
         return list(output)[0].strip() == "reboot_required"
+
+
+class Processes(FactBase["Dict[int, ProcessDict]"]):
+    """
+    Returns a dictionary of running processes keyed by PID.
+
+    .. code:: python
+
+        {
+            1: {
+                "user": "root",
+                "state": "Ss",
+                "cpu_percent": 0.0,
+                "mem_percent": 0.1,
+                "command": "init",
+                "args": "/sbin/init",
+            },
+        }
+    """
+
+    default = dict
+
+    @override
+    def command(self, pid: int | None = None) -> str:
+        self._kernel = host.get_fact(Kernel)
+        is_bsd = self._kernel.strip() in ("FreeBSD", "Darwin")
+
+        fields = "pid,user,stat,%cpu,%mem,comm,args"
+        if pid is not None:
+            self._has_header = True
+            return f"LANG=C ps -p {pid} -o {fields}"
+
+        if is_bsd:
+            self._has_header = True
+            return f"LANG=C ps -eo {fields}"
+        else:
+            self._has_header = False
+            return f"LANG=C ps -eo {fields} --no-headers"
+
+    @override
+    def process(self, output: Iterable[str]) -> dict[int, ProcessDict]:
+        processes: dict[int, ProcessDict] = {}
+
+        for line in output:
+            line = line.strip()
+            if not line:
+                continue
+            if self._has_header and line.startswith("PID"):
+                continue
+
+            parts = line.split(None, 6)
+            if len(parts) < 6:
+                continue
+
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+
+            args = parts[6] if len(parts) > 6 else parts[5]
+
+            processes[pid] = {
+                "user": parts[1],
+                "state": parts[2],
+                "cpu_percent": float(parts[3]),
+                "mem_percent": float(parts[4]),
+                "command": parts[5],
+                "args": args,
+            }
+
+        return processes

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -1079,16 +1079,29 @@ class Processes(FactBase["Dict[int, ProcessDict]"]):
         self._kernel = host.get_fact(Kernel)
         is_bsd = self._kernel.strip() in ("FreeBSD", "Darwin")
 
-        fields = "pid,user,stat,%cpu,%mem,comm,args"
+        # BusyBox ps (Alpine) only supports limited columns.
+        # Detect by checking if busybox exists on the system.
+        if not is_bsd:
+            self._is_busybox = bool(host.get_fact(Which, "busybox"))
+        else:
+            self._is_busybox = False
+
+        if not self._is_busybox:
+            fields = "pid,user,stat,%cpu,%mem,comm,args"
+        else:
+            # BusyBox ps: only pid, user/uid, vsz, stat, args are reliable
+            fields = "pid,user,vsz,stat,args"
+
         if pid is not None:
-            self._has_header = True
+            if self._is_busybox:
+                return f"LANG=C ps -o {fields} | awk 'NR==1 || $1=={pid}'"
             return f"LANG=C ps -p {pid} -o {fields}"
 
         if is_bsd:
-            self._has_header = True
             return f"LANG=C ps -eo {fields}"
+        elif self._is_busybox:
+            return f"LANG=C ps -o {fields}"
         else:
-            self._has_header = False
             return f"LANG=C ps -eo {fields} --no-headers"
 
     @override
@@ -1099,27 +1112,44 @@ class Processes(FactBase["Dict[int, ProcessDict]"]):
             line = line.strip()
             if not line:
                 continue
-            if self._has_header and line.startswith("PID"):
+            if line.startswith("PID"):
                 continue
 
-            parts = line.split(None, 6)
-            if len(parts) < 6:
-                continue
-
-            try:
-                pid = int(parts[0])
-            except ValueError:
-                continue
-
-            args = parts[6] if len(parts) > 6 else parts[5]
-
-            processes[pid] = {
-                "user": parts[1],
-                "state": parts[2],
-                "cpu_percent": float(parts[3]),
-                "mem_percent": float(parts[4]),
-                "command": parts[5],
-                "args": args,
-            }
+            if not self._is_busybox:
+                parts = line.split(None, 6)
+                if len(parts) < 6:
+                    continue
+                try:
+                    pid = int(parts[0])
+                except ValueError:
+                    continue
+                args = parts[6] if len(parts) > 6 else parts[5]
+                processes[pid] = {
+                    "user": parts[1],
+                    "state": parts[2],
+                    "cpu_percent": float(parts[3]),
+                    "mem_percent": float(parts[4]),
+                    "command": parts[5],
+                    "args": args,
+                }
+            else:
+                # BusyBox format: pid, user, vsz, stat, args
+                parts = line.split(None, 4)
+                if len(parts) < 5:
+                    continue
+                try:
+                    pid = int(parts[0])
+                except ValueError:
+                    continue
+                args = parts[4]
+                command = args.split()[0].rsplit("/", 1)[-1] if args else ""
+                processes[pid] = {
+                    "user": parts[1],
+                    "state": parts[3],
+                    "cpu_percent": 0.0,
+                    "mem_percent": 0.0,
+                    "command": command,
+                    "args": args,
+                }
 
         return processes

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -1097,6 +1097,28 @@ def locale(
         yield "locale-gen"
 
 
+@operation(is_idempotent=False)
+def kill(pid: int, signal: str = "TERM"):
+    """
+    Kill a running process.
+
+    + pid: PID of the process to kill
+    + signal: signal to send (default ``TERM``)
+
+    **Example:**
+
+    .. code:: python
+
+        server.kill(
+            name="Kill process 1234",
+            pid=1234,
+            signal="KILL",
+        )
+    """
+
+    yield "kill -{0} {1}".format(signal, pid)
+
+
 @operation()
 def security_limit(
     domain: str,

--- a/tests/facts/server.Processes/bsd_all.json
+++ b/tests/facts/server.Processes/bsd_all.json
@@ -1,0 +1,29 @@
+{
+  "command": "LANG=C ps -eo pid,user,stat,%cpu,%mem,comm,args",
+  "facts": {
+    "server.Kernel": "FreeBSD"
+  },
+  "output": [
+    "  PID USER     STAT %CPU %MEM COMMAND         COMMAND",
+    "    1 root     SLs   0.0  0.0 init            /sbin/init --",
+    "  742 root     Ss    0.0  0.2 sshd            /usr/sbin/sshd"
+  ],
+  "fact": {
+    "1": {
+      "user": "root",
+      "state": "SLs",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.0,
+      "command": "init",
+      "args": "/sbin/init --"
+    },
+    "742": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.2,
+      "command": "sshd",
+      "args": "/usr/sbin/sshd"
+    }
+  }
+}

--- a/tests/facts/server.Processes/bsd_single_pid.json
+++ b/tests/facts/server.Processes/bsd_single_pid.json
@@ -1,0 +1,21 @@
+{
+  "command": "LANG=C ps -p 742 -o pid,user,stat,%cpu,%mem,comm,args",
+  "arg": 742,
+  "facts": {
+    "server.Kernel": "FreeBSD"
+  },
+  "output": [
+    "  PID USER     STAT %CPU %MEM COMMAND         COMMAND",
+    "  742 root     Ss    0.0  0.2 sshd            /usr/sbin/sshd"
+  ],
+  "fact": {
+    "742": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.2,
+      "command": "sshd",
+      "args": "/usr/sbin/sshd"
+    }
+  }
+}

--- a/tests/facts/server.Processes/busybox_all.json
+++ b/tests/facts/server.Processes/busybox_all.json
@@ -1,0 +1,41 @@
+{
+  "command": "LANG=C ps -o pid,user,vsz,stat,args",
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=busybox": "/bin/busybox"
+    }
+  },
+  "output": [
+    "  PID USER       VSZ STAT ARGS",
+    "    1 root      2108 S    /sbin/init",
+    "  200 root      1536 S    /usr/sbin/sshd",
+    "  310 root      1488 S    /usr/sbin/crond -c /etc/crontabs"
+  ],
+  "fact": {
+    "1": {
+      "user": "root",
+      "state": "S",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.0,
+      "command": "init",
+      "args": "/sbin/init"
+    },
+    "200": {
+      "user": "root",
+      "state": "S",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.0,
+      "command": "sshd",
+      "args": "/usr/sbin/sshd"
+    },
+    "310": {
+      "user": "root",
+      "state": "S",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.0,
+      "command": "crond",
+      "args": "/usr/sbin/crond -c /etc/crontabs"
+    }
+  }
+}

--- a/tests/facts/server.Processes/busybox_single_pid.json
+++ b/tests/facts/server.Processes/busybox_single_pid.json
@@ -1,0 +1,24 @@
+{
+  "command": "LANG=C ps -o pid,user,vsz,stat,args | awk 'NR==1 || $1==1'",
+  "arg": 1,
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=busybox": "/bin/busybox"
+    }
+  },
+  "output": [
+    "  PID USER       VSZ STAT ARGS",
+    "    1 root      2108 S    /sbin/init"
+  ],
+  "fact": {
+    "1": {
+      "user": "root",
+      "state": "S",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.0,
+      "command": "init",
+      "args": "/sbin/init"
+    }
+  }
+}

--- a/tests/facts/server.Processes/linux_all.json
+++ b/tests/facts/server.Processes/linux_all.json
@@ -1,0 +1,37 @@
+{
+  "command": "LANG=C ps -eo pid,user,stat,%cpu,%mem,comm,args --no-headers",
+  "facts": {
+    "server.Kernel": "Linux"
+  },
+  "output": [
+    "    1 root     Ss    0.0  0.1 init            /sbin/init",
+    "  200 www-data S     1.2  3.4 nginx           nginx: worker process",
+    " 1500 postgres Ss    0.5  2.0 postgres        /usr/lib/postgresql/14/bin/postgres -D /var/lib/postgresql/14/main"
+  ],
+  "fact": {
+    "1": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.1,
+      "command": "init",
+      "args": "/sbin/init"
+    },
+    "200": {
+      "user": "www-data",
+      "state": "S",
+      "cpu_percent": 1.2,
+      "mem_percent": 3.4,
+      "command": "nginx",
+      "args": "nginx: worker process"
+    },
+    "1500": {
+      "user": "postgres",
+      "state": "Ss",
+      "cpu_percent": 0.5,
+      "mem_percent": 2.0,
+      "command": "postgres",
+      "args": "/usr/lib/postgresql/14/bin/postgres -D /var/lib/postgresql/14/main"
+    }
+  }
+}

--- a/tests/facts/server.Processes/linux_all.json
+++ b/tests/facts/server.Processes/linux_all.json
@@ -1,7 +1,10 @@
 {
   "command": "LANG=C ps -eo pid,user,stat,%cpu,%mem,comm,args --no-headers",
   "facts": {
-    "server.Kernel": "Linux"
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=busybox": null
+    }
   },
   "output": [
     "    1 root     Ss    0.0  0.1 init            /sbin/init",

--- a/tests/facts/server.Processes/linux_single_pid.json
+++ b/tests/facts/server.Processes/linux_single_pid.json
@@ -1,0 +1,21 @@
+{
+  "command": "LANG=C ps -p 1 -o pid,user,stat,%cpu,%mem,comm,args",
+  "arg": 1,
+  "facts": {
+    "server.Kernel": "Linux"
+  },
+  "output": [
+    "  PID USER     STAT %CPU %MEM COMMAND         COMMAND",
+    "    1 root     Ss    0.0  0.1 systemd         /lib/systemd/systemd --system"
+  ],
+  "fact": {
+    "1": {
+      "user": "root",
+      "state": "Ss",
+      "cpu_percent": 0.0,
+      "mem_percent": 0.1,
+      "command": "systemd",
+      "args": "/lib/systemd/systemd --system"
+    }
+  }
+}

--- a/tests/facts/server.Processes/linux_single_pid.json
+++ b/tests/facts/server.Processes/linux_single_pid.json
@@ -2,7 +2,10 @@
   "command": "LANG=C ps -p 1 -o pid,user,stat,%cpu,%mem,comm,args",
   "arg": 1,
   "facts": {
-    "server.Kernel": "Linux"
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=busybox": null
+    }
   },
   "output": [
     "  PID USER     STAT %CPU %MEM COMMAND         COMMAND",

--- a/tests/operations/server.kill/kill_default.json
+++ b/tests/operations/server.kill/kill_default.json
@@ -1,0 +1,5 @@
+{
+  "args": [1234],
+  "commands": ["kill -TERM 1234"],
+  "idempotent": false
+}

--- a/tests/operations/server.kill/kill_signal.json
+++ b/tests/operations/server.kill/kill_signal.json
@@ -1,0 +1,6 @@
+{
+  "args": [5678],
+  "kwargs": {"signal": "KILL"},
+  "commands": ["kill -KILL 5678"],
+  "idempotent": false
+}


### PR DESCRIPTION
Add process listing fact supporting Linux and BSD/macOS, and a kill operation to send signals to processes.

As discussed with Paul Hoffman on Matrix

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)