### PR TITLE
cli: add --ssh-password-prompt flag for interactive SSH password input

### DIFF
--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -169,6 +169,12 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     help="SSH Private key password.",
 )
 @click.option("--ssh-password", "--password", "ssh_password", help="SSH password.")
+@click.option(
+    "--ssh-password-prompt",
+    is_flag=True,
+    default=False,
+    help="Prompt for SSH password instead of passing it on the command line.",
+)
 # Eager commands (pyinfra --support)
 @click.option(
     "--support",
@@ -281,6 +287,7 @@ def _main(
     ssh_key,
     ssh_key_password: str,
     ssh_password: str,
+    ssh_password_prompt: bool,
     same_sudo_password: bool,
     shell_executable,
     sudo: bool,
@@ -344,6 +351,9 @@ def _main(
         retry,
         retry_delay,
     )
+    if ssh_password_prompt:
+        ssh_password = getpass("SSH password: ")
+
     override_data = _set_override_data(
         data,
         ssh_user,

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -170,6 +170,7 @@ class TestDirectMainExecution(PatchSSHTestCase):
                 ssh_key=None,
                 ssh_key_password=None,
                 ssh_password=None,
+                ssh_password_prompt=False,
                 same_sudo_password=False,
                 sudo=False,
                 sudo_user=None,


### PR DESCRIPTION
Adds a --ssh-password-prompt flag that prompts for the SSH password via getpass instead of requiring it on the command line, avoiding exposure in process lists and shell history. Follows the same pattern as --same-sudo-password.

Closes pyinfra-dev/pyinfra#1560


- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
