### PR TITLE
docs: fix extra trailing comma in operation argument lists

### DIFF
--- a/scripts/generate_facts_docs.py
+++ b/scripts/generate_facts_docs.py
@@ -87,7 +87,7 @@ def build_facts_docs():
                     else {}
                 )
 
-                if len(argspec.args):
+                if len(argspec.args) and (argspec.args != ["self"]):
                     args_string_and_brackets = ", {0}".format(
                         ", ".join(
                             ("{0}={1}".format(arg, defaults.get(arg)) if arg in defaults else arg)


### PR DESCRIPTION
Tweak `scripts/generate_facts_docs.py` for facts with no parameters to not generate a tralling comma in the invocation example.  Before is at /1/ below, after is at /2/.  /3/ shows a fact with arguments after the change

- [x] Pull request is based on the default branch (`3.x` at this time)
- [n/a ] Pull request includes tests for any new/updated operations/facts
- [n/a] Pull request includes documentation for any new/updated operations/facts
- [n/a] Tests pass (see `scripts/dev-test.sh`)
- [ n/a] Type checking & code style passes (see `scripts/dev-lint.sh`)

/1/ 
<img width="988" height="169" alt="image" src="https://github.com/user-attachments/assets/c8934036-1fd3-4fe3-a454-8a1eafe4dcfb" />

/2/
<img width="975" height="175" alt="image" src="https://github.com/user-attachments/assets/873d0665-5b66-42fd-af7f-83324db8f4d4" />

/3/
<img width="971" height="164" alt="image" src="https://github.com/user-attachments/assets/24e6a81c-6beb-406a-8ecc-2babc695ecab" />