### PR TITLE
operations.server.mount fix not detecting already-mounted devices

### DIFF
--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -316,6 +316,17 @@ def mount(
 
     mounts = host.get_fact(Mounts)
     is_mounted = path in mounts
+    mounted_path = path
+
+    # If path not found directly, check by device as fallback.
+    # Handles cases where the path representation differs between user input
+    # and /proc/self/mountinfo (e.g. relative vs absolute paths).
+    if not is_mounted and device:
+        for mp, info in mounts.items():
+            if info.get("device") == device:
+                is_mounted = True
+                mounted_path = mp
+                break
 
     # Want mount but don't have?
     if mounted and not is_mounted:
@@ -332,25 +343,25 @@ def mount(
 
     # Want no mount but mounted?
     elif mounted is False and is_mounted:
-        yield "umount {0}".format(shlex.quote(path))
+        yield "umount {0}".format(shlex.quote(mounted_path))
 
     # Want mount and is mounted! Check the options
     elif is_mounted and mounted and options:
-        mounted_options = mounts[path]["options"]
+        mounted_options = mounts[mounted_path]["options"]
         needed_options = set(options) - set(mounted_options)
         if needed_options:
             if host.get_fact(Kernel).strip() == "FreeBSD":
-                fs_type = mounts[path]["type"]
-                device = mounts[path]["device"]
+                fs_type = mounts[mounted_path]["type"]
+                device = mounts[mounted_path]["device"]
 
                 yield "mount -o update,{options} -t {fs_type} {device} {path}".format(
                     options=options_string,
                     fs_type=fs_type,
                     device=shlex.quote(device),
-                    path=shlex.quote(path),
+                    path=shlex.quote(mounted_path),
                 )
             else:
-                yield "mount -o remount,{0} {1}".format(options_string, shlex.quote(path))
+                yield "mount -o remount,{0} {1}".format(options_string, shlex.quote(mounted_path))
 
     else:
         host.noop(

--- a/tests/operations/server.mount/mount_exists_device_fallback.json
+++ b/tests/operations/server.mount/mount_exists_device_fallback.json
@@ -1,0 +1,17 @@
+{
+    "args": ["/data"],
+    "kwargs": {
+        "device": "/dev/sdb1"
+    },
+    "facts": {
+        "server.Mounts": {
+            "/mnt/data": {
+                "device": "/dev/sdb1",
+                "type": "ext4",
+                "options": ["rw", "relatime"]
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "filesystem /data is mounted"
+}

--- a/tests/operations/server.mount/mount_exists_device_match.json
+++ b/tests/operations/server.mount/mount_exists_device_match.json
@@ -1,0 +1,17 @@
+{
+    "args": ["/data"],
+    "kwargs": {
+        "device": "/dev/sdb1"
+    },
+    "facts": {
+        "server.Mounts": {
+            "/data": {
+                "device": "/dev/sdb1",
+                "type": "ext4",
+                "options": ["rw", "relatime"]
+            }
+        }
+    },
+    "commands": [],
+    "noop_description": "filesystem /data is mounted"
+}

--- a/tests/operations/server.mount/remount_options_device_fallback.json
+++ b/tests/operations/server.mount/remount_options_device_fallback.json
@@ -1,0 +1,20 @@
+{
+    "args": ["/data"],
+    "kwargs": {
+        "device": "/dev/sdb1",
+        "options": ["rw", "noatime"]
+    },
+    "facts": {
+        "server.Kernel": "Linux",
+        "server.Mounts": {
+            "/mnt/data": {
+                "device": "/dev/sdb1",
+                "type": "ext4",
+                "options": ["rw"]
+            }
+        }
+    },
+    "commands": [
+        "mount -o remount,rw,noatime /mnt/data"
+    ]
+}

--- a/tests/operations/server.mount/unmount_device_fallback.json
+++ b/tests/operations/server.mount/unmount_device_fallback.json
@@ -1,0 +1,19 @@
+{
+    "args": ["/data"],
+    "kwargs": {
+        "device": "/dev/sdb1",
+        "mounted": false
+    },
+    "facts": {
+        "server.Mounts": {
+            "/mnt/data": {
+                "device": "/dev/sdb1",
+                "type": "ext4",
+                "options": ["rw", "relatime"]
+            }
+        }
+    },
+    "commands": [
+        "umount /mnt/data"
+    ]
+}

--- a/tests/operations/server.mount/unmount_device_fallback_needs_quotes.json
+++ b/tests/operations/server.mount/unmount_device_fallback_needs_quotes.json
@@ -1,0 +1,19 @@
+{
+    "args": ["/data"],
+    "kwargs": {
+        "device": "/dev/sdb1",
+        "mounted": false
+    },
+    "facts": {
+        "server.Mounts": {
+            "/mnt/my data; rm -rf /": {
+                "device": "/dev/sdb1",
+                "type": "ext4",
+                "options": ["rw", "relatime"]
+            }
+        }
+    },
+    "commands": [
+        "umount '/mnt/my data; rm -rf /'"
+    ]
+}


### PR DESCRIPTION
When the mount path in /proc/self/mountinfo doesn't exactly match the user-provided path (e.g. relative vs absolute), add a device-based fallback check that scans existing mounts for a matching device. Use the actual mount point from mountinfo for umount and remount operations.

Fix #1608 

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
