### PR TITLE
facts.choco: add requires_command to ChocoPackages and ChocoVersion

### DIFF
--- a/src/pyinfra/facts/choco.py
+++ b/src/pyinfra/facts/choco.py
@@ -21,6 +21,10 @@ class ChocoPackages(FactBase):
     """
 
     @override
+    def requires_command(self) -> str:
+        return "choco"
+
+    @override
     def command(self) -> str:
         return "choco list"
 
@@ -37,6 +41,10 @@ class ChocoVersion(FactBase):
     """
     Returns the choco (Chocolatey) version.
     """
+
+    @override
+    def requires_command(self) -> str:
+        return "choco"
 
     @override
     def command(self) -> str:

--- a/tests/facts/choco.ChocoPackages/packages.json
+++ b/tests/facts/choco.ChocoPackages/packages.json
@@ -1,5 +1,6 @@
 {
     "command": "choco list",
+    "requires_command": "choco",
     "output": [
         "Chocolatey v0.10.15",
         "chocolatey 0.10.15",

--- a/tests/facts/choco.ChocoVersion/version.json
+++ b/tests/facts/choco.ChocoVersion/version.json
@@ -1,5 +1,6 @@
 {
     "command": "choco --version",
+    "requires_command": "choco",
     "output": ["0.10.15", ""],
     "fact": "0.10.15"
 }


### PR DESCRIPTION
Both choco fact classes were missing requires_command, causing errors on hosts without Chocolatey instead of cleanly skipping.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)