### PR TITLE
api.command: fix `make_formatted_string_command` adding unwanted spaces between format args

### DIFF
--- a/src/pyinfra/api/command.py
+++ b/src/pyinfra/api/command.py
@@ -35,7 +35,7 @@ def make_formatted_string_command(string: str, *args, **kwargs) -> "StringComman
     """
 
     formatter = Formatter()
-    string_bits = []
+    string_bits: list[object] = []
 
     for bit in shlex.split(string):
         token_bits = []

--- a/src/pyinfra/api/command.py
+++ b/src/pyinfra/api/command.py
@@ -38,12 +38,17 @@ def make_formatted_string_command(string: str, *args, **kwargs) -> "StringComman
     string_bits = []
 
     for bit in shlex.split(string):
+        token_bits = []
         for item in formatter.parse(bit):
             if item[0]:
-                string_bits.append(item[0])
+                token_bits.append(item[0])
             if item[1]:
                 value, _ = formatter.get_field(item[1], args, kwargs)
-                string_bits.append(value)
+                token_bits.append(value)
+        if len(token_bits) == 1:
+            string_bits.append(token_bits[0])
+        elif len(token_bits) > 1:
+            string_bits.append(StringCommand(*token_bits, _separator=""))
 
     return StringCommand(*string_bits)
 

--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -246,7 +246,7 @@ def download(
             yield make_formatted_string_command(
                 (
                     "(( sha256sum {0} 2> /dev/null || shasum -a 256 {0} || sha256 {0} ) "
-                    "| grep {1}) || ( echo {2} && exit 1 )"
+                    "| grep {1} ) || ( echo {2} && exit 1 )"
                 ),
                 QuoteString(dest),
                 sha256sum,
@@ -257,7 +257,7 @@ def download(
             yield make_formatted_string_command(
                 (
                     "(( sha384sum {0} 2> /dev/null || shasum -a 384 {0} ) "
-                    "| grep {1}) || ( echo {2} && exit 1 )"
+                    "| grep {1} ) || ( echo {2} && exit 1 )"
                 ),
                 QuoteString(dest),
                 sha384sum,
@@ -266,7 +266,7 @@ def download(
 
         if md5sum:
             yield make_formatted_string_command(
-                ("(( md5sum {0} 2> /dev/null || md5 {0} ) | grep {1}) || ( echo {2} && exit 1 )"),
+                ("(( md5sum {0} 2> /dev/null || md5 {0} ) | grep {1} ) || ( echo {2} && exit 1 )"),
                 QuoteString(dest),
                 md5sum,
                 QuoteString("MD5 did not match!"),

--- a/tests/test_api/test_api_command.py
+++ b/tests/test_api/test_api_command.py
@@ -18,7 +18,7 @@ from pyinfra.api import (
     RsyncCommand,
     StringCommand,
 )
-from pyinfra.api.command import PyinfraCommand
+from pyinfra.api.command import PyinfraCommand, make_formatted_string_command
 
 
 class TestBaseCommand(TestCase):
@@ -91,6 +91,50 @@ class TestFileCommands(TestCase):
     def test_rsync_command_repr(self):
         cmd = RsyncCommand("src", "dest", ["-a"])
         assert repr(cmd) == "RsyncCommand(src, dest, ['-a'])"
+
+
+class TestMakeFormattedStringCommand(TestCase):
+    def test_basic_formatting(self):
+        cmd = make_formatted_string_command("echo {0}", "hello")
+        assert str(cmd) == "echo hello"
+
+    def test_adjacent_args_no_extra_spaces(self):
+        """Regression test for https://github.com/pyinfra-dev/pyinfra/issues/1603"""
+        cmd = make_formatted_string_command("cat /{0}/{1}", "etc", "passwd")
+        assert str(cmd) == "cat /etc/passwd"
+
+    def test_adjacent_args_no_literal_separator(self):
+        cmd = make_formatted_string_command("{0}{1}", "hello", "world")
+        assert str(cmd) == "helloworld"
+
+    def test_prefix_with_arg(self):
+        cmd = make_formatted_string_command("prefix{0}", "value")
+        assert str(cmd) == "prefixvalue"
+
+    def test_arg_with_suffix(self):
+        cmd = make_formatted_string_command("{0}.txt", "myfile")
+        assert str(cmd) == "myfile.txt"
+
+    def test_multiple_separate_args(self):
+        cmd = make_formatted_string_command("curl -sSLf {0} -o {1}", "http://example.com", "/tmp/f")
+        assert str(cmd) == "curl -sSLf http://example.com -o /tmp/f"
+
+    def test_kwargs(self):
+        cmd = make_formatted_string_command("echo {msg}", msg="hello")
+        assert str(cmd) == "echo hello"
+
+    def test_quoted_arg(self):
+        cmd = make_formatted_string_command("echo {0}", QuoteString("hello world"))
+        assert str(cmd) == "echo 'hello world'"
+
+    def test_masked_arg(self):
+        cmd = make_formatted_string_command("echo {0}", MaskString("secret"))
+        assert cmd.get_raw_value() == "echo secret"
+        assert str(cmd) == "echo ***"
+
+    def test_path_with_multiple_segments(self):
+        cmd = make_formatted_string_command("ls /{0}/{1}/{2}", "home", "user", "docs")
+        assert str(cmd) == "ls /home/user/docs"
 
 
 class TestFunctionCommand(TestCase):


### PR DESCRIPTION
Fix #1603 

Pieces parsed from the same shlex token are now grouped into a nested StringCommand with empty separator, preserving adjacency instead of being space-joined.

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
