### PR TITLE
api: decouple core API from click by introducing pluggable output functions

### DIFF
--- a/src/pyinfra/api/facts.py
+++ b/src/pyinfra/api/facts.py
@@ -16,12 +16,12 @@ from inspect import getcallargs
 from socket import error as socket_error, timeout as timeout_error
 from typing import TYPE_CHECKING, Any, Callable, Generic, Optional, Type, TypeVar, cast
 
-import click
 import gevent
 from paramiko import SSHException
 from typing_extensions import override
 
 from pyinfra import logger
+from pyinfra.api.output import format_text
 from pyinfra.api import StringCommand
 from pyinfra.api.arguments import all_global_arguments, pop_global_arguments
 from pyinfra.api.exceptions import FactProcessError
@@ -303,7 +303,7 @@ def _get_fact(
         log_message = "{0}{1}".format(
             host.print_prefix,
             "Loaded fact {0}{1}".format(
-                click.style(name, bold=True),
+                format_text(name, bold=True),
                 f" ({get_kwargs_str(kwargs)})" if kwargs else "",
             ),
         )

--- a/src/pyinfra/api/host.py
+++ b/src/pyinfra/api/host.py
@@ -16,10 +16,10 @@ from typing import (
 )
 from uuid import uuid4
 
-import click
 from typing_extensions import Unpack, override
 
 from pyinfra import logger
+from pyinfra.api.output import format_text
 from pyinfra.connectors.base import BaseConnector
 from pyinfra.connectors.util import CommandOutput, remove_any_sudo_askpass_file
 
@@ -205,22 +205,22 @@ class Host:
     def print_prefix(self) -> str:
         if self.nested_executing_op_hash:
             return "{0}[{1}] {2}{3} ".format(
-                click.style(""),  # reset
-                click.style(self.name, bold=True),
-                click.style("nested", "blue"),
+                format_text(""),  # reset
+                format_text(self.name, bold=True),
+                format_text("nested", "blue"),
                 self.print_prefix_padding,
             )
 
         return "{0}[{1}]{2} ".format(
-            click.style(""),  # reset
-            click.style(self.name, bold=True),
+            format_text(""),  # reset
+            format_text(self.name, bold=True),
             self.print_prefix_padding,
         )
 
     def style_print_prefix(self, *args, **kwargs) -> str:
         return "{0}[{1}]{2} ".format(
-            click.style(""),  # reset
-            click.style(self.name, *args, **kwargs),
+            format_text(""),  # reset
+            format_text(self.name, *args, **kwargs),
             self.print_prefix_padding,
         )
 
@@ -230,7 +230,7 @@ class Host:
     def log_styled(
         self, message: str, log_func: Callable[[str], Any] = logger.info, **kwargs
     ) -> None:
-        message_styled = click.style(message, **kwargs)
+        message_styled = format_text(message, **kwargs)
         self.log(message_styled, log_func=log_func)
 
     def get_deploy_data(self):
@@ -391,7 +391,7 @@ class Host:
                 if show_errors:
                     log_message = "{0}{1}".format(
                         self.print_prefix,
-                        click.style(e.args[0], "red"),
+                        format_text(e.args[0], "red"),
                     )
                     logger.error(log_message)
 
@@ -402,7 +402,7 @@ class Host:
             else:
                 log_message = "{0}{1}".format(
                     self.print_prefix,
-                    click.style("Connected", "green"),
+                    format_text("Connected", "green"),
                 )
                 if reason:
                     log_message = "{0}{1}".format(

--- a/src/pyinfra/api/operations.py
+++ b/src/pyinfra/api/operations.py
@@ -6,11 +6,11 @@ from itertools import product
 from socket import error as socket_error, timeout as timeout_error
 from typing import TYPE_CHECKING, cast
 
-import click
 import gevent
 from paramiko import SSHException
 
 from pyinfra import logger
+from pyinfra.api.output import format_text
 from pyinfra.connectors.util import CommandOutput, OutputLine
 from pyinfra.context import ctx_host, ctx_state
 from pyinfra.progress import progress_spinner
@@ -39,7 +39,7 @@ def run_host_op(state: "State", host: "Host", op_hash: str) -> bool:
     state.trigger_callbacks("operation_host_start", host, op_hash)
 
     if op_hash not in state.ops[host]:
-        logger.info("{0}{1}".format(host.print_prefix, click.style("Skipped", "blue")))
+        logger.info("{0}{1}".format(host.print_prefix, format_text("Skipped", "blue")))
         return True
 
     op_meta = state.get_op_meta(op_hash)
@@ -200,7 +200,7 @@ def _run_host_op(state: "State", host: "Host", op_hash: str) -> bool:
         if retry_attempt > 0:
             _status_text = f"{_status_text} on retry {retry_attempt}"
 
-        _log_status = click.style(_status_text, "green" if executed_commands > 0 else "cyan")
+        _log_status = format_text(_status_text, "green" if executed_commands > 0 else "cyan")
         logger.info("{0}{1}".format(host.print_prefix, _log_status))
 
         state.trigger_callbacks("operation_host_success", host, op_hash, retry_attempt)

--- a/src/pyinfra/api/output.py
+++ b/src/pyinfra/api/output.py
@@ -1,0 +1,56 @@
+"""
+Pluggable output formatting for pyinfra.
+
+Provides ``format_text`` and ``echo`` functions that default to plain-text
+no-ops, allowing the API layer to work without any CLI dependency.  The CLI
+layer replaces them at startup via ``set_formatter`` and ``set_echo``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+# Default formatter: identity function (returns plain text, ignores styling kwargs).
+def _default_format_text(text: str, *args: Any, **kwargs: Any) -> str:
+    return text
+
+
+# Default echo: no-op.
+def _default_echo(message: Any = None, **kwargs: Any) -> None:
+    pass
+
+
+_format_text: Callable[..., str] = _default_format_text
+_echo: Callable[..., None] = _default_echo
+
+
+def format_text(text: str, *args: Any, **kwargs: Any) -> str:
+    """Format text with optional styling (color, bold, etc.).
+
+    Mirrors ``click.style`` signature.  Accepts positional ``fg`` argument
+    for compatibility with ``click.style("text", "red")``.
+    """
+    return _format_text(text, *args, **kwargs)
+
+
+def echo(message: Any = None, **kwargs: Any) -> None:
+    """Echo a message.  Mirrors ``click.echo`` signature."""
+    return _echo(message, **kwargs)
+
+
+def set_formatter(func: Callable[..., str]) -> None:
+    """Replace the default formatter (e.g. with ``click.style``)."""
+    global _format_text
+    _format_text = func
+
+
+def set_echo(func: Callable[..., None]) -> None:
+    """Replace the default echo function (e.g. with ``click.echo``)."""
+    global _echo
+    _echo = func
+
+
+def is_output_active() -> bool:
+    """Return True if a non-default echo function has been installed."""
+    return _echo is not _default_echo

--- a/src/pyinfra/api/util.py
+++ b/src/pyinfra/api/util.py
@@ -9,13 +9,13 @@ from os import getcwd, path, stat
 from socket import error as socket_error, timeout as timeout_error
 from typing import IO, TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 
-import click
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, Template
 from paramiko import SSHException
 from typeguard import TypeCheckError, check_type
 
 import pyinfra
 from pyinfra import logger
+from pyinfra.api.output import format_text
 
 if TYPE_CHECKING:
     from pyinfra.api.host import Host
@@ -188,7 +188,7 @@ def format_exception(e: Exception) -> str:
 def print_host_combined_output(host: "Host", output: "CommandOutput") -> None:
     for line in output:
         if line.buffer_name == "stderr":
-            logger.error(f"{host.print_prefix}{click.style(line.line, 'red')}")
+            logger.error(f"{host.print_prefix}{format_text(line.line, 'red')}")
         else:
             logger.error(f"{host.print_prefix}{line.line}")
 
@@ -208,14 +208,14 @@ def log_operation_start(
 
     logger.info(
         "{0} {1} {2}".format(
-            click.style(
+            format_text(
                 "{0}Starting{1}operation:".format(
                     prefix,
                     " {0} ".format(", ".join(op_types)) if op_types else " ",
                 ),
                 "blue",
             ),
-            click.style(", ".join(op_meta.names), bold=True),
+            format_text(", ".join(op_meta.names), bold=True),
             args,
         ),
     )
@@ -247,14 +247,14 @@ def log_error_or_warning(
         log_func(
             "{0}{1}".format(
                 host.print_prefix,
-                click.style(exc_text, log_color),
+                format_text(exc_text, log_color),
             ),
         )
 
     log_func(
         "{0}{1}{2}".format(
             host.print_prefix,
-            click.style(log_text, log_color),
+            format_text(log_text, log_color),
             description,
         ),
     )
@@ -265,7 +265,7 @@ def log_host_command_error(host: "Host", e: Exception, timeout: int | None = 0) 
         logger.error(
             "{0}{1}".format(
                 host.print_prefix,
-                click.style(
+                format_text(
                     "Command timed out after {0}s".format(
                         timeout,
                     ),
@@ -278,7 +278,7 @@ def log_host_command_error(host: "Host", e: Exception, timeout: int | None = 0) 
         logger.error(
             "{0}{1}".format(
                 host.print_prefix,
-                click.style(
+                format_text(
                     "Command socket/SSH error: {0}".format(format_exception(e)),
                     "red",
                 ),
@@ -289,7 +289,7 @@ def log_host_command_error(host: "Host", e: Exception, timeout: int | None = 0) 
         logger.error(
             "{0}{1}".format(
                 host.print_prefix,
-                click.style(
+                format_text(
                     "Command IO error: {0}".format(format_exception(e)),
                     "red",
                 ),

--- a/src/pyinfra/connectors/chroot.py
+++ b/src/pyinfra/connectors/chroot.py
@@ -2,10 +2,10 @@ import os
 from tempfile import mkstemp
 from typing import TYPE_CHECKING, Optional
 
-import click
 from typing_extensions import Unpack, override
 
 from pyinfra import local, logger
+from pyinfra.api.output import echo
 from pyinfra.api import QuoteString, StringCommand
 from pyinfra.api.exceptions import ConnectError, InventoryError, PyinfraError
 from pyinfra.api.util import get_file_io, memoize
@@ -146,7 +146,7 @@ class ChrootConnector(BaseConnector):
             raise IOError(output.stderr)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file uploaded to chroot: {1}".format(
                     self.host.print_prefix,
                     remote_filename,
@@ -201,7 +201,7 @@ class ChrootConnector(BaseConnector):
             raise IOError(output.stderr)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file downloaded from chroot: {1}".format(
                     self.host.print_prefix,
                     remote_filename,

--- a/src/pyinfra/connectors/docker.py
+++ b/src/pyinfra/connectors/docker.py
@@ -5,10 +5,10 @@ import os
 from tempfile import mkstemp
 from typing import TYPE_CHECKING
 
-import click
 from typing_extensions import TypedDict, Unpack, override
 
 from pyinfra import local, logger
+from pyinfra.api.output import echo, format_text
 from pyinfra.api import QuoteString, StringCommand
 from pyinfra.api.exceptions import ConnectError, InventoryError, PyinfraError
 from pyinfra.api.util import get_file_io
@@ -168,7 +168,7 @@ class DockerConnector(BaseConnector):
                 "{0}{1} build complete, container left running: {2}".format(
                     self.host.print_prefix,
                     self.docker_cmd,
-                    click.style(container_id, bold=True),
+                    format_text(container_id, bold=True),
                 ),
             )
             return
@@ -187,7 +187,7 @@ class DockerConnector(BaseConnector):
             "{0}{1} build complete, image ID: {2}".format(
                 self.host.print_prefix,
                 self.docker_cmd,
-                click.style(image_id, bold=True),
+                format_text(image_id, bold=True),
             ),
         )
 
@@ -272,7 +272,7 @@ class DockerConnector(BaseConnector):
             raise IOError(output.stderr)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file uploaded to container: {1}".format(
                     self.host.print_prefix,
                     remote_filename,
@@ -326,7 +326,7 @@ class DockerConnector(BaseConnector):
             raise IOError(output.stderr)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file downloaded from container: {1}".format(
                     self.host.print_prefix,
                     remote_filename,

--- a/src/pyinfra/connectors/dockerssh.py
+++ b/src/pyinfra/connectors/dockerssh.py
@@ -2,10 +2,10 @@ import os
 from tempfile import mkstemp
 from typing import TYPE_CHECKING
 
-import click
 from typing_extensions import Unpack, override
 
 from pyinfra import logger
+from pyinfra.api.output import echo, format_text
 from pyinfra.api import QuoteString, StringCommand
 from pyinfra.api.exceptions import ConnectError, InventoryError, PyinfraError
 from pyinfra.api.util import get_file_io, memoize
@@ -126,7 +126,7 @@ class DockerSSHConnector(BaseConnector):
             "{0}{1} build complete, image ID: {2}".format(
                 self.host.print_prefix,
                 self.docker_cmd,
-                click.style(image_id, bold=True),
+                format_text(image_id, bold=True),
             ),
         )
 
@@ -225,7 +225,7 @@ class DockerSSHConnector(BaseConnector):
             raise IOError(output.stderr)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file uploaded to container: {1}".format(
                     self.host.print_prefix,
                     remote_filename,
@@ -282,7 +282,7 @@ class DockerSSHConnector(BaseConnector):
             raise IOError(output.stderr)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file downloaded from container: {1}".format(
                     self.host.print_prefix,
                     remote_filename,

--- a/src/pyinfra/connectors/local.py
+++ b/src/pyinfra/connectors/local.py
@@ -3,10 +3,10 @@ from shutil import which
 from tempfile import mkstemp
 from typing import TYPE_CHECKING, Tuple
 
-import click
 from typing_extensions import Unpack, override
 
 from pyinfra import logger
+from pyinfra.api.output import echo
 from pyinfra.api.command import QuoteString, StringCommand
 from pyinfra.api.exceptions import InventoryError
 from pyinfra.api.util import get_file_io
@@ -80,7 +80,7 @@ class LocalConnector(BaseConnector):
             logger.debug("--> Running command on localhost: %s", unix_command)
 
             if print_input:
-                click.echo("{0}>>> {1}".format(self.host.print_prefix, unix_command), err=True)
+                echo("{0}>>> {1}".format(self.host.print_prefix, unix_command), err=True)
 
             return run_local_process(
                 actual_command,
@@ -148,7 +148,7 @@ class LocalConnector(BaseConnector):
             os.remove(temp_filename)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file copied: {1}".format(self.host.print_prefix, remote_filename),
                 err=True,
             )
@@ -203,7 +203,7 @@ class LocalConnector(BaseConnector):
             os.remove(temp_filename)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file copied: {1}".format(self.host.print_prefix, remote_filename),
                 err=True,
             )

--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -7,12 +7,12 @@ from socket import error as socket_error, gaierror
 from time import sleep
 from typing import IO, TYPE_CHECKING, Any, Iterable, Optional, Protocol, Tuple
 
-import click
 from paramiko import AuthenticationException, BadHostKeyException, SFTPClient, SSHException
 from paramiko.agent import Agent
 from typing_extensions import TypedDict, Unpack, override
 
 from pyinfra import logger
+from pyinfra.api.output import echo
 from pyinfra.api.command import QuoteString, StringCommand
 from pyinfra.api.exceptions import ConnectError
 from pyinfra.api.util import get_file_io, memoize
@@ -388,7 +388,7 @@ class SSHConnector(BaseConnector):
             )
 
             if print_input:
-                click.echo("{0}>>> {1}".format(self.host.print_prefix, unix_command), err=True)
+                echo("{0}>>> {1}".format(self.host.print_prefix, unix_command), err=True)
 
             # Run it! Get stdout, stderr & the underlying channel
             assert self.client is not None
@@ -520,7 +520,7 @@ class SSHConnector(BaseConnector):
             self._get_file(remote_filename, filename_or_io)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file downloaded: {1}".format(self.host.print_prefix, remote_filename),
                 err=True,
             )
@@ -626,7 +626,7 @@ class SSHConnector(BaseConnector):
             self._put_file(filename_or_io, remote_filename)
 
         if print_output:
-            click.echo(
+            echo(
                 "{0}file uploaded: {1}".format(self.host.print_prefix, remote_filename),
                 err=True,
             )
@@ -714,7 +714,7 @@ class SSHConnector(BaseConnector):
         )
 
         if print_input:
-            click.echo("{0}>>> {1}".format(self.host.print_prefix, rsync_command), err=True)
+            echo("{0}>>> {1}".format(self.host.print_prefix, rsync_command), err=True)
 
         return_code, output = run_local_process(
             rsync_command,

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -8,10 +8,10 @@ from socket import timeout as timeout_error
 from subprocess import PIPE, Popen
 from typing import TYPE_CHECKING, Callable, Iterable, Optional, Union
 
-import click
 import gevent
 
 from pyinfra import logger
+from pyinfra.api.output import echo, format_text
 from pyinfra.api import MaskString, QuoteString, StringCommand
 from pyinfra.api.util import memoize
 
@@ -130,7 +130,7 @@ def read_buffer(
         if print_func:
             line = print_func(line)
 
-        click.echo(line, err=True)
+        echo(line, err=True)
 
     for line in io:
         # Handle local Popen shells returning list of bytes, not strings
@@ -172,7 +172,7 @@ def read_output_buffers(
         print_output=print_output,
         print_func=lambda line: "{0}{1}".format(
             print_prefix,
-            click.style(line, "red"),
+            format_text(line, "red"),
         ),
     )
 

--- a/src/pyinfra/local.py
+++ b/src/pyinfra/local.py
@@ -1,10 +1,9 @@
 from os import path
 from typing import Optional
 
-import click
-
 import pyinfra
 from pyinfra import config, host, logger, state
+from pyinfra.api.output import echo
 from pyinfra.api.exceptions import PyinfraError
 from pyinfra.api.util import get_file_path
 from pyinfra.connectors.util import run_local_process
@@ -75,7 +74,7 @@ def shell(
         print_prefix = "localhost: "
 
         if print_input:
-            click.echo("{0}>>> {1}".format(print_prefix, command), err=True)
+            echo("{0}>>> {1}".format(print_prefix, command), err=True)
 
         return_code, output = run_local_process(
             command,

--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -1189,8 +1189,8 @@ def put(
             # Check mode
             if mode and remote_file["mode"] != mode:
                 if state.config.DIFF:
-                    logger.info("mode %s", format_text(remote_file["mode"], "red"))
-                    logger.info("mode %s", format_text(mode, "green"))
+                    logger.info("mode %s", format_text(str(remote_file["mode"]), "red"))
+                    logger.info("mode %s", format_text(str(mode), "green"))
                 yield file_utils.chmod(dest, mode)
                 changed = True
 
@@ -1220,8 +1220,8 @@ def put(
                     canonical_mtime, remote_file["mtime"].replace(tzinfo=timezone.utc)
                 ):
                     if state.config.DIFF:
-                        logger.info("mtime %s", format_text(remote_file["mtime"], "red"))
-                        logger.info("mtime %s", format_text(canonical_mtime, "green"))
+                        logger.info("mtime %s", format_text(str(remote_file["mtime"]), "red"))
+                        logger.info("mtime %s", format_text(str(canonical_mtime), "green"))
 
                     yield file_utils.touch(dest, MetadataTimeField.MTIME, canonical_mtime)
                     changed = True
@@ -1234,8 +1234,8 @@ def put(
                     canonical_atime, remote_file["atime"].replace(tzinfo=timezone.utc)
                 ):
                     if state.config.DIFF:
-                        logger.info("atime %s", format_text(remote_file["atime"], "red"))
-                        logger.info("atime %s", format_text(canonical_atime, "green"))
+                        logger.info("atime %s", format_text(str(remote_file["atime"]), "red"))
+                        logger.info("atime %s", format_text(str(canonical_atime), "green"))
 
                     yield file_utils.touch(dest, MetadataTimeField.ATIME, canonical_atime)
                     changed = True

--- a/src/pyinfra/operations/files.py
+++ b/src/pyinfra/operations/files.py
@@ -15,10 +15,10 @@ from io import StringIO
 from pathlib import Path
 from typing import IO, Any, Union
 
-import click
 from jinja2 import TemplateRuntimeError, TemplateSyntaxError, UndefinedError
 
 from pyinfra import host, logger, state
+from pyinfra.api.output import format_text
 from pyinfra.api import (
     FileDownloadCommand,
     FileUploadCommand,
@@ -459,7 +459,7 @@ def line(
     # Line(s) exists and we want to remove them
     elif present_lines and not present:
         if state.config.DIFF:
-            host.log(f"Will Remove lines in {click.style(path, bold=True)}", logger.info)
+            host.log(f"Will Remove lines in {format_text(path, bold=True)}", logger.info)
             for line in generate_color_diff(present_lines, []):
                 logger.info("  %s", line)
             logger.info("")
@@ -477,7 +477,7 @@ def line(
         # If any of lines are different, sed replace them
         if replace and any(line != replace for line in present_lines):
             if state.config.DIFF:
-                host.log(f"Will replace lines in {click.style(path, bold=True)}", logger.info)
+                host.log(f"Will replace lines in {format_text(path, bold=True)}", logger.info)
                 new_lines = [re.sub(match_line, replace, line) for line in present_lines]
                 for line in generate_color_diff(present_lines, new_lines):
                     logger.info("  %s", line)
@@ -1098,7 +1098,7 @@ def put(
     # No remote file, always upload and user/group/mode if supplied
     if not remote_file or force:
         if state.config.DIFF:
-            host.log(f"Will create {click.style(dest, bold=True)}", logger.info)
+            host.log(f"Will create {format_text(dest, bold=True)}", logger.info)
 
             try:
                 with get_file_io(src, "r") as f:
@@ -1148,7 +1148,7 @@ def put(
                 else:
                     current_lines = []
 
-                host.log(f"Will modify {click.style(dest, bold=True)}", logger.info)
+                host.log(f"Will modify {format_text(dest, bold=True)}", logger.info)
 
                 with get_file_io(src, "r") as f:
                     desired_lines = f.readlines()
@@ -1189,8 +1189,8 @@ def put(
             # Check mode
             if mode and remote_file["mode"] != mode:
                 if state.config.DIFF:
-                    logger.info("mode %s", click.style(remote_file["mode"], "red"))
-                    logger.info("mode %s", click.style(mode, "green"))
+                    logger.info("mode %s", format_text(remote_file["mode"], "red"))
+                    logger.info("mode %s", format_text(mode, "green"))
                 yield file_utils.chmod(dest, mode)
                 changed = True
 
@@ -1200,11 +1200,11 @@ def put(
                     old_status = [remote_file["user"], remote_file["group"]]
                     new_status = [user, group]
                     if user and remote_file["user"] != user:
-                        old_status[0] = click.style(remote_file["user"], "red")
-                        new_status[0] = click.style(user, "green")
+                        old_status[0] = format_text(remote_file["user"], "red")
+                        new_status[0] = format_text(user, "green")
                     if group and remote_file["group"] != group:
-                        old_status[1] = click.style(remote_file["group"], "red")
-                        new_status[1] = click.style(group, "green")
+                        old_status[1] = format_text(remote_file["group"], "red")
+                        new_status[1] = format_text(group, "green")
 
                     logger.info("chown %s:%s", *old_status)
                     logger.info("chown %s:%s", *new_status)
@@ -1220,8 +1220,8 @@ def put(
                     canonical_mtime, remote_file["mtime"].replace(tzinfo=timezone.utc)
                 ):
                     if state.config.DIFF:
-                        logger.info("mtime %s", click.style(remote_file["mtime"], "red"))
-                        logger.info("mtime %s", click.style(canonical_mtime, "green"))
+                        logger.info("mtime %s", format_text(remote_file["mtime"], "red"))
+                        logger.info("mtime %s", format_text(canonical_mtime, "green"))
 
                     yield file_utils.touch(dest, MetadataTimeField.MTIME, canonical_mtime)
                     changed = True
@@ -1234,8 +1234,8 @@ def put(
                     canonical_atime, remote_file["atime"].replace(tzinfo=timezone.utc)
                 ):
                     if state.config.DIFF:
-                        logger.info("atime %s", click.style(remote_file["atime"], "red"))
-                        logger.info("atime %s", click.style(canonical_atime, "green"))
+                        logger.info("atime %s", format_text(remote_file["atime"], "red"))
+                        logger.info("atime %s", format_text(canonical_atime, "green"))
 
                     yield file_utils.touch(dest, MetadataTimeField.ATIME, canonical_atime)
                     changed = True

--- a/src/pyinfra/operations/util/files.py
+++ b/src/pyinfra/operations/util/files.py
@@ -6,9 +6,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Callable, Generator
 
-import click
-
 from pyinfra.api import QuoteString, StringCommand
+from pyinfra.api.output import format_text
 
 
 class MetadataTimeField(Enum):
@@ -241,7 +240,7 @@ def generate_color_diff(
                 continue
             if tag in {"replace", "delete"}:
                 for line in current_lines[i1:i2]:
-                    yield click.style("- " + line.rstrip(), "red")
+                    yield format_text("- " + line.rstrip(), "red")
             if tag in {"replace", "insert"}:
                 for line in desired_lines[j1:j2]:
-                    yield click.style("+ " + line.rstrip(), "green")
+                    yield format_text("+ " + line.rstrip(), "green")

--- a/src/pyinfra/progress.py
+++ b/src/pyinfra/progress.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 import gevent
 from gevent.event import Event
 
-import pyinfra
+from pyinfra.api.output import is_output_active
 
 IS_WINDOWS = platform.system() == "Windows"
 
@@ -69,7 +69,7 @@ def _print_spinner(stop_event, progress_queue):
 def progress_spinner(items, prefix_message=None):
     # If there's no current state context we're not in CLI mode, so just return a noop
     # handler and exit.
-    if not pyinfra.is_cli:
+    if not is_output_active():
         yield lambda complete_item: None
         return
 

--- a/src/pyinfra_cli/main.py
+++ b/src/pyinfra_cli/main.py
@@ -5,6 +5,7 @@ import click
 import gevent
 
 import pyinfra
+from pyinfra.api.output import set_echo, set_formatter
 
 from .cli import cli
 
@@ -12,6 +13,10 @@ from .cli import cli
 def main():
     # Set CLI mode
     pyinfra.is_cli = True
+
+    # Wire click's styling/echo into the API output layer
+    set_formatter(click.style)
+    set_echo(click.echo)
 
     # Don't write out deploy.pyc/config.pyc etc
     sys.dont_write_bytecode = True

--- a/tests/test_connectors/test_local.py
+++ b/tests/test_connectors/test_local.py
@@ -68,8 +68,8 @@ class TestLocalConnector(TestCase):
             stdin=PIPE,
         )
 
-    @patch("pyinfra.connectors.local.click")
-    def test_run_shell_command_masked(self, fake_click):
+    @patch("pyinfra.api.output._echo")
+    def test_run_shell_command_masked(self, fake_echo):
         inventory = make_inventory(hosts=("@local",))
         State(inventory, Config())
         host = inventory.get_host("@local")
@@ -91,7 +91,7 @@ class TestLocalConnector(TestCase):
             stdin=PIPE,
         )
 
-        fake_click.echo.assert_called_with(
+        fake_echo.assert_called_with(
             "{0}>>> sh -c 'echo ***'".format(host.print_prefix),
             err=True,
         )

--- a/tests/test_connectors/test_ssh.py
+++ b/tests/test_connectors/test_ssh.py
@@ -387,9 +387,9 @@ class TestSSHConnector(TestCase):
 
         fake_ssh.exec_command.assert_called_with("sh -c 'echo Šablony'", get_pty=False)
 
-    @mock.patch("pyinfra.connectors.ssh.click")
+    @mock.patch("pyinfra.api.output._echo")
     @mock.patch("pyinfra.connectors.ssh.SSHClient")
-    def test_run_shell_command_masked(self, fake_ssh_client, fake_click):
+    def test_run_shell_command_masked(self, fake_ssh_client, fake_echo):
         fake_ssh = mock.MagicMock()
         fake_stdout = mock.MagicMock()
         fake_ssh.exec_command.return_value = (
@@ -419,7 +419,7 @@ class TestSSHConnector(TestCase):
             get_pty=False,
         )
 
-        fake_click.echo.assert_called_with(
+        fake_echo.assert_called_with(
             "{0}>>> sh -c 'echo ***'".format(host.print_prefix),
             err=True,
         )


### PR DESCRIPTION
Remove all `click` imports from `src/pyinfra/` so that the API layer can be used programmatically without pulling in click or getting unwanted ANSI codes. A new `pyinfra.api.output` module provides `format_text()` and `echo()` that default to plain-text no-ops; the CLI wires in `click.style` and `click.echo` at startup via `set_formatter`/`set_echo`.

Resolves pyinfra-dev/pyinfra#1613


- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
