### PR TITLE
facts.opkg: add requires_command and stop hardcoding /bin/opkg

### DIFF
--- a/src/pyinfra/facts/opkg.py
+++ b/src/pyinfra/facts/opkg.py
@@ -66,6 +66,10 @@ class OpkgConf(FactBase):
 
     """
 
+    @override
+    def requires_command(self) -> str:
+        return "opkg"
+
     regex = re.compile(
         r"""
                        ^(?:\s*)
@@ -133,6 +137,10 @@ class OpkgFeeds(FactBase):
     default = dict
 
     @override
+    def requires_command(self) -> str:
+        return "opkg"
+
+    @override
     def command(self) -> str:
         return "cat /etc/opkg/distfeeds.conf; echo CUSTOM; cat /etc/opkg/customfeeds.conf"
 
@@ -172,8 +180,12 @@ class OpkgInstallableArchitectures(FactBase):
     default = dict
 
     @override
+    def requires_command(self) -> str:
+        return "opkg"
+
+    @override
     def command(self) -> str:
-        return "/bin/opkg print-architecture"
+        return "opkg print-architecture"
 
     @override
     def process(self, output):
@@ -205,8 +217,12 @@ class OpkgPackages(FactBase):
     default = dict
 
     @override
+    def requires_command(self) -> str:
+        return "opkg"
+
+    @override
     def command(self) -> str:
-        return "/bin/opkg list-installed"
+        return "opkg list-installed"
 
     @override
     def process(self, output):
@@ -230,8 +246,12 @@ class OpkgUpgradeablePackages(FactBase):
     use_default_on_error = True
 
     @override
+    def requires_command(self) -> str:
+        return "opkg"
+
+    @override
     def command(self) -> str:
-        return "/bin/opkg list-upgradable"  # yes, really spelled that way
+        return "opkg list-upgradable"  # yes, really spelled that way
 
     @override
     def process(self, output):

--- a/tests/facts/opkg.OpkgConf/opkg_conf.json
+++ b/tests/facts/opkg.OpkgConf/opkg_conf.json
@@ -1,5 +1,6 @@
 {
     "command": "cat /etc/opkg.conf",
+    "requires_command": "opkg",
     "output": [
         "",
         "# a comment",

--- a/tests/facts/opkg.OpkgFeeds/opkg_feeds.json
+++ b/tests/facts/opkg.OpkgFeeds/opkg_feeds.json
@@ -1,5 +1,6 @@
 {
     "command": "cat /etc/opkg/distfeeds.conf; echo CUSTOM; cat /etc/opkg/customfeeds.conf",
+    "requires_command": "opkg",
     "output": [
         "",
         "   # a different comment",

--- a/tests/facts/opkg.OpkgInstallableArchitectures/opkg_installable_architectures.json
+++ b/tests/facts/opkg.OpkgInstallableArchitectures/opkg_installable_architectures.json
@@ -1,5 +1,6 @@
 {
-    "command": "/bin/opkg print-architecture",
+    "command": "opkg print-architecture",
+    "requires_command": "opkg",
     "output": [
         "",
         "# a comment to start",

--- a/tests/facts/opkg.OpkgPackages/opkg_packages.json
+++ b/tests/facts/opkg.OpkgPackages/opkg_packages.json
@@ -1,5 +1,6 @@
 {
-    "command": "/bin/opkg list-installed",
+    "command": "opkg list-installed",
+    "requires_command": "opkg",
     "output": [
         "urandom-seed - 1.0-1",
         "urngd - 2020-01-21-c7f7b6b6-1",

--- a/tests/facts/opkg.OpkgUpgradeablePackages/opkg_upgradeable_packages.json
+++ b/tests/facts/opkg.OpkgUpgradeablePackages/opkg_upgradeable_packages.json
@@ -1,5 +1,6 @@
 {
-    "command": "/bin/opkg list-upgradable",
+    "command": "opkg list-upgradable",
+    "requires_command": "opkg",
     "output": [
         "",
         "rpcd-mod-iwinfo - 2019-12-10-aaa08366-2 - 2020-05-26-67c8a3fd-1",


### PR DESCRIPTION
All five opkg fact classes were missing requires_command, causing confusing errors on hosts without opkg. Also replaced hardcoded /bin/opkg paths with just opkg so the command is resolved via PATH. (maybe a big mistake...)

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)