### PR TITLE
docs: facts.opkg, operations.opkg - add note about Openwrt switch to apk

### DIFF
--- a/src/pyinfra/facts/opkg.py
+++ b/src/pyinfra/facts/opkg.py
@@ -5,8 +5,11 @@ Gather the information provided by ``opkg`` on OpenWrt systems:
     + list of installed packages
     + list of packages with available upgrades
 
+See https://openwrt.org/docs/guide-user/additional-software/opkg
 
-    see https://openwrt.org/docs/guide-user/additional-software/opkg
+**Note:** as of OpenWrt Release `2025.12`_, OpenWrt uses ``apk``.
+
+.. _2025.12: https://openwrt.org/releases/25.12/notes-25.12.0#switch_package_manager_from_opkg_to_apk
 """
 
 import re

--- a/src/pyinfra/operations/opkg.py
+++ b/src/pyinfra/operations/opkg.py
@@ -3,8 +3,13 @@ Manage packages on OpenWrt using opkg
     + ``update`` - update local copy of package information
     + ``packages`` -  install and remove packages
 
-see https://openwrt.org/docs/guide-user/additional-software/opkg
+See https://openwrt.org/docs/guide-user/additional-software/opkg
+
 OpenWrt recommends against upgrading all packages  thus there is no ``opkg.upgrade`` function
+
+**Note:** as of OpenWrt Release `2025.12`_, OpenWrt uses ``apk``.
+
+.. _2025.12: https://openwrt.org/releases/25.12/notes-25.12.0#switch_package_manager_from_opkg_to_apk
 """
 
 from typing import List, Union


### PR DESCRIPTION
As of Release 2025-12, OpenWrt has [moved from ``opkg`` to ``apk``](https://openwrt.org/releases/25.12/notes-25.12.0#switch_package_manager_from_opkg_to_apk)
This adds a note to that effect to the top of the facts and operations pages in case, for some reason, the ``opkg`` routines gets used and nothing happens.

- [x ] Pull request is based on the default branch (`3.x` at this time)
- [n/a] Pull request includes tests for any new/updated operations/facts
- [x ] Pull request includes documentation for any new/updated operations/facts
- [ x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
