### PR TITLE
Migrate shlex.quote() to StringCommand + QuoteString across the codebase

### DIFF
--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shlex
 from random import uniform
 from shutil import which
 from socket import error as socket_error, gaierror
@@ -671,18 +670,28 @@ class SSHConnector(BaseConnector):
         known_hosts_file = self.data["ssh_known_hosts_file"]
         if known_hosts_file:
             ssh_flags.append(
-                '-o \\"UserKnownHostsFile={0}\\"'.format(shlex.quote(known_hosts_file))
+                StringCommand(
+                    '-o \\"UserKnownHostsFile=',
+                    QuoteString(known_hosts_file),
+                    '\\"',
+                    _separator="",
+                ).get_raw_value()
             )  # never trust users
 
         strict_host_key_checking = self.data["ssh_strict_host_key_checking"]
         if strict_host_key_checking:
             ssh_flags.append(
-                '-o \\"StrictHostKeyChecking={0}\\"'.format(shlex.quote(strict_host_key_checking))
+                StringCommand(
+                    '-o \\"StrictHostKeyChecking=',
+                    QuoteString(strict_host_key_checking),
+                    '\\"',
+                    _separator="",
+                ).get_raw_value()
             )
 
         ssh_config_file = self.data["ssh_config_file"]
         if ssh_config_file:
-            ssh_flags.append("-F {0}".format(shlex.quote(ssh_config_file)))
+            ssh_flags.append(StringCommand("-F", QuoteString(ssh_config_file)).get_raw_value())
 
         port = self.data["ssh_port"]
         if port:

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shlex
 from dataclasses import dataclass
 from getpass import getpass
 from queue import Queue
@@ -276,7 +275,9 @@ def _ensure_sudo_askpass_set_for_host(host: "Host"):
     _, output = host.run_shell_command(
         SUDO_ASKPASS_COMMAND.format(host.get_temp_dir_config(), SUDO_ASKPASS_ENV_VAR)
     )
-    host.connector_data["sudo_askpass_path"] = shlex.quote(output.stdout_lines[0])
+    host.connector_data["sudo_askpass_path"] = StringCommand(
+        QuoteString(output.stdout_lines[0])
+    ).get_raw_value()
 
 
 def _ensure_su_askpass_set_for_host(host: "Host"):
@@ -285,7 +286,9 @@ def _ensure_su_askpass_set_for_host(host: "Host"):
     _, output = host.run_shell_command(
         SUDO_ASKPASS_COMMAND.format(host.get_temp_dir_config(), SU_ASKPASS_ENV_VAR)
     )
-    host.connector_data["su_askpass_path"] = shlex.quote(output.stdout_lines[0])
+    host.connector_data["su_askpass_path"] = StringCommand(
+        QuoteString(output.stdout_lines[0])
+    ).get_raw_value()
 
 
 def make_unix_command_for_host(
@@ -375,7 +378,12 @@ def make_unix_command(
             [
                 "env",
                 "SUDO_ASKPASS={0}".format(_sudo_askpass_path),
-                MaskString("{0}={1}".format(SUDO_ASKPASS_ENV_VAR, shlex.quote(_sudo_password))),
+                MaskString(
+                    "{0}={1}".format(
+                        SUDO_ASKPASS_ENV_VAR,
+                        StringCommand(QuoteString(_sudo_password)).get_raw_value(),
+                    )
+                ),
             ],
         )
 
@@ -401,7 +409,12 @@ def make_unix_command(
             command_bits.extend(
                 [
                     "env",
-                    MaskString("{0}={1}".format(SU_ASKPASS_ENV_VAR, shlex.quote(_su_password))),
+                    MaskString(
+                        "{0}={1}".format(
+                            SU_ASKPASS_ENV_VAR,
+                            StringCommand(QuoteString(_su_password)).get_raw_value(),
+                        )
+                    ),
                     _su_askpass_path,
                     "|",
                 ],
@@ -443,7 +456,6 @@ def make_win_command(command):
     """
 
     # Quote the command as a string
-    command = shlex.quote(str(command))
-    command = "{0}".format(command)
+    command = StringCommand(QuoteString(str(command))).get_raw_value()
 
     return command

--- a/src/pyinfra/facts/deb.py
+++ b/src/pyinfra/facts/deb.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import re
-import shlex
 
 from typing_extensions import override
 
-from pyinfra.api import FactBase
+from pyinfra.api import FactBase, QuoteString
+from pyinfra.api.command import make_formatted_string_command
 
 from .util.packaging import parse_packages
 
@@ -74,8 +74,9 @@ class DebPackage(FactBase):
 
     @override
     def command(self, package):
-        return "! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}".format(
-            shlex.quote(package)
+        return make_formatted_string_command(
+            "! test -e {0} && (dpkg -s {0} 2>/dev/null || true) || dpkg -I {0}",
+            QuoteString(package),
         )
 
     @override

--- a/src/pyinfra/facts/files.py
+++ b/src/pyinfra/facts/files.py
@@ -9,7 +9,6 @@ from pyinfra.facts.files import File
 from __future__ import annotations
 
 import re
-import shlex
 import stat
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
@@ -229,7 +228,7 @@ class File(FactBase[Union[FileDict, Literal[False], None]]):
     def command(self, path):
         if path.startswith("~/"):
             # Do not quote leading tilde to ensure that it gets properly expanded by the shell
-            path = f"~/{shlex.quote(path[2:])}"
+            path = StringCommand("~/", QuoteString(path[2:]), _separator="")
         else:
             path = QuoteString(path)
 

--- a/src/pyinfra/facts/pacman.py
+++ b/src/pyinfra/facts/pacman.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import shlex
-
 from typing_extensions import override
 
-from pyinfra.api import FactBase
+from pyinfra.api import FactBase, QuoteString
+from pyinfra.api.command import make_formatted_string_command
 
 from .util.packaging import parse_packages
 
@@ -32,7 +31,9 @@ class PacmanUnpackGroup(FactBase):
     @override
     def command(self, package):
         # Accept failure here (|| true) for invalid/unknown packages
-        return 'pacman -S --print-format "%n" {0} || true'.format(shlex.quote(package))
+        return make_formatted_string_command(
+            'pacman -S --print-format "%n" {0} || true', QuoteString(package)
+        )
 
     @override
     def process(self, output):

--- a/src/pyinfra/facts/rpm.py
+++ b/src/pyinfra/facts/rpm.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import re
-import shlex
 
 from typing_extensions import override
 
-from pyinfra.api import FactBase
+from pyinfra.api import FactBase, QuoteString
+from pyinfra.api.command import make_formatted_string_command
 
 from .util.packaging import parse_packages
 
@@ -25,8 +25,10 @@ class RpmPackages(FactBase):
     """
 
     @override
-    def command(self) -> str:
-        return "rpm --queryformat {0} -qa".format(shlex.quote(rpm_query_format))
+    def command(self):
+        return make_formatted_string_command(
+            "rpm --queryformat {0} -qa", QuoteString(rpm_query_format)
+        )
 
     @override
     def requires_command(self) -> str:
@@ -56,12 +58,14 @@ class RpmPackage(FactBase):
         return "rpm"
 
     @override
-    def command(self, package) -> str:
-        return (
+    def command(self, package):
+        return make_formatted_string_command(
             "rpm --queryformat {0} -q {1} || "
             "! test -e {1} || "
-            "rpm --queryformat {0} -qp {1} 2> /dev/null"
-        ).format(shlex.quote(rpm_query_format), shlex.quote(package))
+            "rpm --queryformat {0} -qp {1} 2> /dev/null",
+            QuoteString(rpm_query_format),
+            QuoteString(package),
+        )
 
     @override
     def process(self, output):
@@ -88,9 +92,10 @@ class RpmPackageProvides(FactBase):
     @override
     def command(self, package):
         # Accept failure here (|| true) for invalid/unknown packages
-        return "repoquery --queryformat {0} --whatprovides {1} || true".format(
-            shlex.quote(rpm_query_format),
-            shlex.quote(package),
+        return make_formatted_string_command(
+            "repoquery --queryformat {0} --whatprovides {1} || true",
+            QuoteString(rpm_query_format),
+            QuoteString(package),
         )
 
     @override

--- a/src/pyinfra/operations/crontab.py
+++ b/src/pyinfra/operations/crontab.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-import shlex
-
 from pyinfra import logger
-from pyinfra.api.command import StringCommand
+from pyinfra.api.command import QuoteString, StringCommand
 from pyinfra.api.operation import operation
 from pyinfra.api.util import try_int
 from pyinfra.context import host
@@ -131,17 +129,11 @@ def crontab(
             edit_commands.append("echo '' >> {0}".format(temp_filename))
         if cron_name:
             edit_commands.append(
-                "echo {0} >> {1}".format(
-                    shlex.quote(name_comment),
-                    temp_filename,
-                ),
+                StringCommand("echo", QuoteString(name_comment), ">>", temp_filename),
             )
 
         edit_commands.append(
-            "echo {0} >> {1}".format(
-                shlex.quote(new_crontab_line),
-                temp_filename,
-            ),
+            StringCommand("echo", QuoteString(new_crontab_line), ">>", temp_filename),
         )
 
     # We have the cron and it exists, do it's details? If not, replace the line

--- a/src/pyinfra/operations/git.py
+++ b/src/pyinfra/operations/git.py
@@ -5,10 +5,9 @@ Manage git repositories and configuration.
 from __future__ import annotations
 
 import re
-import shlex
 
 from pyinfra import host
-from pyinfra.api import OperationError, operation
+from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.files import Directory, File
 from pyinfra.facts.git import GitBranch, GitConfig, GitTag, GitTrackingBranch
 
@@ -66,15 +65,17 @@ def config(key: str, value: str, multi_value=False, repo: str | None = None, sys
         existing_config = host.get_fact(GitConfig, repo=repo)
 
     if repo is None:
-        base_command = "git config" + (" --system" if system else " --global")
+        base_command = StringCommand("git", "config", "--system" if system else "--global")
     else:
-        base_command = "cd {0} && git config --local".format(shlex.quote(repo))
+        base_command = StringCommand("cd", QuoteString(repo), "&&", "git", "config", "--local")
+
+    quoted_value = StringCommand('"', value, '"', _separator="")
 
     if not multi_value and existing_config.get(key) != [value]:
-        yield '{0} {1} "{2}"'.format(base_command, shlex.quote(key), value)
+        yield StringCommand(base_command, QuoteString(key), quoted_value)
 
     elif multi_value and value not in existing_config.get(key, []):
-        yield '{0} --add {1} "{2}"'.format(base_command, shlex.quote(key), value)
+        yield StringCommand(base_command, "--add", QuoteString(key), quoted_value)
 
     else:
         host.noop("git config {0} is set to {1}".format(key, value))
@@ -134,7 +135,7 @@ def repo(
             )
 
     # Store git commands for directory prefix
-    git_commands = []
+    git_commands: list[str | StringCommand] = []
     git_dir = unix_path_join(dest, ".git")
     is_repo = host.get_fact(Directory, path=git_dir)
 
@@ -142,18 +143,18 @@ def repo(
     if not is_repo:
         if branch:
             git_commands.append(
-                "clone {0} --branch {1} .".format(shlex.quote(src), shlex.quote(branch))
+                StringCommand("clone", QuoteString(src), "--branch", QuoteString(branch), ".")
             )
         else:
-            git_commands.append("clone {0} .".format(shlex.quote(src)))
+            git_commands.append(StringCommand("clone", QuoteString(src), "."))
     # Ensuring existing repo
     else:
         is_tag = False
         if branch and host.get_fact(GitBranch, repo=dest) != branch:
             git_commands.append("fetch")  # fetch to ensure we have the branch locally
-            git_commands.append("checkout {0}".format(shlex.quote(branch)))
+            git_commands.append(StringCommand("checkout", QuoteString(branch)))
         if branch and branch in (host.get_fact(GitTag, repo=dest) or []):
-            git_commands.append("checkout {0}".format(shlex.quote(branch)))
+            git_commands.append(StringCommand("checkout", QuoteString(branch)))
             is_tag = True
         if pull and not is_tag:
             if rebase:
@@ -168,11 +169,10 @@ def repo(
             git_commands.append("submodule update --init")
 
     # Attach prefixes for directory
-    command_prefix = "cd {0} && git".format(shlex.quote(dest))
-    git_commands = ["{0} {1}".format(command_prefix, command) for command in git_commands]
+    command_prefix = StringCommand("cd", QuoteString(dest), "&&", "git")
 
     for cmd in git_commands:
-        yield cmd
+        yield StringCommand(command_prefix, cmd)
 
     # Apply any user or group if we did anything
     if git_commands and (user or group):
@@ -332,22 +332,29 @@ def worktree(
         if repo is None:
             raise OperationError("repo must be specified when creating a worktree")
 
-        command_parts = ["cd {0} && git worktree add".format(shlex.quote(repo))]
+        args: list[str | QuoteString] = [
+            "cd",
+            QuoteString(repo),
+            "&&",
+            "git",
+            "worktree",
+            "add",
+        ]
 
         if new_branch:
-            command_parts.append("-b {0}".format(shlex.quote(new_branch)))
+            args.extend(["-b", QuoteString(new_branch)])
         elif detached:
-            command_parts.append("--detach")
+            args.append("--detach")
 
         if force:
-            command_parts.append("--force")
+            args.append("--force")
 
-        command_parts.append(shlex.quote(worktree))
+        args.append(QuoteString(worktree))
 
         if commitish:
-            command_parts.append(shlex.quote(commitish))
+            args.append(QuoteString(commitish))
 
-        yield " ".join(command_parts)
+        yield StringCommand(*args)
 
         # Apply any user or group
         if user or group:
@@ -355,12 +362,20 @@ def worktree(
 
     # It exists and we don't want it
     elif host.get_fact(Directory, path=worktree) and not present:
-        command = "cd {0} && git worktree remove .".format(shlex.quote(worktree))
+        remove_args: list[str | QuoteString] = [
+            "cd",
+            QuoteString(worktree),
+            "&&",
+            "git",
+            "worktree",
+            "remove",
+            ".",
+        ]
 
         if force:
-            command += " --force"
+            remove_args.append("--force")
 
-        yield command
+        yield StringCommand(*remove_args)
 
     # It exists and we still want it => pull/rebase it
     elif host.get_fact(Directory, path=worktree) and present:
@@ -370,10 +385,16 @@ def worktree(
         # pull the worktree only if it's already linked to a tracking branch or
         # if a remote branch is set
         elif host.get_fact(GitTrackingBranch, repo=worktree) or from_remote_branch:
-            command = "cd {0} && git pull".format(shlex.quote(worktree))
+            pull_args: list[str | QuoteString] = [
+                "cd",
+                QuoteString(worktree),
+                "&&",
+                "git",
+                "pull",
+            ]
 
             if rebase:
-                command += " --rebase"
+                pull_args.append("--rebase")
 
             if from_remote_branch:
                 if len(from_remote_branch) != 2 or type(from_remote_branch) not in (tuple, list):
@@ -381,11 +402,14 @@ def worktree(
                         "The remote branch must be a 2-tuple (remote, branch) such as "
                         '("origin", "master")',
                     )
-                command += " {0} {1}".format(
-                    shlex.quote(from_remote_branch[0]), shlex.quote(from_remote_branch[1])
+                pull_args.extend(
+                    [
+                        QuoteString(from_remote_branch[0]),
+                        QuoteString(from_remote_branch[1]),
+                    ]
                 )
 
-            yield command
+            yield StringCommand(*pull_args)
 
 
 @operation()
@@ -420,7 +444,7 @@ def bare_repo(
         head_file = host.get_fact(File, path=head_filename)
 
         if not head_file:
-            yield "git init --bare {0}".format(shlex.quote(path))
+            yield StringCommand("git", "init", "--bare", QuoteString(path))
             if user or group:
                 yield chown(path, user, group, recursive=True)
         else:

--- a/src/pyinfra/operations/npm.py
+++ b/src/pyinfra/operations/npm.py
@@ -4,10 +4,8 @@ Manage npm (aka node aka Node.js) packages.
 
 from __future__ import annotations
 
-import shlex
-
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.npm import NpmPackages
 
 from .util.packaging import ensure_packages
@@ -37,19 +35,19 @@ def packages(
     install_command = (
         "npm install -g"
         if directory is None
-        else "cd {0} && npm install".format(shlex.quote(directory))
+        else StringCommand("cd", QuoteString(directory), "&&", "npm", "install")
     )
 
     uninstall_command = (
         "npm uninstall -g"
         if directory is None
-        else "cd {0} && npm uninstall".format(shlex.quote(directory))
+        else StringCommand("cd", QuoteString(directory), "&&", "npm", "uninstall")
     )
 
     upgrade_command = (
         "npm update -g"
         if directory is None
-        else "cd {0} && npm update".format(shlex.quote(directory))
+        else StringCommand("cd", QuoteString(directory), "&&", "npm", "update")
     )
 
     yield from ensure_packages(

--- a/src/pyinfra/operations/pip.py
+++ b/src/pyinfra/operations/pip.py
@@ -5,10 +5,8 @@ a virtualenv (virtual environment).
 
 from __future__ import annotations
 
-import shlex
-
 from pyinfra import host
-from pyinfra.api import operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.files import File
 from pyinfra.facts.pip import PipPackages
 
@@ -58,13 +56,13 @@ def virtualenv(
     if present:
         if not host.get_fact(File, path=activate_script_path):
             # Create missing virtualenv
-            command = ["virtualenv"]
+            command: list[str | QuoteString] = ["virtualenv"]
 
             if venv:
-                command = [shlex.quote(python) if python else "python", "-m", "venv"]
+                command = [QuoteString(python) if python else "python", "-m", "venv"]
 
             if python and not venv:
-                command.append("-p {0}".format(shlex.quote(python)))
+                command.extend(["-p", QuoteString(python)])
 
             if site_packages:
                 command.append("--system-site-packages")
@@ -74,9 +72,9 @@ def virtualenv(
             elif always_copy and venv:
                 command.append("--copies")
 
-            command.append(shlex.quote(path))
+            command.append(QuoteString(path))
 
-            yield " ".join(command)
+            yield StringCommand(*command)
         else:
             host.noop("virtualenv {0} exists".format(path))
 
@@ -170,7 +168,7 @@ def packages(
 
         # And update pip path
         virtualenv = virtualenv.rstrip("/")
-        pip = "{0}/bin/{1}".format(shlex.quote(virtualenv), pip)
+        pip = StringCommand(QuoteString(virtualenv), "/bin/", pip, _separator="").get_raw_value()
 
     install_command_args = [pip, "install"]
     if extra_install_args:
@@ -183,11 +181,11 @@ def packages(
     # (un)Install requirements
     if requirements is not None:
         if present:
-            yield "{0} -r {1}".format(
-                upgrade_command if latest else install_command, shlex.quote(requirements)
+            yield StringCommand(
+                upgrade_command if latest else install_command, "-r", QuoteString(requirements)
             )
         else:
-            yield "{0} -r {1}".format(uninstall_command, shlex.quote(requirements))
+            yield StringCommand(uninstall_command, "-r", QuoteString(requirements))
 
     # Handle passed in packages
     if packages:

--- a/src/pyinfra/operations/server.py
+++ b/src/pyinfra/operations/server.py
@@ -5,7 +5,6 @@ Linux/BSD.
 
 from __future__ import annotations
 
-import shlex
 from io import StringIO
 from itertools import filterfalse, tee
 from os import path
@@ -13,7 +12,7 @@ from time import sleep
 from typing import TYPE_CHECKING
 
 from pyinfra import host, logger, state
-from pyinfra.api import FunctionCommand, OperationError, StringCommand, operation
+from pyinfra.api import FunctionCommand, OperationError, QuoteString, StringCommand, operation
 from pyinfra.api.util import try_int
 from pyinfra.connectors.util import remove_any_sudo_askpass_file
 from pyinfra.facts.files import Directory, FindInFile, Link
@@ -263,17 +262,17 @@ def modprobe(module: str, present=True, force=False):
     modules = host.get_fact(KernelModules)
     present_mods, missing_mods = partition(lambda mod: mod in modules, list_value)
 
-    args = ""
-    if force:
-        args = " -f"
+    force_args: list[str] = ["-f"] if force else []
 
     # Module is loaded and we don't want it?
     if not present and present_mods:
-        yield "modprobe{0} -r -a {1}".format(args, " ".join(shlex.quote(m) for m in present_mods))
+        yield StringCommand(
+            "modprobe", *force_args, "-r", "-a", *(QuoteString(m) for m in present_mods)
+        )
 
     # Module isn't loaded and we want it?
     elif present and missing_mods:
-        yield "modprobe{0} -a {1}".format(args, " ".join(shlex.quote(m) for m in missing_mods))
+        yield StringCommand("modprobe", *force_args, "-a", *(QuoteString(m) for m in missing_mods))
 
     else:
         host.noop(
@@ -343,7 +342,7 @@ def mount(
 
     # Want no mount but mounted?
     elif mounted is False and is_mounted:
-        yield "umount {0}".format(shlex.quote(mounted_path))
+        yield StringCommand("umount", QuoteString(mounted_path))
 
     # Want mount and is mounted! Check the options
     elif is_mounted and mounted and options:
@@ -354,14 +353,22 @@ def mount(
                 fs_type = mounts[mounted_path]["type"]
                 device = mounts[mounted_path]["device"]
 
-                yield "mount -o update,{options} -t {fs_type} {device} {path}".format(
-                    options=options_string,
-                    fs_type=fs_type,
-                    device=shlex.quote(device),
-                    path=shlex.quote(mounted_path),
+                yield StringCommand(
+                    "mount",
+                    "-o",
+                    StringCommand("update,", options_string, _separator=""),
+                    "-t",
+                    fs_type,
+                    QuoteString(device),
+                    QuoteString(mounted_path),
                 )
             else:
-                yield "mount -o remount,{0} {1}".format(options_string, shlex.quote(mounted_path))
+                yield StringCommand(
+                    "mount",
+                    "-o",
+                    StringCommand("remount,", options_string, _separator=""),
+                    QuoteString(mounted_path),
+                )
 
     else:
         host.noop(
@@ -403,7 +410,7 @@ def hostname(hostname: str, hostname_file: str | None = None):
 
     if host.get_fact(Which, command="hostnamectl"):
         if current_hostname != hostname:
-            yield "hostnamectl set-hostname {0}".format(shlex.quote(hostname))
+            yield StringCommand("hostnamectl", "set-hostname", QuoteString(hostname))
         else:
             host.noop("hostname is set")
         return
@@ -417,7 +424,7 @@ def hostname(hostname: str, hostname_file: str | None = None):
             hostname_file = "/etc/myname"
 
     if current_hostname != hostname:
-        yield "hostname {0}".format(shlex.quote(hostname))
+        yield StringCommand("hostname", QuoteString(hostname))
     else:
         host.noop("hostname is set")
 
@@ -497,7 +504,10 @@ def sysctl(
     existing_value = existing_sysctls.get(key)
 
     if existing_value != value:
-        yield "sysctl {0}={1}".format(shlex.quote(key), shlex.quote(str(string_value)))
+        yield StringCommand(
+            "sysctl",
+            StringCommand(QuoteString(key), "=", QuoteString(str(string_value)), _separator=""),
+        )
     else:
         host.noop("sysctl {0} is set to {1}".format(key, string_value))
 
@@ -686,35 +696,35 @@ def group(group: str, present=True, system=False, gid: int | str | None = None):
     # Group exists but we don't want them?
     if not present and is_present:
         if os_type == "FreeBSD":
-            yield "pw groupdel -n {0}".format(shlex.quote(group))
+            yield StringCommand("pw", "groupdel", "-n", QuoteString(group))
         else:
-            yield "groupdel {0}".format(shlex.quote(group))
+            yield StringCommand("groupdel", QuoteString(group))
 
     # Group doesn't exist and we want it?
     elif present and not is_present:
-        args = []
+        args: list[str | QuoteString] = []
 
         # BSD doesn't do system users
         if system and "BSD" not in host.get_fact(Os):
             args.append("-r")
 
         if os_type == "FreeBSD":
-            args.append("-n {0}".format(shlex.quote(group)))
+            args.extend(["-n", QuoteString(group)])
         else:
-            args.append(shlex.quote(group))
+            args.append(QuoteString(group))
 
         if gid:
             if os_type == "FreeBSD":
-                args.append("-g {0}".format(shlex.quote(str(gid))))
+                args.extend(["-g", QuoteString(str(gid))])
             else:
-                args.append("--gid {0}".format(shlex.quote(str(gid))))
+                args.extend(["--gid", QuoteString(str(gid))])
 
         # Groups are often added by other operations (package installs), so check
         # for the group at runtime before adding.
-        group_add_command = "groupadd"
         if os_type == "FreeBSD":
-            group_add_command = "pw groupadd"
-        yield "{0} {1}".format(group_add_command, " ".join(args))
+            yield StringCommand("pw", "groupadd", *args)
+        else:
+            yield StringCommand("groupadd", *args)
 
 
 @operation()
@@ -905,9 +915,9 @@ def user(
     if not present:
         if existing_user:
             if os_type == "FreeBSD":
-                yield "pw userdel -n {0}".format(shlex.quote(user))
+                yield StringCommand("pw", "userdel", "-n", QuoteString(user))
             else:
-                yield "userdel {0}".format(shlex.quote(user))
+                yield StringCommand("userdel", QuoteString(user))
         return
 
     # User doesn't exist but we want them?
@@ -918,31 +928,36 @@ def user(
             group = user
 
         # Create the user w/home/shell
-        args = []
+        args: list[str | QuoteString | StringCommand] = []
 
         if home:
-            args.append("-d {0}".format(shlex.quote(home)))
+            args.extend(["-d", QuoteString(home)])
 
         if shell:
-            args.append("-s {0}".format(shlex.quote(shell)))
+            args.extend(["-s", QuoteString(shell)])
 
         if group:
-            args.append("-g {0}".format(shlex.quote(group)))
+            args.extend(["-g", QuoteString(group)])
 
         if groups:
-            args.append("-G {0}".format(",".join(shlex.quote(g) for g in groups)))
+            group_parts: list[str | QuoteString] = []
+            for g in groups:
+                if group_parts:
+                    group_parts.append(",")
+                group_parts.append(QuoteString(g))
+            args.extend(["-G", StringCommand(*group_parts, _separator="")])
 
         if system and "BSD" not in host.get_fact(Os):
             args.append("-r")
 
         if uid:
             if os_type == "FreeBSD":
-                args.append("-u {0}".format(shlex.quote(str(uid))))
+                args.extend(["-u", QuoteString(str(uid))])
             else:
-                args.append("--uid {0}".format(shlex.quote(str(uid))))
+                args.extend(["--uid", QuoteString(str(uid))])
 
         if comment:
-            args.append("-c {0}".format(shlex.quote(comment)))
+            args.extend(["-c", QuoteString(comment)])
 
         if not unique:
             args.append("-o")
@@ -953,74 +968,85 @@ def user(
             args.append("-M")
 
         if password and os_type != "FreeBSD":
-            args.append("-p {0}".format(shlex.quote(password)))
+            args.extend(["-p", QuoteString(password)])
 
         # Users are often added by other operations (package installs), so check
         # for the user at runtime before adding.
-        add_user_command = "useradd"
-
         if os_type == "FreeBSD":
-            add_user_command = "pw useradd"
-
             if password:
-                yield "echo {3} | {0} -n {2} -H 0 {1}".format(
-                    add_user_command, " ".join(args), shlex.quote(user), shlex.quote(password)
+                yield StringCommand(
+                    "echo",
+                    QuoteString(password),
+                    "|",
+                    "pw",
+                    "useradd",
+                    "-n",
+                    QuoteString(user),
+                    "-H",
+                    "0",
+                    *args,
                 )
             else:
-                yield "{0} -n {2} {1}".format(
-                    add_user_command,
-                    " ".join(args),
-                    shlex.quote(user),
-                )
+                yield StringCommand("pw", "useradd", "-n", QuoteString(user), *args)
         else:
-            yield "{0} {1} {2}".format(
-                add_user_command,
-                " ".join(args),
-                shlex.quote(user),
-            )
+            yield StringCommand("useradd", *args, QuoteString(user))
 
     # User exists and we want them, check home/shell/keys/password
     else:
-        args = []
+        mod_args: list[str | QuoteString | StringCommand] = []
 
         # Check homedir
         if home and existing_user["home"] != home:
-            args.append("-d {0}".format(shlex.quote(home)))
+            mod_args.extend(["-d", QuoteString(home)])
 
         # Check shell
         if shell and existing_user["shell"] != shell:
-            args.append("-s {0}".format(shlex.quote(shell)))
+            mod_args.extend(["-s", QuoteString(shell)])
 
         # Check primary group
         if group and existing_user["group"] != group:
-            args.append("-g {0}".format(shlex.quote(group)))
+            mod_args.extend(["-g", QuoteString(group)])
 
         # Check secondary groups, if defined
         if groups:
+            mod_group_parts: list[str | QuoteString] = []
+            for g in groups:
+                if mod_group_parts:
+                    mod_group_parts.append(",")
+                mod_group_parts.append(QuoteString(g))
+            groups_cmd = StringCommand(*mod_group_parts, _separator="")
             if append:
                 if not set(groups).issubset(existing_user["groups"]):
-                    args.append("-a")
-                    args.append("-G {0}".format(",".join(shlex.quote(g) for g in groups)))
+                    mod_args.append("-a")
+                    mod_args.extend(["-G", groups_cmd])
             elif set(existing_user["groups"]) != set(groups):
-                args.append("-G {0}".format(",".join(shlex.quote(g) for g in groups)))
+                mod_args.extend(["-G", groups_cmd])
 
         if comment and existing_user["comment"] != comment:
-            args.append("-c {0}".format(shlex.quote(comment)))
+            mod_args.extend(["-c", QuoteString(comment)])
 
         if password and existing_user["password"] != password:
             if os_type == "FreeBSD":
-                yield "echo {0} | pw usermod -n {1} -H 0".format(
-                    shlex.quote(password), shlex.quote(user)
+                yield StringCommand(
+                    "echo",
+                    QuoteString(password),
+                    "|",
+                    "pw",
+                    "usermod",
+                    "-n",
+                    QuoteString(user),
+                    "-H",
+                    "0",
                 )
             else:
-                args.append("-p {0}".format(shlex.quote(password)))
+                mod_args.extend(["-p", QuoteString(password)])
 
         # Need to mod the user?
-        if args:
+        if mod_args:
             if os_type == "FreeBSD":
-                yield "pw usermod -n {1} {0}".format(" ".join(args), shlex.quote(user))
+                yield StringCommand("pw", "usermod", "-n", QuoteString(user), *mod_args)
             else:
-                yield "usermod {0} {1}".format(" ".join(args), shlex.quote(user))
+                yield StringCommand("usermod", *mod_args, QuoteString(user))
 
     # Ensure home directory ownership
     if ensure_home and home:

--- a/src/pyinfra/operations/ssh.py
+++ b/src/pyinfra/operations/ssh.py
@@ -6,10 +6,8 @@ Eg: ``pyinfra -> inventory-host.net <-> another-host.net``
 
 from __future__ import annotations
 
-import shlex
-
 from pyinfra import host
-from pyinfra.api import OperationError, operation
+from pyinfra.api import OperationError, QuoteString, StringCommand, operation
 from pyinfra.facts.files import File, FindInFile
 from pyinfra.facts.server import Home
 
@@ -50,17 +48,16 @@ def keyscan(hostname: str, force=False, port=22):
 
     homedir = str(homedir)
 
-    keyscan_command = "ssh-keyscan -p {0} {1} >> {2}/.ssh/known_hosts".format(
-        port,
-        shlex.quote(hostname),
-        shlex.quote(homedir),
+    known_hosts = StringCommand(QuoteString(homedir), "/.ssh/known_hosts", _separator="")
+    keyscan_command = StringCommand(
+        "ssh-keyscan", "-p", str(port), QuoteString(hostname), ">>", known_hosts
     )
 
     if not hostname_present:
         yield keyscan_command
 
     elif force:
-        yield "ssh-keygen -R {0}".format(shlex.quote(hostname))
+        yield StringCommand("ssh-keygen", "-R", QuoteString(hostname))
         yield keyscan_command
 
     else:
@@ -89,13 +86,13 @@ def command(hostname: str, command: str, user: str | None = None, port=22):
         )
     """
 
-    command = shlex.quote(command)
-
     connection_target = hostname
     if user:
         connection_target = "@".join((user, hostname))
 
-    yield "ssh -p {0} {1} {2}".format(port, shlex.quote(connection_target), command)
+    yield StringCommand(
+        "ssh", "-p", str(port), QuoteString(connection_target), QuoteString(command)
+    )
 
 
 @operation(is_idempotent=False)
@@ -132,33 +129,27 @@ def upload(
 
     # If we're not using sudo on the remote side, just scp the file over
     if not use_remote_sudo:
-        yield "scp -P {0} {1} {2}:{3}".format(
-            port,
-            shlex.quote(filename),
-            shlex.quote(connection_target),
-            shlex.quote(remote_filename),
+        scp_target = StringCommand(
+            QuoteString(connection_target), ":", QuoteString(remote_filename), _separator=""
         )
+        yield StringCommand("scp", "-P", str(port), QuoteString(filename), scp_target)
 
     else:
         # Otherwise - we need a temporary location for the file
         temp_remote_filename = host.get_temp_filename()
 
         # scp it to the temporary location
-        upload_cmd = "scp -P {0} {1} {2}:{3}".format(
-            port,
-            shlex.quote(filename),
-            shlex.quote(connection_target),
-            shlex.quote(temp_remote_filename),
+        scp_target = StringCommand(
+            QuoteString(connection_target), ":", QuoteString(temp_remote_filename), _separator=""
         )
+        yield StringCommand("scp", "-P", str(port), QuoteString(filename), scp_target)
 
-        yield upload_cmd
-
-        # And sudo sudo to move it
+        # And sudo to move it
         yield from command._inner(
             hostname=hostname,
-            command="sudo mv {0} {1}".format(
-                shlex.quote(temp_remote_filename), shlex.quote(remote_filename)
-            ),
+            command=StringCommand(
+                "sudo", "mv", QuoteString(temp_remote_filename), QuoteString(remote_filename)
+            ).get_raw_value(),
             port=port,
             user=user,
         )
@@ -213,9 +204,7 @@ def download(
         yield from keyscan._inner(hostname)
 
     # Download the file with scp
-    yield "scp -P {0} {1}:{2} {3}".format(
-        port,
-        shlex.quote(connection_target),
-        shlex.quote(filename),
-        shlex.quote(local_filename),
+    scp_source = StringCommand(
+        QuoteString(connection_target), ":", QuoteString(filename), _separator=""
     )
+    yield StringCommand("scp", "-P", str(port), scp_source, QuoteString(local_filename))

--- a/src/pyinfra/operations/systemd.py
+++ b/src/pyinfra/operations/systemd.py
@@ -4,10 +4,8 @@ Manage systemd services.
 
 from __future__ import annotations
 
-import shlex
-
 from pyinfra import host
-from pyinfra.api import StringCommand, operation
+from pyinfra.api import QuoteString, StringCommand, operation
 from pyinfra.facts.systemd import SystemdEnabled, SystemdStatus, _make_systemctl_cmd
 
 from .util.service import handle_service_control
@@ -143,8 +141,8 @@ def service(
 
         # Isn't enabled and want enabled?
         if not is_enabled and enabled is True:
-            yield "{0} enable {1}".format(systemctl_cmd, shlex.quote(service))
+            yield StringCommand(systemctl_cmd, "enable", QuoteString(service))
 
         # Is enabled and want disabled?
         elif is_enabled and enabled is False:
-            yield "{0} disable {1}".format(systemctl_cmd, shlex.quote(service))
+            yield StringCommand(systemctl_cmd, "disable", QuoteString(service))

--- a/src/pyinfra/operations/util/packaging.py
+++ b/src/pyinfra/operations/util/packaging.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shlex
 from collections import defaultdict
 from io import StringIO
 from typing import Callable, NamedTuple, cast
@@ -10,7 +9,7 @@ from packaging.requirements import InvalidRequirement, Requirement
 
 from pyinfra import logger
 from pyinfra.api import Host, OperationValueError, State
-from pyinfra.api.command import StringCommand
+from pyinfra.api.command import QuoteString, StringCommand
 from pyinfra.facts.files import File
 from pyinfra.facts.rpm import RpmPackage
 from pyinfra.operations import files
@@ -51,11 +50,13 @@ class PkgInfo(NamedTuple):
         """
 
         if self.url:
-            return shlex.quote(self.url)
+            return StringCommand(QuoteString(self.url)).get_raw_value()
 
         if self.version:
-            return shlex.quote(self.inst_vers_format_fn(self.name, self.operator, self.version))
-        return shlex.quote(self.name)
+            return StringCommand(
+                QuoteString(self.inst_vers_format_fn(self.name, self.operator, self.version))
+            ).get_raw_value()
+        return StringCommand(QuoteString(self.name)).get_raw_value()
 
     @classmethod
     def from_possible_pair(cls, s: str, join: str | None) -> PkgInfo:

--- a/src/pyinfra/operations/util/packaging.py
+++ b/src/pyinfra/operations/util/packaging.py
@@ -10,6 +10,7 @@ from packaging.requirements import InvalidRequirement, Requirement
 
 from pyinfra import logger
 from pyinfra.api import Host, OperationValueError, State
+from pyinfra.api.command import StringCommand
 from pyinfra.facts.files import File
 from pyinfra.facts.rpm import RpmPackage
 from pyinfra.operations import files
@@ -138,10 +139,10 @@ def ensure_packages(
     packages_to_ensure: str | list[str] | list[PkgInfo] | None,
     current_packages: dict[str, set[str]],
     present: bool,
-    install_command: str,
-    uninstall_command: str,
+    install_command: str | StringCommand,
+    uninstall_command: str | StringCommand,
     latest: bool = False,
-    upgrade_command: str | None = None,
+    upgrade_command: str | StringCommand | None = None,
     version_join: str | None = None,
     expand_package_fact: Callable[[str], list[str | list[str]]] | None = None,
 ):

--- a/src/pyinfra/operations/util/service.py
+++ b/src/pyinfra/operations/util/service.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import shlex
-
-from pyinfra.api import Host
+from pyinfra.api import Host, QuoteString
+from pyinfra.api.command import make_formatted_string_command
 
 
 def handle_service_control(
@@ -21,26 +20,26 @@ def handle_service_control(
     # Need down but running
     if running is False:
         if is_running:
-            yield formatter.format(shlex.quote(name), "stop")
+            yield make_formatted_string_command(formatter, QuoteString(name), "stop")
         else:
             host.noop("service {0} is stopped".format(name))
 
     # Need running but down
     if running is True:
         if not is_running:
-            yield formatter.format(shlex.quote(name), "start")
+            yield make_formatted_string_command(formatter, QuoteString(name), "start")
         else:
             host.noop("service {0} is running".format(name))
 
     # Only restart if the service is already running
     if restarted and is_running:
-        yield formatter.format(shlex.quote(name), "restart")
+        yield make_formatted_string_command(formatter, QuoteString(name), "restart")
 
     # Only reload if the service is already reloaded
     if reloaded and is_running:
-        yield formatter.format(shlex.quote(name), "reload")
+        yield make_formatted_string_command(formatter, QuoteString(name), "reload")
 
     # Always execute arbitrary commands as these may or may not rely on the service
     # being up or down
     if command:
-        yield formatter.format(shlex.quote(name), command)
+        yield make_formatted_string_command(formatter, QuoteString(name), command)

--- a/tests/facts/deb.DebPackage/package_needs_quotes.json
+++ b/tests/facts/deb.DebPackage/package_needs_quotes.json
@@ -1,0 +1,13 @@
+{
+    "arg": "/tmp/my package; whoami.deb",
+    "command": "! test -e '/tmp/my package; whoami.deb' && (dpkg -s '/tmp/my package; whoami.deb' 2>/dev/null || true) || dpkg -I '/tmp/my package; whoami.deb'",
+    "requires_command": "dpkg",
+    "output": [
+        "Package: my-package",
+        "Version: 1.0"
+    ],
+    "fact": {
+        "name": "my-package",
+        "version": "1.0"
+    }
+}

--- a/tests/facts/pacman.PacmanUnpackGroup/package_needs_quotes.json
+++ b/tests/facts/pacman.PacmanUnpackGroup/package_needs_quotes.json
@@ -1,0 +1,11 @@
+{
+    "arg": "my;package",
+    "command": "pacman -S --print-format %n 'my;package' || true",
+    "requires_command": "pacman",
+    "output": [
+        "my-package"
+    ],
+    "fact": [
+        "my-package"
+    ]
+}

--- a/tests/facts/rpm.RpmPackage/package_needs_quotes.json
+++ b/tests/facts/rpm.RpmPackage/package_needs_quotes.json
@@ -1,0 +1,12 @@
+{
+    "arg": "/tmp/my package; whoami.rpm",
+    "command": "rpm --queryformat '%{NAME} %{VERSION}-%{RELEASE}\\n' -q '/tmp/my package; whoami.rpm' || ! test -e '/tmp/my package; whoami.rpm' || rpm --queryformat '%{NAME} %{VERSION}-%{RELEASE}\\n' -qp '/tmp/my package; whoami.rpm' 2> /dev/null",
+    "requires_command": "rpm",
+    "output": [
+        "my-package 1.0.0-1.el8"
+    ],
+    "fact": {
+        "name": "my-package",
+        "version": "1.0.0-1.el8"
+    }
+}

--- a/tests/facts/rpm.RpmPackageProvides/package_needs_quotes.json
+++ b/tests/facts/rpm.RpmPackageProvides/package_needs_quotes.json
@@ -1,0 +1,11 @@
+{
+    "arg": "my;package",
+    "command": "repoquery --queryformat '%{NAME} %{VERSION}-%{RELEASE}\\n' --whatprovides 'my;package' || true",
+    "requires_command": "repoquery",
+    "output": [
+        "my-package 1.0.0-1.el8"
+    ],
+    "fact": [
+        ["my-package", "1.0.0-1.el8"]
+    ]
+}

--- a/tests/operations/bsdinit.service/start_needs_quotes.json
+++ b/tests/operations/bsdinit.service/start_needs_quotes.json
@@ -1,0 +1,12 @@
+{
+    "args": ["my service; whoami"],
+    "facts": {
+        "server.Os": "FreeBSD",
+        "bsdinit.RcdStatus": {
+            "my service; whoami": false
+        }
+    },
+    "commands": [
+        "test -e /etc/rc.d/'my service; whoami' && /etc/rc.d/'my service; whoami' start || /usr/local/etc/rc.d/'my service; whoami' start"
+    ]
+}

--- a/tests/operations/crontab.crontab/add_named_needs_quotes.json
+++ b/tests/operations/crontab.crontab/add_named_needs_quotes.json
@@ -1,0 +1,16 @@
+{
+    "args": ["backup /etc; rm -rf /"],
+    "kwargs": {
+        "cron_name": "evil job; $(whoami)"
+    },
+    "facts": {
+        "crontab.Crontab": {
+            "user=None": {}
+        }
+    },
+    "commands": [
+        "echo '# pyinfra-name=evil job; $(whoami)' >> _tempfile_",
+        "echo '* * * * * backup /etc; rm -rf /' >> _tempfile_",
+        "crontab  _tempfile_"
+    ]
+}

--- a/tests/operations/crontab.crontab/add_needs_quotes.json
+++ b/tests/operations/crontab.crontab/add_needs_quotes.json
@@ -1,0 +1,12 @@
+{
+    "args": ["backup /etc; rm -rf /"],
+    "facts": {
+        "crontab.Crontab": {
+            "user=None": {}
+        }
+    },
+    "commands": [
+        "echo '* * * * * backup /etc; rm -rf /' >> _tempfile_",
+        "crontab  _tempfile_"
+    ]
+}

--- a/tests/operations/git.config/set_key_needs_quotes.json
+++ b/tests/operations/git.config/set_key_needs_quotes.json
@@ -1,0 +1,17 @@
+{
+    "args": ["user.name; whoami", "Anon"],
+    "kwargs": {
+        "repo": "/my/repo"
+    },
+    "facts": {
+        "git.GitConfig": {
+            "repo=/my/repo, system=False": {}
+        },
+        "files.Directory": {
+            "path=/my/repo/.git": true
+        }
+    },
+    "commands": [
+        "cd /my/repo && git config --local 'user.name; whoami' \"Anon\""
+    ]
+}

--- a/tests/operations/git.config/set_multivalue_needs_quotes.json
+++ b/tests/operations/git.config/set_multivalue_needs_quotes.json
@@ -1,0 +1,18 @@
+{
+    "args": ["url.evil; whoami.insteadOf", "git://new"],
+    "kwargs": {
+        "multi_value": true,
+        "repo": "/my repo"
+    },
+    "facts": {
+        "git.GitConfig": {
+            "repo=/my repo, system=False": {}
+        },
+        "files.Directory": {
+            "path=/my repo/.git": true
+        }
+    },
+    "commands": [
+        "cd '/my repo' && git config --local --add 'url.evil; whoami.insteadOf' \"git://new\""
+    ]
+}

--- a/tests/operations/git.repo/checkout_branch_needs_quotes.json
+++ b/tests/operations/git.repo/checkout_branch_needs_quotes.json
@@ -1,0 +1,23 @@
+{
+    "args": ["myrepo", "/home/myrepo"],
+    "kwargs": {
+        "branch": "feature/evil; rm -rf /",
+        "pull": false
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/home/myrepo": {},
+            "path=/home/myrepo/.git": {"mode": 0}
+        },
+        "git.GitBranch": {
+            "repo=/home/myrepo": "main"
+        },
+        "git.GitTag": {
+            "repo=/home/myrepo": []
+        }
+    },
+    "commands": [
+        "cd /home/myrepo && git fetch",
+        "cd /home/myrepo && git checkout 'feature/evil; rm -rf /'"
+    ]
+}

--- a/tests/operations/git.worktree/pull_remote_needs_quotes.json
+++ b/tests/operations/git.worktree/pull_remote_needs_quotes.json
@@ -1,0 +1,21 @@
+{
+    "args": ["/home/my worktree; whoami"],
+    "kwargs": {
+        "from_remote_branch": ["origin; evil", "master; rm -rf /"]
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/home/my worktree; whoami": {
+                "mode": 0
+            }
+        },
+        "git.GitTrackingBranch": {
+            "repo=/home/my worktree; whoami": null
+        }
+    },
+    "commands": [
+        "cd '/home/my worktree; whoami' && git pull 'origin; evil' 'master; rm -rf /'"
+    ],
+    "idempotent": false,
+    "disable_idempotent_warning_reason": "git pull is always executed"
+}

--- a/tests/operations/git.worktree/remove_needs_quotes.json
+++ b/tests/operations/git.worktree/remove_needs_quotes.json
@@ -1,0 +1,16 @@
+{
+    "args": ["/home/my worktree; whoami"],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "files.Directory": {
+            "path=/home/my worktree; whoami": {
+                "mode": 0
+            }
+        }
+    },
+    "commands": [
+        "cd '/home/my worktree; whoami' && git worktree remove ."
+    ]
+}

--- a/tests/operations/openrc.service/start_needs_quotes.json
+++ b/tests/operations/openrc.service/start_needs_quotes.json
@@ -1,0 +1,13 @@
+{
+    "args": ["my service; whoami"],
+    "facts": {
+        "openrc.OpenrcStatus": {
+            "runlevel=default": {
+                "my service; whoami": false
+            }
+        }
+    },
+    "commands": [
+        "rc-service 'my service; whoami' start"
+    ]
+}

--- a/tests/operations/pip.packages/virtualenv_path_needs_quotes.json
+++ b/tests/operations/pip.packages/virtualenv_path_needs_quotes.json
@@ -1,0 +1,17 @@
+{
+    "kwargs": {
+        "packages": ["flask"],
+        "virtualenv": "/opt/my venv"
+    },
+    "facts": {
+        "files.File": {
+            "path=/opt/my venv/bin/activate": true
+        },
+        "pip.PipPackages": {
+            "pip='/opt/my venv'/bin/pip": {}
+        }
+    },
+    "commands": [
+        "'/opt/my venv'/bin/pip install flask"
+    ]
+}

--- a/tests/operations/pip.virtualenv/python_path_needs_quotes.json
+++ b/tests/operations/pip.virtualenv/python_path_needs_quotes.json
@@ -1,0 +1,15 @@
+{
+    "kwargs": {
+        "path": "/some/venv",
+        "python": "/opt/python 3.10/bin/python3",
+        "venv": true
+    },
+    "facts": {
+        "files.File": {
+            "path=/some/venv/bin/activate": null
+        }
+    },
+    "commands": [
+        "'/opt/python 3.10/bin/python3' -m venv /some/venv"
+    ]
+}

--- a/tests/operations/server.group/add_freebsd_needs_quotes.json
+++ b/tests/operations/server.group/add_freebsd_needs_quotes.json
@@ -1,0 +1,13 @@
+{
+    "args": ["my group; whoami"],
+    "kwargs": {
+        "gid": 1000
+    },
+    "facts": {
+        "server.Groups": [],
+        "server.Os": "FreeBSD"
+    },
+    "commands": [
+        "pw groupadd -n 'my group; whoami' -g 1000"
+    ]
+}

--- a/tests/operations/server.group/delete_freebsd_needs_quotes.json
+++ b/tests/operations/server.group/delete_freebsd_needs_quotes.json
@@ -1,0 +1,13 @@
+{
+    "args": ["my group; whoami"],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "server.Groups": ["my group; whoami"],
+        "server.Os": "FreeBSD"
+    },
+    "commands": [
+        "pw groupdel -n 'my group; whoami'"
+    ]
+}

--- a/tests/operations/server.group/delete_needs_quotes.json
+++ b/tests/operations/server.group/delete_needs_quotes.json
@@ -1,0 +1,13 @@
+{
+    "args": ["my group; whoami"],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "server.Groups": ["my group; whoami"],
+        "server.Os": "Linux"
+    },
+    "commands": [
+        "groupdel 'my group; whoami'"
+    ]
+}

--- a/tests/operations/server.modprobe/remove_needs_quotes.json
+++ b/tests/operations/server.modprobe/remove_needs_quotes.json
@@ -1,0 +1,14 @@
+{
+    "args": ["evil; rm -rf /"],
+    "kwargs": {
+        "present": false
+    },
+    "facts": {
+        "server.KernelModules": {
+            "evil; rm -rf /": {}
+        }
+    },
+    "commands": [
+        "modprobe -r -a 'evil; rm -rf /'"
+    ]
+}

--- a/tests/operations/server.mount/remount_needs_quotes.json
+++ b/tests/operations/server.mount/remount_needs_quotes.json
@@ -1,0 +1,17 @@
+{
+    "args": ["/data dir; rm -rf /"],
+    "kwargs": {
+        "options": ["rw", "noatime"]
+    },
+    "facts": {
+        "server.Kernel": "Linux",
+        "server.Mounts": {
+            "/data dir; rm -rf /": {
+                "options": ["rw"]
+            }
+        }
+    },
+    "commands": [
+        "mount -o remount,rw,noatime '/data dir; rm -rf /'"
+    ]
+}

--- a/tests/operations/server.user/add_freebsd_needs_quotes.json
+++ b/tests/operations/server.user/add_freebsd_needs_quotes.json
@@ -1,0 +1,17 @@
+{
+    "args": ["evil; whoami"],
+    "kwargs": {
+        "home": "/home/evil $(id)",
+        "shell": "/bin/bash",
+        "password": "$evil;password$",
+        "ensure_home": false
+    },
+    "facts": {
+        "server.Os": "FreeBSD",
+        "server.Users": {},
+        "server.Groups": {}
+    },
+    "commands": [
+        "echo '$evil;password$' | pw useradd -n 'evil; whoami' -H 0 -d '/home/evil $(id)' -s /bin/bash"
+    ]
+}

--- a/tests/operations/server.user/add_groups_needs_quotes.json
+++ b/tests/operations/server.user/add_groups_needs_quotes.json
@@ -1,0 +1,15 @@
+{
+    "args": ["testuser"],
+    "kwargs": {
+        "groups": ["group one", "group; two"],
+        "ensure_home": false
+    },
+    "facts": {
+        "server.Os": "Linux",
+        "server.Users": {},
+        "server.Groups": {}
+    },
+    "commands": [
+        "useradd -d /home/testuser -G 'group one','group; two' -M testuser"
+    ]
+}

--- a/tests/operations/server.user/edit_needs_quotes.json
+++ b/tests/operations/server.user/edit_needs_quotes.json
@@ -1,0 +1,27 @@
+{
+    "args": ["some user; whoami"],
+    "kwargs": {
+        "home": "/home/evil $(id)",
+        "shell": "/bin/bash; rm -rf /",
+        "group": "mygroup; inject",
+        "comment": "Full Name; rm -rf /",
+        "ensure_home": false
+    },
+    "facts": {
+        "server.Os": "Linux",
+        "server.Users": {
+            "some user; whoami": {
+                "comment": "Old Name",
+                "home": "/home/old",
+                "shell": "/bin/sh",
+                "group": "oldgroup",
+                "groups": [],
+                "password": ""
+            }
+        },
+        "server.Groups": {}
+    },
+    "commands": [
+        "usermod -d '/home/evil $(id)' -s '/bin/bash; rm -rf /' -g 'mygroup; inject' -c 'Full Name; rm -rf /' 'some user; whoami'"
+    ]
+}

--- a/tests/operations/ssh.command/command_user_needs_quotes.json
+++ b/tests/operations/ssh.command/command_user_needs_quotes.json
@@ -1,0 +1,10 @@
+{
+    "args": ["host.example.com", "ls"],
+    "kwargs": {
+        "user": "admin; whoami"
+    },
+    "commands": [
+        "ssh -p 22 'admin; whoami@host.example.com' ls"
+    ],
+    "idempotent": false
+}

--- a/tests/operations/ssh.keyscan/scan_force_hostname_needs_quotes.json
+++ b/tests/operations/ssh.keyscan/scan_force_hostname_needs_quotes.json
@@ -1,0 +1,23 @@
+{
+    "args": ["evil; rm -rf /"],
+    "kwargs": {
+        "force": true
+    },
+    "facts": {
+        "server.Home": "/home/pyinfra",
+        "files.Directory": {
+            "path=/home/pyinfra/.ssh": {
+                "mode": 700
+            }
+        },
+        "files.FindInFile": {
+            "interpolate_variables=False, path=/home/pyinfra/.ssh/known_hosts, pattern=evil; rm -rf /": [true]
+        }
+    },
+    "commands": [
+        "ssh-keygen -R 'evil; rm -rf /'",
+        "ssh-keyscan -p 22 'evil; rm -rf /' >> /home/pyinfra/.ssh/known_hosts"
+    ],
+    "idempotent": false,
+    "disable_idempotent_warning_reason": "forced keyscans are always executed"
+}

--- a/tests/operations/ssh.keyscan/scan_hostname_needs_quotes.json
+++ b/tests/operations/ssh.keyscan/scan_hostname_needs_quotes.json
@@ -1,0 +1,17 @@
+{
+    "args": ["evil; rm -rf /"],
+    "facts": {
+        "server.Home": "/home/pyinfra",
+        "files.Directory": {
+            "path=/home/pyinfra/.ssh": {
+                "mode": 700
+            }
+        },
+        "files.FindInFile": {
+            "interpolate_variables=False, path=/home/pyinfra/.ssh/known_hosts, pattern=evil; rm -rf /": []
+        }
+    },
+    "commands": [
+        "ssh-keyscan -p 22 'evil; rm -rf /' >> /home/pyinfra/.ssh/known_hosts"
+    ]
+}

--- a/tests/operations/ssh.upload/upload_user_needs_quotes.json
+++ b/tests/operations/ssh.upload/upload_user_needs_quotes.json
@@ -1,0 +1,10 @@
+{
+    "args": ["remote-host.net", "/tmp/file.txt"],
+    "kwargs": {
+        "user": "admin; whoami"
+    },
+    "commands": [
+        "scp -P 22 /tmp/file.txt 'admin; whoami@remote-host.net':/tmp/file.txt"
+    ],
+    "idempotent": false
+}

--- a/tests/operations/systemd.service/disabled_needs_quotes.json
+++ b/tests/operations/systemd.service/disabled_needs_quotes.json
@@ -1,0 +1,21 @@
+{
+    "args": ["my-service; whoami"],
+    "kwargs": {
+        "enabled": false
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "machine=None, services=['my-service; whoami.service'], user_mode=False, user_name=None": {
+                "my-service; whoami.service": true
+            }
+        },
+        "systemd.SystemdEnabled": {
+            "machine=None, services=['my-service; whoami.service'], user_mode=False, user_name=None": {
+                "my-service; whoami.service": true
+            }
+        }
+    },
+    "commands": [
+        "systemctl disable 'my-service; whoami.service'"
+    ]
+}

--- a/tests/operations/systemd.service/enabled_needs_quotes.json
+++ b/tests/operations/systemd.service/enabled_needs_quotes.json
@@ -1,0 +1,21 @@
+{
+    "args": ["my-service; whoami"],
+    "kwargs": {
+        "enabled": true
+    },
+    "facts": {
+        "systemd.SystemdStatus": {
+            "machine=None, services=['my-service; whoami.service'], user_mode=False, user_name=None": {
+                "my-service; whoami.service": true
+            }
+        },
+        "systemd.SystemdEnabled": {
+            "machine=None, services=['my-service; whoami.service'], user_mode=False, user_name=None": {
+                "my-service; whoami.service": false
+            }
+        }
+    },
+    "commands": [
+        "systemctl enable 'my-service; whoami.service'"
+    ]
+}

--- a/tests/operations/sysvinit.service/start_needs_quotes.json
+++ b/tests/operations/sysvinit.service/start_needs_quotes.json
@@ -1,0 +1,11 @@
+{
+    "args": ["my service; whoami"],
+    "facts": {
+        "sysvinit.InitdStatus": {
+            "my service; whoami": false
+        }
+    },
+    "commands": [
+        "/etc/init.d/'my service; whoami' start"
+    ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #1576 as suggested by @Fizzadar: migrate all direct `shlex.quote()` calls to pyinfra's built-in `StringCommand` + `QuoteString` abstractions. This centralizes shell quoting at the command layer instead of scattering `shlex.quote()` throughout individual operations, facts, and connectors.

After this change, the only `import shlex` remaining in `src/` is in `api/command.py` — where `QuoteString` is implemented.

### What changed

**Operations** (8 files):
- `git.py`, `npm.py`, `pip.py`, `server.py`, `ssh.py` — yield `StringCommand` objects with `QuoteString`-wrapped user inputs instead of format strings with `shlex.quote()`
- `systemd.py` — `StringCommand` for enable/disable
- `crontab.py` — `StringCommand` for echo commands
- `util/service.py` — `make_formatted_string_command` with `QuoteString` for all init system service control (systemd, sysvinit, openrc, bsdinit, upstart, runit, launchd)
- `util/packaging.py` — `QuoteString` in `PkgInfo.inst_vers`; widened type hints to accept `StringCommand` command parameters

**Facts** (4 files):
- `rpm.py`, `pacman.py`, `deb.py` — `make_formatted_string_command` with `QuoteString` for fact command construction
- `files.py` — `StringCommand` for tilde path quoting

**Connectors** (2 files):
- `connectors/ssh.py` — `StringCommand` for SSH flag construction
- `connectors/util.py` — `QuoteString` for askpass paths, passwords, and win command quoting

### Tests

Added **30 new test fixtures** proving command injection is mitigated with shell metacharacters (`;`, `$()`, spaces) in user-supplied values:

- **ssh** (4): keyscan hostname, keyscan force, command user@host, upload user@host
- **git** (5): config key, config multivalue, repo checkout, worktree remove, worktree pull remote
- **pip** (2): virtualenv python path, packages virtualenv path
- **server** (8): group delete (Linux + FreeBSD), group add FreeBSD, mount remount, modprobe remove, user edit, user add FreeBSD, user add with groups
- **systemd/init** (4): systemd enable/disable, sysvinit start, openrc start, bsdinit start
- **crontab** (2): add with quoted command, add_named with quoted name
- **facts** (4): rpm.RpmPackage, rpm.RpmPackageProvides, deb.DebPackage, pacman.PacmanUnpackGroup
- **npm** (1): directory with injection characters (from #1576)

Fix #1549

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [x] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)