### PR TITLE
docs: fix generate_operations_docs.py and add docs build to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,31 @@ jobs:
       - run: uv sync --group test --no-default-groups --python=${{ matrix.python-version }}
       - run: uv run pytest -m end_to_end_${{ matrix.test-name }}
 
-  # Finally, single jon to check if all completed, for use in protected branch
+  docs-build:
+    needs:
+      - lint
+      - type-check
+      - spell-check
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Fetch git tags
+        run: git fetch --tags origin
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install
+        run: |
+          uv sync --group docs --no-default-groups
+          uv pip install 'jinja2<3.1'
+      - name: Generate documentation
+        run: scripts/build-public-docs.sh
+        env:
+          PYTHONPATH: '.'
+
+  # Finally, single job to check if all completed, for use in protected branch
 
   tests-done:
     if: ${{ always() }}
@@ -118,6 +142,7 @@ jobs:
       - spell-check
       - unit-test
       - end-to-end-test
+      - docs-build
     runs-on: ubuntu-latest
     steps:
       - uses: matrix-org/done-action@v3

--- a/docs/api/facts.md
+++ b/docs/api/facts.md
@@ -9,7 +9,7 @@ occurs during fact collection. Additionally, a ``requires_command`` variable can
 on the host to collect the fact. If this command is not present on the host, the fact will be set to the default, or empty if no ``default`` function
 is available.
 
-### Importing & Using Facts
+## Importing & Using Facts
 
 Like operations, facts are imported from Python modules and executed by calling `Host.get_fact`. For example:
 
@@ -20,7 +20,7 @@ from pyinfra.facts.server import Which
 host.get_fact(Which, command='htop')
 ```
 
-### Example: getting swap status
+## Example: getting swap status
 
 This fact returns a boolean indicating whether swap is enabled. For this fact the ``command`` is declared as a class attribute.
 
@@ -44,7 +44,7 @@ This fact could then be used like so:
 is_swap_enabled = host.get_fact(SwapEnabled)
 ```
 
-### Example: getting the list of files in a directory
+## Example: getting the list of files in a directory
 
 This fact returns a list of files found in a given directory. For this fact the ``command`` is declared as a class method, indicating the fact takes arguments.
 
@@ -70,7 +70,7 @@ This fact could then be used like so:
 list_of_files = host.get_fact(FindFiles, path='/somewhere')
 ```
 
-### Example: getting any output from a command
+## Example: getting any output from a command
 
 This fact returns the raw output of any command. For this fact the ``command`` is declared as a class method, indicating the fact takes arguments.
 

--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -2,7 +2,7 @@
 
 [Operations](../operations) are defined as Python functions. They are passed the current deploy state, the target host, and any operation arguments. Operation functions read state from the host, compare it to the arguments, and yield commands.
 
-### Input: arguments
+## Input: arguments
 
 Operations can accept any arguments except ``name`` and those starting with ``_`` which are reserved for internal use.
 
@@ -12,7 +12,7 @@ def my_operation(...):
     ...
 ```
 
-### Output: commands
+## Output: commands
 
 Operations are generator functions and ``yield`` three types of command:
 
@@ -44,7 +44,7 @@ yield from files.file._inner(
 )
 ```
 
-### Example: managing files
+## Example: managing files
 
 This is a simplified version of the ``files.file`` operation, which will create/remove a
 remote file based on the ``present`` kwargs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ html_theme_options = {
 }
 
 myst_heading_anchors = 3
+suppress_warnings = ["myst.header"]
 
 templates_path = ["templates"]
 

--- a/docs/deploy-process.rst
+++ b/docs/deploy-process.rst
@@ -11,6 +11,8 @@ pyinfra executes in five of stages:
 
 Every time you run pyinfra it steps through each of these stages with the goal of updating the inventory to match the commands or state provided. Most of these stages are simple to reason about. The one exception to this is the **prepare**, or change detection, phase which is used to define the order operations are executed.
 
+.. _deploy-process-detects-changes:
+
 How pyinfra Detects Changes & Orders Operations
 ---------------------------------------------------
 
@@ -63,6 +65,8 @@ To make this possible we have to first execute the code to generate the order an
 
 When does this matter?
 ----------------------
+
+.. _deploy-process-using-host-facts:
 
 Using Host Facts
 ~~~~~~~~~~~~~~~~

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Example Deploys
 ===============
 

--- a/docs/examples/client_side_assets.md
+++ b/docs/examples/client_side_assets.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 # Client Side Assets
 
 Often projects need to pre-compile assets at or just before deploy time to be uploaded to the remote host. The `config.py` file is a perfect place to perform this kind of thing as it will be loaded once and before any remote connections are made.

--- a/docs/examples/data_multiple_environments.md
+++ b/docs/examples/data_multiple_environments.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 # Data Across Multiple Environments
 
 Let's say you have an app that you wish to deploy in two environments: staging and production, with the dev VM as the default. A good layout for this would be:
@@ -35,4 +38,3 @@ git_branch = 'develop'
 ```
 
 For more information on inventory files, see :doc:`inventory-data`.
-

--- a/docs/examples/dynamic_execution_deploy.md
+++ b/docs/examples/dynamic_execution_deploy.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 # Dynamic Execution during Deploy
 
 **Note:** this example is out of date (the code is valid, but there's better ways to do it), please see [using operations: operation output & callbacks](/using-operations).

--- a/docs/examples/dynamic_inventories_data.md
+++ b/docs/examples/dynamic_inventories_data.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 # Dynamic Inventories & Data
 
 One of the biggest features of pyinfra is that it's configured in regular Python. This means inventory, data and deploy files can use Python code and modules. As a result it is possible to generate inventory and group data for a deploy.

--- a/docs/examples/groups_roles.md
+++ b/docs/examples/groups_roles.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 # Groups & Roles
 
 Deploying complex projects usually involves multiple groups of servers, for example database & web servers. It is useful to separate the deploy into multiple files.

--- a/docs/examples/secret_storage.md
+++ b/docs/examples/secret_storage.md
@@ -1,3 +1,6 @@
+---
+orphan: true
+---
 # Using Secrets in pyinfra
 
 Encrypting sensitive information can be achieved using Python packages such as [privy](https://pypi.org/project/privy/).

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -25,7 +25,7 @@ The currently executing host can be fetched from the ``host`` context variable. 
 How do I use sudo in an operation?
 ----------------------------------
 
-Sudo is controlled by one of the privilege and user escalation :doc:`arguments </arguments>`, there are a number of additional arguments to control sudo execution:
+Sudo is controlled by one of the :ref:`privilege and user escalation arguments <arguments-privilege-user-escalation>`, there are a number of additional arguments to control sudo execution:
 
 .. code:: python
 
@@ -56,7 +56,7 @@ Use the LINK ``files.file``, ``files.directory`` or ``files.link`` operations to
 How do I handle unreliable operations or network issues?
 --------------------------------------------------------
 
-Use the retry behavior :doc:`arguments </arguments>` to automatically retry failed operations. This is especially useful for network operations or services that may be temporarily unavailable:
+Use the :ref:`retry behavior arguments <arguments-retry-behavior>` to automatically retry failed operations. This is especially useful for network operations or services that may be temporarily unavailable:
 
 .. code:: python
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -25,7 +25,7 @@ The currently executing host can be fetched from the ``host`` context variable. 
 How do I use sudo in an operation?
 ----------------------------------
 
-Sudo is controlled by one of the :ref:`privilege and user escalation arguments <arguments#privilege-user-escalation>`_, there are a number of additional arguments to control sudo execution:
+Sudo is controlled by one of the privilege and user escalation :doc:`arguments </arguments>`, there are a number of additional arguments to control sudo execution:
 
 .. code:: python
 
@@ -56,7 +56,7 @@ Use the LINK ``files.file``, ``files.directory`` or ``files.link`` operations to
 How do I handle unreliable operations or network issues?
 --------------------------------------------------------
 
-Use the :ref:`retry behavior arguments <arguments#retry-behavior>`_ to automatically retry failed operations. This is especially useful for network operations or services that may be temporarily unavailable:
+Use the retry behavior :doc:`arguments </arguments>` to automatically retry failed operations. This is especially useful for network operations or services that may be temporarily unavailable:
 
 .. code:: python
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -56,13 +56,13 @@ Now you can install pyinfra as a tool, or add it to your project's dependencies.
 
 First install [pipx](https://pipx.pypa.io/stable/installation/) if you haven't already.
 
-#### Install pyinfra
+#### Install pyinfra via pipx
 
    ```sh
    pipx install pyinfra
    ```
 
-#### Verify Installation
+#### Verify pipx Installation
 
    ```sh
    pyinfra --version
@@ -83,13 +83,13 @@ First install [pipx](https://pipx.pypa.io/stable/installation/) if you haven't a
    env\Scripts\activate
    ```
 
-#### Install pyinfra
+#### Install pyinfra via pip
 
    ```sh
    pip install pyinfra
    ```
 
-#### Verify Installation
+#### Verify pip Installation
 
    ```sh
    pyinfra --version
@@ -117,7 +117,7 @@ First install [pipx](https://pipx.pypa.io/stable/installation/) if you haven't a
   - C++/CLI support for v142...
   - C++ Modules for v142...
 
-#### Install pyinfra
+#### Install pyinfra on Windows
 
    ```sh
    python -m venv env

--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -162,7 +162,7 @@ Facts are imported from ``pyinfra.facts.*`` and can be retrieved using the ``hos
 See :doc:`facts` for a full list of available facts and arguments.
 
 .. Important::
-    Only use immutable facts in deploy code (installed OS, Arch, etc) unless you are absolutely sure they will not change. See: :doc:`deploy process </deploy-process>`.
+    Only use immutable facts in deploy code (installed OS, Arch, etc) unless you are absolutely sure they will not change. See: :ref:`using host facts <deploy-process-using-host-facts>`.
 
 Fact Errors
 ^^^^^^^^^^^
@@ -237,7 +237,7 @@ Output & Callbacks
 ------------------
 
 pyinfra doesn't immediately execute operations, meaning output is not available right away. It is possible to access this output at runtime by providing a callback function using the :ref:`operations:python.call` operation. Callback functions may also call other operations which will be immediately executed.
-Why/how this works :doc:`is described here </deploy-process>`.
+Why/how this works :ref:`is described here <deploy-process-detects-changes>`.
 
 .. code:: python
 

--- a/docs/using-operations.rst
+++ b/docs/using-operations.rst
@@ -162,7 +162,7 @@ Facts are imported from ``pyinfra.facts.*`` and can be retrieved using the ``hos
 See :doc:`facts` for a full list of available facts and arguments.
 
 .. Important::
-    Only use immutable facts in deploy code (installed OS, Arch, etc) unless you are absolutely sure they will not change. See: :ref:`using host facts <deploy-process#using-host-facts>`_.
+    Only use immutable facts in deploy code (installed OS, Arch, etc) unless you are absolutely sure they will not change. See: :doc:`deploy process </deploy-process>`.
 
 Fact Errors
 ^^^^^^^^^^^
@@ -237,7 +237,7 @@ Output & Callbacks
 ------------------
 
 pyinfra doesn't immediately execute operations, meaning output is not available right away. It is possible to access this output at runtime by providing a callback function using the :ref:`operations:python.call` operation. Callback functions may also call other operations which will be immediately executed.
-Why/how this works :ref:`is described here <deploy-process#how-pyinfra-detects-changes-orders-operations>`_.
+Why/how this works :doc:`is described here </deploy-process>`.
 
 .. code:: python
 

--- a/docs/utils.py
+++ b/docs/utils.py
@@ -6,8 +6,12 @@ def title_line(char, string):
 
 
 def format_doc_line(line):
-    # Bold the <arg>: part of each line
-    line = re.sub(r"\+ ([0-9a-z_\/\*]+)(.*)", r"+ **\1**\2", line)
+    # Bold the <arg>: part of each line, escaping * prefixes for RST compatibility
+    def _bold_arg(m):
+        stars = m.group(1).replace("*", "\\*")
+        return f"+ **{stars}{m.group(2)}**{m.group(3)}"
+
+    line = re.sub(r"\+ (\*{0,2})([0-9a-z_\/]+)(.*)", _bold_arg, line)
 
     # Python's __doc__ attribute already dedents docstrings, so we don't need to strip anything
     return line

--- a/scripts/generate_arguments_doc.py
+++ b/scripts/generate_arguments_doc.py
@@ -34,7 +34,12 @@ def build_arguments_doc():
         arguments_title_doc,
         arguments_example_doc,
     ) in __argument_docs__.items():
-        lines.append("\n{0}".format(group_name))
+        # Add a cross-reference label for each section
+        slug = group_name.lower().replace(" & ", "-").replace(" ", "-")
+        lines.append("")
+        lines.append(".. _arguments-{0}:".format(slug))
+        lines.append("")
+        lines.append(group_name)
         lines.append(title_line("~", group_name))
         lines.append("")
 

--- a/scripts/generate_operations_docs.py
+++ b/scripts/generate_operations_docs.py
@@ -122,7 +122,7 @@ def build_operations_docs():
             # get signature, remove parens, append (or set) kwargs for global arguments and
             # expand spacing so params are indented wrt to the operation name
             args_string = signature(func).format(
-                max_width=MODULE_DEF_LINE_MAX, quote_annotation_strings=False
+                max_width=MODULE_DEF_LINE_MAX,
             )
             args_string = (
                 f"{args_string[:-1]},\n    **kwargs,\n" if args_string != "()" else "**kwargs,"

--- a/scripts/generate_operations_docs.py
+++ b/scripts/generate_operations_docs.py
@@ -125,7 +125,9 @@ def build_operations_docs():
                 max_width=MODULE_DEF_LINE_MAX,
             )
             args_string = (
-                f"{args_string[:-1]},\n    **kwargs,\n" if args_string != "()" else "**kwargs,"
+                f"{args_string[:-1].rstrip()},\n    **kwargs,\n"
+                if args_string != "()"
+                else "**kwargs,"
             )
             args_string = f"{args_string.replace('   ', '        ')}    )"
 
@@ -151,8 +153,9 @@ def build_operations_docs():
                     ).strip(),
                 )
 
+            lines.append("")
             lines.append(
-                "Note:\n\tThis operation also inherits all :doc:`global arguments </arguments>`."
+                ".. note::\n    This operation also inherits all :doc:`global arguments </arguments>`."
             )
             lines.append("")
             lines.append("")

--- a/src/pyinfra/operations/gpg.py
+++ b/src/pyinfra/operations/gpg.py
@@ -241,21 +241,23 @@ def key(
     """
     Install or remove GPG keys from various sources.
 
-    Args:
-        src: filename or URL to a key (ASCII .asc or binary .gpg)
-        dest: destination path for the key file (required for installation, optional for removal)
-        keyserver: keyserver URL for fetching keys by ID
-        keyid: key ID or list of key IDs (required with keyserver, optional for removal)
-        dearmor: whether to convert ASCII armored keys to binary format
-        mode: file permissions for the installed key
-        present: whether the key should be present (True) or absent (False)
-        working_dirs: dirs to search for existing keyrings (required for removal without dest)
-                When False: if dest is provided, removes from specific keyring;
-                           if dest is None, removes from keyrings found in working_dirs;
-                           if keyid is provided, removes specific key(s);
-                           if keyid is None, removes entire keyring file(s)
+    + src: filename or URL to a key (ASCII .asc or binary .gpg)
+    + dest: destination path for the key file (required for installation, optional for removal)
+    + keyserver: keyserver URL for fetching keys by ID
+    + keyid: key ID or list of key IDs (required with keyserver, optional for removal)
+    + dearmor: whether to convert ASCII armored keys to binary format
+    + mode: file permissions for the installed key
+    + present: whether the key should be present (True) or absent (False)
+    + working_dirs: dirs to search for existing keyrings (required for removal without dest).
+      When False: if dest is provided, removes from specific keyring;
+      if dest is None, removes from keyrings found in working_dirs;
+      if keyid is provided, removes specific key(s);
+      if keyid is None, removes entire keyring file(s)
 
-    Examples:
+    **Examples:**
+
+    .. code:: python
+
         gpg.key(
             name="Install Docker GPG key",
             src="https://download.docker.com/linux/debian/gpg",
@@ -402,12 +404,14 @@ def dearmor(src: str, dest: str, mode: str = "0644"):
     """
     Convert ASCII armored GPG key to binary format.
 
-    Args:
-        src: source ASCII armored key file
-        dest: destination binary key file
-        mode: file permissions for the output file
+    + src: source ASCII armored key file
+    + dest: destination binary key file
+    + mode: file permissions for the output file
 
-    Example:
+    **Example:**
+
+    .. code:: python
+
         gpg.dearmor(
             name="Convert key to binary",
             src="/tmp/key.asc",


### PR DESCRIPTION
## Summary

Fix broken documentation build caused by an invalid `quote_annotation_strings` kwarg passed to `inspect.Signature.format()` (introduced in #1600), and resolve all 372 Sphinx build warnings.

Also adds a `docs-build` job to the CI test workflow so documentation generation is validated on every PR without publishing.

## Changes

### Fix doc build failure
- Remove invalid `quote_annotation_strings` kwarg from `inspect.Signature.format()` in `generate_operations_docs.py`

### Fix all Sphinx warnings (372 → 0)

**Generated operations docs (~340 warnings):**
- Add blank line before note directive and use proper `.. note::` RST admonition
- Fix stray comma in multiline signatures
- Escape `*` prefixes in `format_doc_line` for `**kwargs`-style args
- Convert `gpg.py` docstrings to standard pyinfra format (`+ arg` style)

**Hand-written docs (~30 warnings):**
- Fix broken `:ref:` cross-references in `faq.rst` and `using-operations.rst` by adding explicit RST labels to `generate_arguments_doc.py` and `deploy-process.rst`
- Deduplicate heading text in `install.md` for `autosectionlabel`
- Fix H1→H3 header level jumps in `api/facts.md` and `api/operations.md`
- Mark orphaned `examples.rst` and `examples/*.md` with `:orphan:`
- Suppress `myst.header` warnings from `CHANGELOG.md` in `conf.py`

### CI: add docs build job
- Add `docs-build` job to `test.yml` that runs after lint checks
- Include it in the `tests-done` gate

## Checklist

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)