### PR TITLE
facts.systemd: ensure that user-mode systemd facts do not fail if user manager is not available

### DIFF
--- a/src/pyinfra/facts/systemd.py
+++ b/src/pyinfra/facts/systemd.py
@@ -87,7 +87,7 @@ class SystemdStatus(FactBase[Dict[str, bool]]):
         elif isinstance(services, Iterable):
             service_strs = [QuoteString(s) for s in services]
 
-        return StringCommand(
+        cmd = StringCommand(
             fact_cmd,
             "show",
             "--all",
@@ -97,6 +97,14 @@ class SystemdStatus(FactBase[Dict[str, bool]]):
             self.state_key,
             *service_strs,
         )
+
+        if user_mode:
+            # In the planning stage, user managers might not be available yet. We
+            # swallow the error `Failed to connect to user scope bus ...`, so that the
+            # preparation stage does not fail.
+            return StringCommand("(", cmd, "2>/dev/null", "||", "true", ")")
+
+        return cmd
 
     @override
     def process(self, output) -> Dict[str, bool]:

--- a/tests/facts/systemd.SystemdEnabled/user_machine_services.json
+++ b/tests/facts/systemd.SystemdEnabled/user_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [true, "testmachine", "testuser"],
-    "command": "systemctl --user --machine=testuser@testmachine show --all --property Id --property UnitFileState '*'",
+    "command": "( systemctl --user --machine=testuser@testmachine show --all --property Id --property UnitFileState '*' 2>/dev/null || true )",
     "requires_command": "systemctl",
     "output": [
         "Id=vboxadd.service",

--- a/tests/facts/systemd.SystemdEnabled/user_services.json
+++ b/tests/facts/systemd.SystemdEnabled/user_services.json
@@ -1,6 +1,6 @@
 {
     "arg": [true],
-    "command": "systemctl --user show --all --property Id --property UnitFileState '*'",
+    "command": "( systemctl --user show --all --property Id --property UnitFileState '*' 2>/dev/null || true )",
     "requires_command": "systemctl",
     "output": [
         "Id=vboxadd.service",

--- a/tests/facts/systemd.SystemdStatus/user_machine_services.json
+++ b/tests/facts/systemd.SystemdStatus/user_machine_services.json
@@ -1,6 +1,6 @@
 {
     "arg": ["True", "testmachine", "testuser"],
-    "command": "systemctl --user --machine=testuser@testmachine show --all --property Id --property SubState '*'",
+    "command": "( systemctl --user --machine=testuser@testmachine show --all --property Id --property SubState '*' 2>/dev/null || true )",
     "requires_command": "systemctl",
     "output": [
         "Id=lvm2-activation.service",

--- a/tests/facts/systemd.SystemdStatus/user_services.json
+++ b/tests/facts/systemd.SystemdStatus/user_services.json
@@ -1,6 +1,6 @@
 {
     "arg": ["True"],
-    "command": "systemctl --user show --all --property Id --property SubState '*'",
+    "command": "( systemctl --user show --all --property Id --property SubState '*' 2>/dev/null || true )",
     "requires_command": "systemctl",
     "output": [
         "Id=lvm2-activation.service",


### PR DESCRIPTION
If a script uses systemd facts in user-mode anywhere but will only enable the user's manager via `loginctl enable-linger` during its first run, calls to `systemctl --user` will fail during the preparation stage in the initial run. This change makes it so that such scripts run through anyway immediately. Before, it was required to comment out all systemd commands on the first run until the user manager has been enabled.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
