### PR TITLE
facts.server.Port: fix ss command for Alpine/BusyBox compatibility

### DIFF
--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -369,10 +369,12 @@ class Port(FactBase[Union[Tuple[str, int], Tuple[None, None]]]):
             if not line:
                 continue
             parts = line.split()
-            pid_prog = parts[-1]
-            if "/" in pid_prog:
-                pid_str, proc = pid_prog.split("/", 1)
-                return (proc, int(pid_str))
+            for part in parts:
+                if "/" in part:
+                    pid_str, proc = part.split("/", 1)
+                    if pid_str.isdigit():
+                        return (proc, int(pid_str))
+                    break
         return None, None
 
     def _process_sockstat(self, output: Iterable[str]) -> Union[Tuple[str, int], Tuple[None, None]]:

--- a/src/pyinfra/facts/server.py
+++ b/src/pyinfra/facts/server.py
@@ -338,7 +338,7 @@ class Port(FactBase[Union[Tuple[str, int], Tuple[None, None]]]):
         if self._has_ss:
             self._tool = "ss"
             proto_flag = "t" if protocol == "tcp" else "u"
-            return f"ss -lp{proto_flag}nH 'src :{port}'"
+            return f"ss -lp{proto_flag}n | grep ':{port} ' || true"
         else:
             self._tool = "netstat"
             proto_flag = "t" if protocol == "tcp" else "u"

--- a/tests/facts/server.Port/empty.json
+++ b/tests/facts/server.Port/empty.json
@@ -1,5 +1,5 @@
 {
-  "command": "ss -lptnH 'src :53'",
+  "command": "ss -lptn | grep ':53 ' || true",
   "arg": 53,
   "facts": {
     "server.Kernel": "Linux",

--- a/tests/facts/server.Port/netstat-tcp-truncated-name.json
+++ b/tests/facts/server.Port/netstat-tcp-truncated-name.json
@@ -1,0 +1,17 @@
+{
+  "command": "netstat -tlnp 2>/dev/null | awk '$4 ~ /:22$/'",
+  "arg": {"port": 22, "protocol": "tcp"},
+  "facts": {
+    "server.Kernel": "Linux",
+    "server.Which": {
+      "command=ss": null
+    }
+  },
+  "output": [
+    "tcp        0      0 0.0.0.0:22              0.0.0.0:*               LISTEN      2316/sshd [listener"
+  ],
+  "fact": [
+    "sshd",
+    2316
+  ]
+}

--- a/tests/facts/server.Port/one-process.json
+++ b/tests/facts/server.Port/one-process.json
@@ -1,5 +1,5 @@
 {
-  "command": "ss -lptnH 'src :10025'",
+  "command": "ss -lptn | grep ':10025 ' || true",
   "arg": 10025,
   "facts": {
     "server.Kernel": "Linux",

--- a/tests/facts/server.Port/ss-tcp-no-process-info.json
+++ b/tests/facts/server.Port/ss-tcp-no-process-info.json
@@ -1,5 +1,5 @@
 {
-  "command": "ss -lptnH 'src :22'",
+  "command": "ss -lptn | grep ':22 ' || true",
   "arg": 22,
   "facts": {
     "server.Kernel": "Linux",

--- a/tests/facts/server.Port/ss-udp-empty.json
+++ b/tests/facts/server.Port/ss-udp-empty.json
@@ -1,5 +1,5 @@
 {
-  "command": "ss -lpunH 'src :53'",
+  "command": "ss -lpun | grep ':53 ' || true",
   "arg": {"port": 53, "protocol": "udp"},
   "facts": {
     "server.Kernel": "Linux",

--- a/tests/facts/server.Port/ss-udp-one-process.json
+++ b/tests/facts/server.Port/ss-udp-one-process.json
@@ -1,5 +1,5 @@
 {
-  "command": "ss -lpunH 'src :53'",
+  "command": "ss -lpun | grep ':53 ' || true",
   "arg": {"port": 53, "protocol": "udp"},
   "facts": {
     "server.Kernel": "Linux",

--- a/tests/facts/server.Port/two-processes.json
+++ b/tests/facts/server.Port/two-processes.json
@@ -1,5 +1,5 @@
 {
-  "command": "ss -lptnH 'src :443'",
+  "command": "ss -lptn | grep ':443 ' || true",
   "arg": 443,
   "facts": {
     "server.Kernel": "Linux",


### PR DESCRIPTION
BusyBox ss (used sometimes on Alpine) does not support the -H flag or filter expressions like 'src :port'. Replace with pipe to grep which works on both iproute2 and BusyBox ss. Append || true so grep returning no matches does not cause a command failure.

On Alpine, netstat outputs program names like "sshd [listener" which contain spaces. The parser was taking the last whitespace-delimited field, missing the PID/program column. Now scans fields for the one containing "/" to reliably find the PID/program pair.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)

