### PR TITLE
docs: fix missing keyword-only args in operations documentation

### DIFF
--- a/scripts/generate_operations_docs.py
+++ b/scripts/generate_operations_docs.py
@@ -124,15 +124,17 @@ def build_operations_docs():
             args_string = signature(func).format(
                 max_width=MODULE_DEF_LINE_MAX, quote_annotation_strings=False
             )
-            args_string = f"{args_string[1:-2]},\n    **kwargs" if args_string != "()" else "**kwargs"
-            args_string = args_string.replace("   ", "        ")
+            args_string = (
+                f"{args_string[:-2]},\n    **kwargs,\n" if args_string != "()" else "**kwargs,"
+            )
+            args_string = f"{args_string.replace('   ', '        ')}    )"
 
             # Attach the code block
             lines.append(
                 """
 .. code:: python
 
-    {0}.{1}({2})
+    {0}.{1}{2}
 
 """.strip().format(
                     module_name,
@@ -140,7 +142,6 @@ def build_operations_docs():
                     args_string,
                 ),
             )
-
             # Append any remaining docstring
             if doc:
                 lines.append("")

--- a/scripts/generate_operations_docs.py
+++ b/scripts/generate_operations_docs.py
@@ -3,7 +3,7 @@
 import sys
 from glob import glob
 from importlib import import_module
-from inspect import getfullargspec, getmembers, isclass
+from inspect import getmembers, isclass, signature
 from os import makedirs, path
 from types import FunctionType
 
@@ -119,66 +119,13 @@ def build_operations_docs():
                     lines.append("")
                     doc = "\n".join(docbits[len(description_lines) :])
 
-            argspec = getfullargspec(func)
-
-            # Make default strings appear as strings
-            arg_defaults = (
-                ['"{}"'.format(arg) if isinstance(arg, str) else arg for arg in argspec.defaults]
-                if argspec.defaults
-                else None
+            # get signature, remove parens, append (or set) kwargs for global arguments and
+            # expand spacing so params are indented wrt to the operation name
+            args_string = signature(func).format(
+                max_width=MODULE_DEF_LINE_MAX, quote_annotation_strings=False
             )
-
-            # Create a dict of arg name -> default
-            defaults = (
-                dict(
-                    zip(
-                        argspec.args[-len(arg_defaults) :],
-                        arg_defaults,
-                    ),
-                )
-                if arg_defaults
-                else {}
-            )
-
-            # Build args string
-            args = []
-
-            for arg in argspec.args:
-                if arg in ("state", "host") or arg.startswith("_"):
-                    continue
-
-                value = arg
-
-                if arg in argspec.annotations:
-                    value += f": {argspec.annotations[arg]}"
-
-                if arg in defaults:
-                    value += f"={defaults[arg]}"
-
-                args.append(value)
-
-            # Add **kwargs to indicate global arguments
-            args.append("**kwargs")
-
-            if len(", ".join(args)) <= MODULE_DEF_LINE_MAX:
-                args_string = ", ".join(args)
-
-            else:
-                arg_buffer = []
-                arg_lines = []
-                for arg in args:
-                    if len(", ".join(arg_buffer + [arg])) >= MODULE_DEF_LINE_MAX:
-                        arg_lines.append(arg_buffer)
-                        arg_buffer = []
-
-                    arg_buffer.append(arg)
-
-                if arg_buffer:
-                    arg_lines.append(arg_buffer)
-
-                arg_lines = ["        {0}".format(", ".join(line_args)) for line_args in arg_lines]
-
-                args_string = "\n{0},\n    ".format(",\n".join(arg_lines))
+            args_string = f"{args_string[1:-2]},\n    **kwargs" if args_string != "()" else "**kwargs"
+            args_string = args_string.replace("   ", "        ")
 
             # Attach the code block
             lines.append(

--- a/scripts/generate_operations_docs.py
+++ b/scripts/generate_operations_docs.py
@@ -125,7 +125,7 @@ def build_operations_docs():
                 max_width=MODULE_DEF_LINE_MAX, quote_annotation_strings=False
             )
             args_string = (
-                f"{args_string[:-2]},\n    **kwargs,\n" if args_string != "()" else "**kwargs,"
+                f"{args_string[:-1]},\n    **kwargs,\n" if args_string != "()" else "**kwargs,"
             )
             args_string = f"{args_string.replace('   ', '        ')}    )"
 


### PR DESCRIPTION
``./scripts/generate_operations_docs.py`` does not make keyword-only arguments visible in the document (see /1/ below taken from #1500).  It also, as visible at /2/ and /3/, struggles for some reason with the arguments to ``opkg.packages`` (even if they, separately, probably should catch up to modern Python typing).

The proposed fix uses `inspect.signature` instead of `inspect.getfullargspec` as it produces a formatted argument string including the all arguments, regardless of their kind, complete with defaults and annotations..

The one side effect of this change is that once the signature exceeds the maximum line width,  `signature.format` does _not_ pack arguments onto a line the way``build_operations_docs`` currently does (see /3/)  but places them one per line (see /4/)  the way `ruff` does.  

If preferable, I can tweak the output to restore the current (condensed) format.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [n/a] Pull request includes tests for any new/updated operations/facts
- [n/a] Pull request includes documentation for any new/updated operations/facts
- [n/a] Tests pass (see `scripts/dev-test.sh`)
- [~] Type checking & code style passes (see `scripts/dev-lint.sh`) -- _`ruff format and check run manually`_

/1/

<img width="990" height="254" alt="image" src="https://github.com/user-attachments/assets/f94339a5-23a0-40e1-8094-5c1e15779cc4" />

/2/
```
/Users/Someone/Projects/pyinfra-dev/docs/operations/opkg.rst:22: WARNING: Lexing literal_block 'opkg.packages(\n    packages: str | typing.List[str]="", present: <class \'bool\'>=True,\n    latest: <class \'bool\'>=False, update: <class \'bool\'>=True, **kwargs,\n)' as "python" resulted in an error at token: "'". Retrying in relaxed mode. [misc.highlighting_failure]
```

/3/

<img width="978" height="154" alt="image" src="https://github.com/user-attachments/assets/8c821064-53d8-4bc0-bb50-1a485f08a690" />

/4/

<img width="980" height="400" alt="image" src="https://github.com/user-attachments/assets/fbbeef7c-8d8a-4ddb-9609-ecd0a9de2361" />


/5/

<img width="977" height="378" alt="image" src="https://github.com/user-attachments/assets/0b7551a0-1c29-4274-82a7-0331ed97c0a3" />
