### PR TITLE
zfs: return an empty dict if zfs/zpool commands are not available

### DIFF
--- a/src/pyinfra/facts/zfs.py
+++ b/src/pyinfra/facts/zfs.py
@@ -26,6 +26,8 @@ class ZfsPools(FactBase):
     def requires_command(self) -> str:
         return "zpool"
 
+    default = dict
+
     @override
     def process(self, output):
         return _process_zfs_props_table(output)
@@ -39,6 +41,8 @@ class ZfsDatasets(FactBase):
     @override
     def requires_command(self) -> str:
         return "zfs"
+
+    default = dict
 
     @override
     def process(self, output):

--- a/tests/test_api/test_api_facts.py
+++ b/tests/test_api/test_api_facts.py
@@ -50,6 +50,23 @@ class TestFactsApi(PatchSSHTestCase):
             **_get_executor_defaults(state, anotherhost),
         )
 
+    def test_get_fact_missing_command_returns_the_default(self):
+        inventory = make_inventory(hosts=("anotherhost",))
+        state = State(inventory, Config())
+
+        anotherhost = inventory.get_host("anotherhost")
+
+        connect_all(state)
+
+        with patch("pyinfra.connectors.ssh.SSHConnector.run_shell_command") as fake_run_command:
+            fake_run_command.return_value = (
+                True,
+                CommandOutput([]),
+            )
+            fact_data = get_facts(state, Command, ("nonexistent_command",))
+
+        assert fact_data == {anotherhost: None}
+
     def test_get_fact_current_op_global_arguments(self):
         inventory = make_inventory(hosts=("anotherhost",))
         state = State(inventory, Config())


### PR DESCRIPTION
If the required command is not installed, a default value is returned. `FactsBase.default = None`, which causes `zfs.dataset` to fail [here](https://github.com/pyinfra-dev/pyinfra/blob/cedf47eeab8882f15a54e2a70c8a7ee661319a37/src/pyinfra/operations/zfs.py#L54).

With this PR in, both zfs.Pools and zfs.Datasets will return `{}` when the relevant binaries are missing.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [x] Pull request includes tests for any new/updated operations/facts
- [ ] Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
