### PR TITLE
progress: finish spinner as soon as possible

### DIFF
--- a/src/pyinfra/progress.py
+++ b/src/pyinfra/progress.py
@@ -62,7 +62,7 @@ def _print_spinner(stop_event, progress_queue):
         if not IS_WINDOWS:
             sys.stderr.write("\033[K")
 
-        gevent.sleep(WAIT_TIME)
+        stop_event.wait(timeout=WAIT_TIME)
 
 
 @contextmanager


### PR DESCRIPTION
Before this commit, a progress spinner would finish its 200ms sleep time when the last operation the spinner was reporting progress for finished. In the case of a single host and a fast operation, this meant there was up to 200ms of delay for each operation that was unneeded.

This commit changes the sleep to a wait on the stop condition, using a timeout. This means that as long as the operations are still ongoing, there is a 200ms delay between spinner updates, bit as soon as the operations are done and the stop_event is set, the spinner terminates immediately.

When there are a lot of small/fast operations, this can reduce the total execution time of pyinfra considerably.

- [x] Pull request is based on the default branch (`3.x` at this time)
- [ ] N/A Pull request includes tests for any new/updated operations/facts
- [ ] N/A Pull request includes documentation for any new/updated operations/facts
- [x] Tests pass (see `scripts/dev-test.sh`)
- [x] Type checking & code style passes (see `scripts/dev-lint.sh`)
