### PR TITLE
docs: update Python version requirements

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -9,8 +9,8 @@ orphan: true
 
 ### Python Version Requirements
 
-- Python 3.9 or later is required
-- pyinfra 3.2+ supports Python 3.9, 3.10, 3.11, and 3.12
+- Python 3.10 or later is required
+- pyinfra 3.5.1+ supports Python 3.10, 3.11, 3.12 and 3.13
 - You can check your Python version with:
 
   ```sh


### PR DESCRIPTION
Starting with commit [b14c575](https://github.com/pyinfra-dev/pyinfra/commit/b14c5751350c1c24dafa592daffc64791d5f6de4) ([pyproject.toml](https://github.com/pyinfra-dev/pyinfra/blob/b14c5751350c1c24dafa592daffc64791d5f6de4/pyproject.toml#L13)), Python 3.9 support was dropped due to its EOL.

This PR updates the install docs to reflect the change in supported Python versions.