### PR TITLE
feat: Add `dzdo` support for privilege escalation, including CLI options and configuration.

### DIFF
--- a/src/pyinfra/api/arguments.py
+++ b/src/pyinfra/api/arguments.py
@@ -61,6 +61,8 @@ class ConnectorArguments(TypedDict, total=False):
     _su_password: str
     _doas: bool
     _doas_user: str
+    _dzdo: bool
+    _dzdo_user: str
 
     # Shell arguments
     _shell_executable: str
@@ -138,6 +140,14 @@ auth_argument_meta: dict[str, ArgumentMeta] = {
     "_doas_user": ArgumentMeta(
         "Execute/apply any changes with doas as a non-root user.",
         default=lambda config: config.DOAS_USER,
+    ),
+    "_dzdo": ArgumentMeta(
+        "Execute/apply any changes with dzdo.",
+        default=lambda config: config.DZDO,
+    ),
+    "_dzdo_user": ArgumentMeta(
+        "Execute/apply any changes with dzdo as a non-root user.",
+        default=lambda config: config.DZDO_USER,
     ),
 }
 
@@ -282,7 +292,7 @@ __argument_docs__ = {
         """
         .. caution::
             When combining privilege escalation arguments it is important to know the order they
-            are applied: ``doas`` -> ``sudo`` -> ``su``. For example
+            are applied: ``doas`` -> ``dzdo`` -> ``sudo`` -> ``su``. For example
             ``_sudo=True,_su_user="pyinfra"`` yields a command like ``sudo su pyinfra..``.
         """,
         """

--- a/src/pyinfra/api/arguments_typed.py
+++ b/src/pyinfra/api/arguments_typed.py
@@ -37,6 +37,8 @@ class PyinfraOperation(Generic[P], Protocol):
         _su_password: None | str = None,
         _doas: bool = False,
         _doas_user: None | str = None,
+        _dzdo: bool = False,
+        _dzdo_user: None | str = None,
         # Shell arguments
         _shell_executable: None | str = None,
         _chdir: None | str = None,

--- a/src/pyinfra/api/config.py
+++ b/src/pyinfra/api/config.py
@@ -50,6 +50,9 @@ class ConfigDefaults:
     # Use doas and optional user
     DOAS: bool = False
     DOAS_USER: Optional[str] = None
+    # Use dzdo and optional user
+    DZDO: bool = False
+    DZDO_USER: Optional[str] = None
     # Only show errors but don't count as failure
     IGNORE_ERRORS: bool = False
     # Shell to use to execute commands

--- a/src/pyinfra/connectors/ssh.py
+++ b/src/pyinfra/connectors/ssh.py
@@ -568,6 +568,8 @@ class SSHConnector(BaseConnector):
         _sudo_user = noauth_arguments.pop("_sudo_user", False)
         _doas = noauth_arguments.pop("_doas", False)
         _doas_user = noauth_arguments.pop("_doas_user", False)
+        _dzdo = noauth_arguments.pop("_dzdo", False)
+        _dzdo_user = noauth_arguments.pop("_dzdo_user", False)
         _su_user = noauth_arguments.pop("_su_user", None)
 
         # _chdir is the only one of the global arguments that could require _sudo to succeed
@@ -576,13 +578,13 @@ class SSHConnector(BaseConnector):
 
         # sudo/su are a little more complicated, as you can only sftp with the SSH
         # user connected, so upload to tmp and copy/chown w/sudo and/or su_user
-        if _sudo or _doas or _su_user:
+        if _sudo or _doas or _dzdo or _su_user:
             # Get temp file location
             temp_file = remote_temp_filename or self.host.get_temp_filename(remote_filename)
             self._put_file(filename_or_io, temp_file)
 
             # Make sure our sudo/su user can access the file
-            other_user = _su_user or _sudo_user or _doas_user
+            other_user = _su_user or _sudo_user or _doas_user or _dzdo_user
             if other_user:
                 status, output = self.run_shell_command(
                     StringCommand("setfacl", "-m", f"u:{other_user}:r", temp_file),

--- a/src/pyinfra/connectors/util.py
+++ b/src/pyinfra/connectors/util.py
@@ -341,6 +341,9 @@ def make_unix_command(
     # Doas config
     _doas=False,
     _doas_user=None,
+    # Dzdo config
+    _dzdo=False,
+    _dzdo_user=None,
     # Retry config (ignored in command generation but passed through)
     _retries=0,
     _retry_delay=0,
@@ -369,6 +372,12 @@ def make_unix_command(
 
         if _doas_user:
             command_bits.extend(["-u", _doas_user])
+
+    if _dzdo:
+        command_bits.extend(["dzdo", "-H", "-n"])
+
+        if _dzdo_user:
+            command_bits.extend(["-u", _dzdo_user])
 
     if _sudo_password and _sudo_askpass_path:
         command_bits.extend(

--- a/src/pyinfra_cli/cli.py
+++ b/src/pyinfra_cli/cli.py
@@ -130,6 +130,13 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     help="Whether to use a password with sudo.",
 )
 @click.option("--su-user", help="Which user to su to.")
+@click.option(
+    "--dzdo",
+    is_flag=True,
+    default=False,
+    help="Whether to execute operations with dzdo.",
+)
+@click.option("--dzdo-user", help="Which user to dzdo when using dzdo.")
 @click.option("--shell-executable", help='Shell to use (ex: "sh", "cmd", "ps").')
 # Operation flow args
 @click.option("--parallel", type=int, help="Number of operations to run in parallel.")
@@ -294,6 +301,8 @@ def _main(
     sudo_user: str,
     use_sudo_password: bool,
     su_user: str,
+    dzdo: bool,
+    dzdo_user: str,
     parallel: int,
     fail_percent: int,
     data,
@@ -343,6 +352,8 @@ def _main(
         use_sudo_password,
         same_sudo_password,
         su_user,
+        dzdo,
+        dzdo_user,
         parallel,
         shell_executable,
         fail_percent,
@@ -589,6 +600,8 @@ def _set_config(
     use_sudo_password,
     same_sudo_password,
     su_user,
+    dzdo,
+    dzdo_user,
     parallel,
     shell_executable,
     fail_percent,
@@ -619,6 +632,11 @@ def _set_config(
 
     if su_user:
         config.SU_USER = su_user
+
+    if dzdo:
+        config.DZDO = True
+        if dzdo_user:
+            config.DZDO_USER = dzdo_user
 
     if parallel:
         config.PARALLEL = parallel

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -176,6 +176,8 @@ class TestDirectMainExecution(PatchSSHTestCase):
                 sudo_user=None,
                 use_sudo_password=False,
                 su_user=None,
+                dzdo=False,
+                dzdo_user=None,
                 parallel=None,
                 fail_percent=0,
                 dry=False,

--- a/tests/test_connectors/test_util.py
+++ b/tests/test_connectors/test_util.py
@@ -21,6 +21,14 @@ class TestMakeUnixCommandConnectorUtil(TestCase):
         command = make_unix_command("uptime", _doas=True, _doas_user="pyinfra")
         assert command.get_raw_value() == "doas -n -u pyinfra sh -c uptime"
 
+    def test_dzdo_command(self):
+        command = make_unix_command("uptime", _dzdo=True)
+        assert command.get_raw_value() == "dzdo -H -n sh -c uptime"
+
+    def test_dzdo_user_command(self):
+        command = make_unix_command("uptime", _dzdo=True, _dzdo_user="pyinfra")
+        assert command.get_raw_value() == "dzdo -H -n -u pyinfra sh -c uptime"
+
     def test_sudo_command(self):
         command = make_unix_command("uptime", _sudo=True)
         assert command.get_raw_value() == "sudo -H -n sh -c uptime"


### PR DESCRIPTION
**Add `dzdo` as a privilege escalation method**

Adds support for `dzdo` (Centrify's `sudo` drop-in wrapper) as a first-class privilege escalation option, mirroring the existing `doas` implementation.

**Changes:**
- New `DZDO` / `DZDO_USER` config defaults
- New `_dzdo` / `_dzdo_user` operation arguments
- Command built as `dzdo -H -n [-u <user>]`, consistent with how `sudo` is invoked
- `put_file` in the SSH connector handles `dzdo` for temporary file permission management
- `--dzdo` and `--dzdo-user` CLI flags
- Escalation order: `doas` > `dzdo` > `sudo` > `su`

**Tests:** 2 new unit tests added; full suite passes (1422/1422).

- [X] Pull request is based on the default branch (`3.x` at this time)
- [X] Pull request includes tests for any new/updated operations/facts
- [X] Pull request includes documentation for any new/updated operations/facts
- [X] Tests pass (see `scripts/dev-test.sh`)
- [X] Type checking & code style passes (see `scripts/dev-lint.sh`)
