### PR TITLE
docs: generate fact/operation docs for modules (vs files)

### DIFF
--- a/docs/utils.py
+++ b/docs/utils.py
@@ -1,4 +1,8 @@
 import re
+from inspect import getmembers, ismodule
+from pathlib import Path
+from types import ModuleType
+from typing import Generator, Any
 
 
 def title_line(char, string):
@@ -11,3 +15,47 @@ def format_doc_line(line):
 
     # Python's __doc__ attribute already dedents docstrings, so we don't need to strip anything
     return line
+
+
+def including_sub_modules(module: ModuleType) -> Generator[ModuleType]:
+    """Yield all modules to be examined, including the base modules."""
+    yield module
+    module_name = module.__name__
+    for key, value in getmembers(module):
+        if (
+            ismodule(value)
+            and value.__name__.startswith(module_name)
+            and (not key.startswith("__"))
+        ):
+            yield value
+
+
+def get_module_names(
+    src_dir: Path,
+    *,
+    exclude_dir: str | list[str] | None = None,
+    exclude_file: str | list[str] | None = None,
+) -> list[str]:
+    """Return file names of all modules found in src_dir."""
+    exclude_path = set(exclude_dir or ["util"])
+    exclude_name = set(exclude_file or ["__init__.py"])
+
+    module_names = [
+        path.stem
+        for path in (src_dir.iterdir())
+        if (
+            (path.is_dir() and (path.name not in exclude_path))
+            or ((path.suffix == ".py") and (path.name not in exclude_name))
+        )
+    ]
+    return module_names
+
+
+def remove_dups(all: list[tuple[str, Any]]) -> list[tuple[str, Any]]:
+    """Remove items with duplicate values, i.e. the same function or module found again."""
+    unique, seen = [], set()
+    for key, value in all:
+        if value not in seen:
+            seen.add(value)
+            unique.append((key, value))
+    return unique

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -27,7 +27,7 @@ def including_sub_modules(module: ModuleType) -> Generator[ModuleType]:
             and value.__name__.startswith(module_name)
             and (not key.startswith("__"))
         ):
-            yield value
+            yield from including_sub_modules(value)
 
 
 def get_module_names(

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -37,7 +37,7 @@ def get_module_names(
     exclude_file: str | list[str] | None = None,
 ) -> list[str]:
     """Return file names of all modules found in src_dir."""
-    exclude_path = set(exclude_dir or ["util"])
+    exclude_path = set(exclude_dir or ["util", "__pycache__"])
     exclude_name = set(exclude_file or ["__init__.py"])
 
     module_names = [

--- a/scripts/generate_facts_docs.py
+++ b/scripts/generate_facts_docs.py
@@ -1,30 +1,32 @@
 #!/usr/bin/env python
 
 import sys
-from glob import glob
 from importlib import import_module
 from inspect import getfullargspec, getmembers, isclass
 from os import makedirs, path
+from pathlib import Path
 from types import FunctionType, MethodType
 
 from pyinfra.api.facts import FactBase, ShortFactBase
 
 sys.path.append(".")
-from docs.utils import format_doc_line, title_line  # noqa: E402
+from docs.utils import (
+    format_doc_line,
+    title_line,
+    including_sub_modules,
+    get_module_names,
+    remove_dups,
+)  # noqa: E402
 
 
 def build_facts_docs():
     this_dir = path.dirname(path.realpath(__file__))
     docs_dir = path.abspath(path.join(this_dir, "..", "docs"))
-    facts_dir = path.join(this_dir, "..", "src", "pyinfra", "facts", "*.py")
+    pyinfra_dir = Path(docs_dir).parent / "src" / "pyinfra"
 
     makedirs(path.join(docs_dir, "facts"), exist_ok=True)
 
-    fact_module_names = [
-        path.basename(name)[:-3] for name in glob(facts_dir) if not name.endswith("__init__.py")
-    ]
-
-    for module_name in sorted(fact_module_names):
+    for module_name in sorted(get_module_names(pyinfra_dir / "facts")):
         lines = []
         print("--> Doing fact module: {0}".format(module_name))
         module = import_module("pyinfra.facts.{0}".format(module_name))
@@ -37,22 +39,27 @@ def build_facts_docs():
         if module.__doc__:
             lines.append(module.__doc__)
 
-        if path.exists(path.join(this_dir, "..", "pyinfra", "operations", f"{module_name}.py")):
+        ops_paths = {
+            pyinfra_dir / "operations" / name for name in [module_name, f"{module_name}.py"]
+        }
+        if any(p.exists() for p in ops_paths):
             lines.append(f"See also: :doc:`../operations/{module_name}`.")
             lines.append("")
 
-        fact_classes = [
+        all_fact_classes = [
             (key, value)
-            for key, value in getmembers(module)
+            for m in including_sub_modules(module)
+            for key, value in getmembers(m)
             if (
                 isclass(value)
                 and (issubclass(value, FactBase) or issubclass(value, ShortFactBase))
-                and value.__module__ == module.__name__
+                and value.__module__.startswith(m.__name__)
                 and value is not FactBase
                 and not value.__name__.endswith("Base")  # hacky!
             )
         ]
 
+        fact_classes = remove_dups(all_fact_classes)
         for fact, cls in fact_classes:
             # FactClass -> fact_accessor on host object
             name = fact

--- a/scripts/generate_operations_docs.py
+++ b/scripts/generate_operations_docs.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
 
 import sys
-from glob import glob
 from importlib import import_module
 from inspect import getfullargspec, getmembers, isclass
 from os import makedirs, path
+from pathlib import Path
 from types import FunctionType
 
 from pyinfra.api.facts import FactBase
 
 sys.path.append(".")
-from docs.utils import format_doc_line, title_line  # noqa: E402
+from docs.utils import (
+    format_doc_line,
+    get_module_names,
+    including_sub_modules,
+    remove_dups,
+    title_line,
+)  # noqa: E402
 
 MODULE_DEF_LINE_MAX = 90
 
@@ -18,17 +24,11 @@ MODULE_DEF_LINE_MAX = 90
 def build_operations_docs():
     this_dir = path.dirname(path.realpath(__file__))
     docs_dir = path.abspath(path.join(this_dir, "..", "docs"))
-    operations_dir = path.join(this_dir, "..", "src", "pyinfra", "operations", "*.py")
+    pyinfra_dir = Path(docs_dir).parent / "src" / "pyinfra"
 
     makedirs(path.join(docs_dir, "operations"), exist_ok=True)
 
-    op_module_names = [
-        path.basename(name)[:-3]
-        for name in glob(operations_dir)
-        if not name.endswith("__init__.py")
-    ]
-
-    for module_name in op_module_names:
+    for module_name in get_module_names(pyinfra_dir / "operations"):
         lines = []
 
         print("--> Doing module: {0}".format(module_name))
@@ -44,7 +44,8 @@ def build_operations_docs():
 
         operation_facts = [
             (key, value)
-            for key, value in getmembers(module)
+            for m in including_sub_modules(module)
+            for key, value in getmembers(m)
             if (isclass(value) and issubclass(value, FactBase))
         ]
 
@@ -59,17 +60,20 @@ def build_operations_docs():
             lines.append("Facts used in these operations: {0}.".format(", ".join(items)))
             lines.append("")
 
-        operation_functions = [
-            (key, value._inner)
-            for key, value in getmembers(module)
+        all_operation_functions = [
+            (f"{m.__name__.split('.')[-1]}.{key}" if m != module else key, value._inner)
+            for m in including_sub_modules(module)
+            for key, value in getmembers(m)
             if (
                 isinstance(value, FunctionType)
-                and value.__module__ == module.__name__
+                and value.__module__.startswith(m.__name__)
                 and getattr(value, "_inner", False)
                 and not value.__name__.startswith("_")
                 and not key.startswith("_")
             )
         ]
+        # remove duplicates in case functions imported by __init__.py and then also seen where defined
+        operation_functions = remove_dups(all_operation_functions)
 
         for name, func in operation_functions:
             decorated_func = getattr(func, "_inner", None)


### PR DESCRIPTION
Generate online docs for  facts and/or operations when they are implemented in a module (vs. in a file).
The immediate impact is to reveal ``freebsd`` in the sidebar of the [Operations Index](https://docs.pyinfra.com/en/3.x/operations.html) but can be used more generally.

I did not add `freebsd-ops` to `pyinfra-metadata.toml` as I am assuming it was not present for a reason but can do so if the consistency is helpful.

Related to this, I would have expected ``__init__.py`` for the ``freebsd`` operations to be as shown at /1/ (vs. the current ``from . import *``) to minimize duplication in the import lines but did _not_ change it in this PR as it would be a breaking change.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [n/a] Pull request includes tests for any new/updated operations/facts
- [n/a] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`) ***ruff format and ruff check run manually***

/1/
```python
from . import pkg
from .freebsd_update import update
from .service import service
from .sysrc import sysrc
```