### PR TITLE
operations.docker: add support for dns

### DIFF
--- a/src/pyinfra/operations/docker.py
+++ b/src/pyinfra/operations/docker.py
@@ -35,6 +35,7 @@ def container(
     start: bool = True,
     restart_policy: str | None = None,
     auto_remove: bool = False,
+    dns: list[str] | None = None,
 ):
     """
     Manage Docker containers
@@ -53,6 +54,7 @@ def container(
     + start: start or stop the container
     + restart_policy: restart policy to apply when a container exits
     + auto_remove: automatically remove the container and its associated anonymous volumes when it exits
+    + dns: list of dns servers to be used by the container
 
     **Examples:**
 
@@ -100,6 +102,7 @@ def container(
         pull_always,
         restart_policy,
         auto_remove,
+        dns or list(),
     )
     existent_container = host.get_fact(DockerContainer, object_id=container)
 

--- a/src/pyinfra/operations/util/docker.py
+++ b/src/pyinfra/operations/util/docker.py
@@ -168,6 +168,7 @@ class ContainerSpec:
     pull_always: bool = False
     restart_policy: str | None = None
     auto_remove: bool = False
+    dns: list[str] = field(default_factory=list)
 
     def container_create_args(self):
         args = []
@@ -197,6 +198,9 @@ class ContainerSpec:
 
         if self.auto_remove:
             args.append("--rm")
+
+        for dns in self.dns:
+            args.append("--dns {0}".format(dns))
 
         args.append(self.image)
 

--- a/tests/operations/docker.container/add_container_with_dns.json
+++ b/tests/operations/docker.container/add_container_with_dns.json
@@ -1,0 +1,19 @@
+{
+    "kwargs": {
+        "container": "nginx",
+        "image": "nginx:alpine",
+        "present": "true",
+        "start": false,
+        "dns": [
+            "1.1.1.1"
+        ]
+    },
+    "facts": {
+        "docker.DockerContainer": {
+            "object_id=nginx": []
+        }
+    },
+    "commands": [
+        "docker container create --name nginx --dns 1.1.1.1 nginx:alpine"
+    ]
+}

--- a/tests/operations/docker.container/add_container_with_multiple_dns.json
+++ b/tests/operations/docker.container/add_container_with_multiple_dns.json
@@ -1,0 +1,20 @@
+{
+    "kwargs": {
+        "container": "nginx",
+        "image": "nginx:alpine",
+        "present": "true",
+        "start": false,
+        "dns": [
+            "1.1.1.1",
+            "2.2.2.2"
+        ]
+    },
+    "facts": {
+        "docker.DockerContainer": {
+            "object_id=nginx": []
+        }
+    },
+    "commands": [
+        "docker container create --name nginx --dns 1.1.1.1 --dns 2.2.2.2 nginx:alpine"
+    ]
+}


### PR DESCRIPTION
Hello there! While working on #1572 , I noticed the `--dns` flag was also missing, so I added it here.
The tests for dockerssh (podmanssh?) are failing when run from my machine, but they fail both with or without these changes so I'm hoping the pipeline won't complain (might be something wrong on my end). :crossed_fingers: 

<!--
    🎉 Thank you for taking the time to contribute to pyinfra! 🎉

    Please provide a short description of the proposed change and here's a handy checklist of things
    to make PRs quicker to review and merge.

    Note that we will not merge new connectors, but instead welcome PRs that link to thid party
    connector packages.
-->

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [ ] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
